### PR TITLE
PR00: Apply google-java-format to telemetry-modified files

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -4,25 +4,21 @@
 
 package frc.robot;
 
+import edu.wpi.first.apriltag.AprilTagFieldLayout;
+import edu.wpi.first.apriltag.AprilTagFields;
+import edu.wpi.first.math.geometry.*;
 import edu.wpi.first.math.geometry.Rotation2d;
-import edu.wpi.first.math.geometry.Transform2d;
 import edu.wpi.first.math.geometry.Translation2d;
 import edu.wpi.first.math.geometry.Translation3d;
 import edu.wpi.first.math.util.Units;
 import swervelib.math.Matter;
-import edu.wpi.first.apriltag.AprilTagFieldLayout;
-import edu.wpi.first.apriltag.AprilTagFields;
-import edu.wpi.first.math.geometry.*;
+
 /**
- * The Constants class provides a convenient place for teams to hold robot-wide
- * numerical or boolean constants. This
- * class should not be used for any other purpose. All constants should be
- * declared globally (i.e. public static). Do
- * not put anything functional in this class.
+ * The Constants class provides a convenient place for teams to hold robot-wide numerical or boolean
+ * constants. This class should not be used for any other purpose. All constants should be declared
+ * globally (i.e. public static). Do not put anything functional in this class.
  *
- * <p>
- * It is advised to statically import this class (or one of its inner classes)
- * wherever the
+ * <p>It is advised to statically import this class (or one of its inner classes) wherever the
  * constants are needed, to reduce verbosity.
  */
 public final class Constants {
@@ -31,7 +27,9 @@ public final class Constants {
   public static final double LOOP_TIME = 0.13; // s, 20ms + 110ms sprk max velocity lag
   public static final double MAX_SPEED = Units.feetToMeters(14.5);
   // Maximum speed of the robot in meters per second, used to limit acceleration.
-  public static final Matter CHASSIS = new Matter(new Translation3d(0, 0, Units.inchesToMeters(8)), ROBOT_MASS);
+  public static final Matter CHASSIS =
+      new Matter(new Translation3d(0, 0, Units.inchesToMeters(8)), ROBOT_MASS);
+
   // public static final class AutonConstants
   // {
   //
@@ -45,12 +43,14 @@ public final class Constants {
     // Hold time on motor brakes when disabled
     public static final double WHEEL_LOCK_TIME = 10; // seconds
   }
+
   public static final class FieldConstants {
-    public static final AprilTagFieldLayout FIELD_LAYOUT = AprilTagFieldLayout.loadField(
-      AprilTagFields.k2026RebuiltAndymark);
+    public static final AprilTagFieldLayout FIELD_LAYOUT =
+        AprilTagFieldLayout.loadField(AprilTagFields.k2026RebuiltAndymark);
 
     public static final double DistanceToHub = 0.4;
   }
+
   public static class OperatorConstants {
 
     // Joystick Deadband
@@ -59,25 +59,29 @@ public final class Constants {
     public static final double RIGHT_X_DEADBAND = 0.1;
     public static final double TURN_CONSTANT = 6;
   }
+
   public static final class HubScoringConstants {
-  
+
     // Hub positions on field (adjust based on your field layout)
     public static final Translation2d BLUE_HUB_CENTER = new Translation2d(4.625594, 4.0);
-    public static final Translation2d RED_HUB_CENTER = new Translation2d(11.901424, 4.0); // Adjust for red side
-  
+    public static final Translation2d RED_HUB_CENTER =
+        new Translation2d(11.901424, 4.0); // Adjust for red side
+
     // Scoring parameters
     public static final double SCORING_DISTANCE = 1.06; // meters from hub center
     public static final double MAX_ARC_SPEED = 2.0; // max speed while driving along arc (m/s)
-  
+
     // Valid scoring arc definition
     public static final Rotation2d BLUE_SCORING_SIDE = Rotation2d.fromDegrees(180); // Faces +X
     public static final Rotation2d RED_SCORING_SIDE = Rotation2d.fromDegrees(0); // Faces -X
-    public static final double SCORING_ARC_WIDTH_DEGREES = 90; // 180 = semicircle, 90 = quarter circle
-  
+    public static final double SCORING_ARC_WIDTH_DEGREES =
+        90; // 180 = semicircle, 90 = quarter circle
+
     // Tolerances
     public static final double POSITION_TOLERANCE = 0.05; // meters
     public static final double ANGLE_TOLERANCE = 2.0; // degrees
   }
+
   public static class PhotonvisionConstants {
 
     /*
@@ -86,8 +90,9 @@ public final class Constants {
     frontright,
     backleft,
     backright
-     */ 
+     */
   }
+
   public static final class CANDeviceIDs {
     public static final int kIndexerID = 50;
     public static final int kShooterID = 52;
@@ -119,7 +124,7 @@ public final class Constants {
   }
 
   public static final class ShooterConstants {
-    public static final double P = 0.0001;//0.00005, 0.0001
+    public static final double P = 0.0001; // 0.00005, 0.0001
     public static final double I = 0.0;
     public static final double D = 0.0;
     public static final double MinOutput = -1.0;

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -9,22 +9,17 @@ import edu.wpi.first.wpilibj.RobotController;
 import edu.wpi.first.wpilibj.Timer;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.CommandScheduler;
-import frc.robot.RobotContainer;
-import frc.robot.Cameras;
 import frc.robot.util.ElasticUtil;
-
-// AdvantageKit imports for logging
 import org.littletonrobotics.junction.LoggedRobot;
 import org.littletonrobotics.junction.Logger;
 import org.littletonrobotics.junction.networktables.NT4Publisher;
 import org.littletonrobotics.junction.wpilog.WPILOGWriter;
 
 /**
- * The VM is configured to automatically run this class, and to call the
- * functions corresponding to each mode, as
- * described in the TimedRobot documentation. If you change the name of this
- * class or the package after creating this
- * project, you must also update the build.gradle file in the project.
+ * The VM is configured to automatically run this class, and to call the functions corresponding to
+ * each mode, as described in the TimedRobot documentation. If you change the name of this class or
+ * the package after creating this project, you must also update the build.gradle file in the
+ * project.
  */
 public class Robot extends LoggedRobot {
 
@@ -49,9 +44,7 @@ public class Robot extends LoggedRobot {
 
   // ==================== LOGGING HELPER METHODS ====================
 
-  /**
-   * Returns the current robot mode as a string.
-   */
+  /** Returns the current robot mode as a string. */
   private String getCurrentMode() {
     if (isDisabled()) return "Disabled";
     if (isAutonomous()) return "Autonomous";
@@ -60,9 +53,7 @@ public class Robot extends LoggedRobot {
     return "Unknown";
   }
 
-  /**
-   * Returns the alliance color as a string.
-   */
+  /** Returns the alliance color as a string. */
   private String getAllianceString() {
     var alliance = DriverStation.getAlliance();
     if (alliance.isPresent()) {
@@ -72,8 +63,8 @@ public class Robot extends LoggedRobot {
   }
 
   /**
-   * Logs match state data every cycle.
-   * Signals: Match/Time, Mode, Enabled, FMSAttached, MatchNumber, EventName, Alliance, StationNumber
+   * Logs match state data every cycle. Signals: Match/Time, Mode, Enabled, FMSAttached,
+   * MatchNumber, EventName, Alliance, StationNumber
    */
   private void logMatchData() {
     Logger.recordOutput("Match/Time", DriverStation.getMatchTime());
@@ -89,26 +80,26 @@ public class Robot extends LoggedRobot {
   // Track active commands via callbacks
   private final java.util.Set<String> activeCommands = new java.util.LinkedHashSet<>();
 
-  /**
-   * Sets up command tracking callbacks.
-   * Called once during robotInit.
-   */
+  /** Sets up command tracking callbacks. Called once during robotInit. */
   private void setupCommandLogging() {
-    CommandScheduler.getInstance().onCommandInitialize(command -> {
-      activeCommands.add(command.getName());
-    });
-    CommandScheduler.getInstance().onCommandFinish(command -> {
-      activeCommands.remove(command.getName());
-    });
-    CommandScheduler.getInstance().onCommandInterrupt(command -> {
-      activeCommands.remove(command.getName());
-    });
+    CommandScheduler.getInstance()
+        .onCommandInitialize(
+            command -> {
+              activeCommands.add(command.getName());
+            });
+    CommandScheduler.getInstance()
+        .onCommandFinish(
+            command -> {
+              activeCommands.remove(command.getName());
+            });
+    CommandScheduler.getInstance()
+        .onCommandInterrupt(
+            command -> {
+              activeCommands.remove(command.getName());
+            });
   }
 
-  /**
-   * Logs active command data every cycle.
-   * Signals: Commands/ActiveList, Commands/ActiveCount
-   */
+  /** Logs active command data every cycle. Signals: Commands/ActiveList, Commands/ActiveCount */
   private void logCommands() {
     String list = activeCommands.isEmpty() ? "none" : String.join(", ", activeCommands);
     Logger.recordOutput("Commands/ActiveList", list);
@@ -116,8 +107,8 @@ public class Robot extends LoggedRobot {
   }
 
   /**
-   * Logs system health data every cycle.
-   * Signals: BatteryVoltage, CAN stats, RIO voltages/temp, BrownedOut, RSLState
+   * Logs system health data every cycle. Signals: BatteryVoltage, CAN stats, RIO voltages/temp,
+   * BrownedOut, RSLState
    */
   private void logSystemHealth() {
     // Battery voltage
@@ -142,9 +133,8 @@ public class Robot extends LoggedRobot {
   }
 
   /**
-   * Logs loop timing data every cycle.
-   * Tracks loop time in milliseconds and counts overruns (> 20ms).
-   * Signals: SystemHealth/LoopTimeMs, SystemHealth/LoopOverruns
+   * Logs loop timing data every cycle. Tracks loop time in milliseconds and counts overruns (>
+   * 20ms). Signals: SystemHealth/LoopTimeMs, SystemHealth/LoopOverruns
    */
   private void logLoopTiming() {
     double currentTimestamp = Timer.getFPGATimestamp();
@@ -168,10 +158,9 @@ public class Robot extends LoggedRobot {
   // ==================== LOGGING CONFIGURATION ====================
 
   /**
-   * Configures AdvantageKit logging.
-   * - Records build metadata for traceability
-   * - Sets up file logging (WPILOGWriter) to USB drive
-   * - Sets up NetworkTables publishing (NT4Publisher) for live dashboard
+   * Configures AdvantageKit logging. - Records build metadata for traceability - Sets up file
+   * logging (WPILOGWriter) to USB drive - Sets up NetworkTables publishing (NT4Publisher) for live
+   * dashboard
    */
   @SuppressWarnings("unused")
   private void configureLogging() {
@@ -198,8 +187,8 @@ public class Robot extends LoggedRobot {
   }
 
   /**
-   * This function is run when the robot is first started up and should be used
-   * for any initialization code.
+   * This function is run when the robot is first started up and should be used for any
+   * initialization code.
    */
   @Override
   public void robotInit() {
@@ -228,13 +217,10 @@ public class Robot extends LoggedRobot {
   }
 
   /**
-   * This function is called every 20 ms, no matter the mode. Use this for items
-   * like diagnostics that you want ran
-   * during disabled, autonomous, teleoperated and test.
+   * This function is called every 20 ms, no matter the mode. Use this for items like diagnostics
+   * that you want ran during disabled, autonomous, teleoperated and test.
    *
-   * <p>
-   * This runs after the mode specific periodic functions, but before LiveWindow
-   * and
+   * <p>This runs after the mode specific periodic functions, but before LiveWindow and
    * SmartDashboard integrated updating.
    */
   @Override
@@ -261,9 +247,7 @@ public class Robot extends LoggedRobot {
     logCommands();
   }
 
-  /**
-   * This function is called once each time the robot enters Disabled mode.
-   */
+  /** This function is called once each time the robot enters Disabled mode. */
   @Override
   public void disabledInit() {
     m_robotContainer.setMotorBrake(true);
@@ -280,10 +264,7 @@ public class Robot extends LoggedRobot {
     }
   }
 
-  /**
-   * This autonomous runs the autonomous command selected by your
-   * {@link RobotContainer} class.
-   */
+  /** This autonomous runs the autonomous command selected by your {@link RobotContainer} class. */
   @Override
   public void autonomousInit() {
     m_robotContainer.setMotorBrake(true);
@@ -295,12 +276,9 @@ public class Robot extends LoggedRobot {
     }
   }
 
-  /**
-   * This function is called periodically during autonomous.
-   */
+  /** This function is called periodically during autonomous. */
   @Override
-  public void autonomousPeriodic() {
-  }
+  public void autonomousPeriodic() {}
 
   @Override
   public void teleopInit() {
@@ -308,16 +286,13 @@ public class Robot extends LoggedRobot {
     // teleop starts running. If you want the autonomous to
     // continue until interrupted by another command, remove
     // this line or comment it out.
-    
+
     CommandScheduler.getInstance().cancelAll();
   }
 
-  /**
-   * This function is called periodically during operator control.
-   */
+  /** This function is called periodically during operator control. */
   @Override
-  public void teleopPeriodic() {
-  }
+  public void teleopPeriodic() {}
 
   @Override
   public void testInit() {
@@ -325,24 +300,15 @@ public class Robot extends LoggedRobot {
     CommandScheduler.getInstance().cancelAll();
   }
 
-  /**
-   * This function is called periodically during test mode.
-   */
+  /** This function is called periodically during test mode. */
   @Override
-  public void testPeriodic() {
-  }
+  public void testPeriodic() {}
 
-  /**
-   * This function is called once when the robot is first started up.
-   */
+  /** This function is called once when the robot is first started up. */
   @Override
-  public void simulationInit() {
-  }
+  public void simulationInit() {}
 
-  /**
-   * This function is called periodically whilst in simulation.
-   */
+  /** This function is called periodically whilst in simulation. */
   @Override
-  public void simulationPeriodic() {
-  }
+  public void simulationPeriodic() {}
 }

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -4,6 +4,8 @@
 
 package frc.robot;
 
+import static frc.robot.Constants.HubScoringConstants.*;
+
 import com.pathplanner.lib.auto.AutoBuilder;
 import com.pathplanner.lib.auto.NamedCommands;
 import edu.wpi.first.math.controller.ProfiledPIDController;
@@ -20,46 +22,25 @@ import edu.wpi.first.wpilibj.smartdashboard.Field2d;
 import edu.wpi.first.wpilibj.smartdashboard.SendableChooser;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.Command;
-import edu.wpi.first.wpilibj2.command.CommandScheduler;
 import edu.wpi.first.wpilibj2.command.Commands;
 import edu.wpi.first.wpilibj2.command.InstantCommand;
-import edu.wpi.first.wpilibj2.command.SequentialCommandGroup;
-import edu.wpi.first.wpilibj2.command.button.CommandXboxController;
-import edu.wpi.first.wpilibj2.command.button.JoystickButton;
 import edu.wpi.first.wpilibj2.command.button.CommandJoystick;
+import edu.wpi.first.wpilibj2.command.button.CommandXboxController;
 import edu.wpi.first.wpilibj2.command.button.Trigger;
 import frc.robot.Constants.OperatorConstants;
-import frc.robot.commands.AlignToTag;
-import frc.robot.commands.DriveToHub;
-import frc.robot.commands.HubArcDrive;
-//import frc.robot.commands.AlignWithAprilTag;
-import frc.robot.commands.RetractIntake;
-import frc.robot.commands.RunIntake;
+import frc.robot.commands.MoveIndexer;
+import frc.robot.commands.MoveShooter;
 import frc.robot.commands.SpeedUpThenIndex;
 import frc.robot.subsystems.swervedrive.SwerveSubsystem;
 import frc.robot.subsystems.swervedrive.Vision;
-import swervelib.SwerveInputStream;
-import frc.robot.Constants;
-import frc.robot.Constants.HubScoringConstants;
 import java.io.File;
-import java.util.function.BooleanSupplier;
-import frc.robot.commands.MoveIndexer;
-import frc.robot.commands.MoveShooter;
-import frc.robot.subsystems.swervedrive.SwerveSubsystem;
-import frc.robot.subsystems.swervedrive.Vision;
 import swervelib.SwerveInputStream;
-import static frc.robot.Constants.HubScoringConstants.*;
-import edu.wpi.first.wpilibj.DriverStation;
 
-import java.io.File;
-import java.util.function.BooleanSupplier;
 /**
- * This class is where the bulk of the robot should be declared. Since
- * Command-based is a "declarative" paradigm, very
- * little robot logic should actually be handled in the {@link Robot} periodic
- * methods (other than the scheduler calls).
- * Instead, the structure of the robot (including subsystems, commands, and
- * trigger mappings) should be declared here.
+ * This class is where the bulk of the robot should be declared. Since Command-based is a
+ * "declarative" paradigm, very little robot logic should actually be handled in the {@link Robot}
+ * periodic methods (other than the scheduler calls). Instead, the structure of the robot (including
+ * subsystems, commands, and trigger mappings) should be declared here.
  */
 public class RobotContainer {
 
@@ -67,88 +48,90 @@ public class RobotContainer {
   final CommandXboxController driverXbox = new CommandXboxController(0);
   final CommandJoystick driverJoystick = new CommandJoystick(1);
   private final SendableChooser<Command> autoChooser;
-  
+
   private boolean useLeftOffset = true;
 
   private static RobotContainer instance;
 
   // The robot's subsystems and commands are defined here...
-  private final SwerveSubsystem drivebase = new SwerveSubsystem(new File(Filesystem.getDeployDirectory(),
-      "swerve/neo"));
-   // Initialize the vision subsystem
+  private final SwerveSubsystem drivebase =
+      new SwerveSubsystem(new File(Filesystem.getDeployDirectory(), "swerve/neo"));
+  // Initialize the vision subsystem
 
   private final Field2d field = new Field2d();
 
   public final Vision visionSubsystem = new Vision(drivebase::getPose, field);
-  /**
-   * 
-   * Converts driver input into a field-relative ChassisSpeeds that is controlled
-   * by angular velocity.
-   */
-  SwerveInputStream driveAngularVelocity = SwerveInputStream.of(drivebase.getSwerveDrive(),
-      () -> driverXbox.getLeftY() * -1,
-      () -> driverXbox.getLeftX() * -1)
-      .withControllerRotationAxis(() -> driverXbox.getRightX() * -1)
-      .deadband(OperatorConstants.DEADBAND)
-      .scaleTranslation(0.8)
-      .allianceRelativeControl(true);
 
   /**
-   * Clone's the angular velocity input stream and converts it to a fieldRelative
-   * input stream.
+   * Converts driver input into a field-relative ChassisSpeeds that is controlled by angular
+   * velocity.
    */
-  SwerveInputStream driveDirectAngle = driveAngularVelocity.copy().withControllerHeadingAxis(driverXbox::getRightX,
-      driverXbox::getRightY)
-      .headingWhile(true);
+  SwerveInputStream driveAngularVelocity =
+      SwerveInputStream.of(
+              drivebase.getSwerveDrive(),
+              () -> driverXbox.getLeftY() * -1,
+              () -> driverXbox.getLeftX() * -1)
+          .withControllerRotationAxis(() -> driverXbox.getRightX() * -1)
+          .deadband(OperatorConstants.DEADBAND)
+          .scaleTranslation(0.8)
+          .allianceRelativeControl(true);
 
-  /**
-   * Clone's the angular velocity input stream and converts it to a robotRelative
-   * input stream.
-   */
-  SwerveInputStream driveRobotOriented = driveAngularVelocity.copy().robotRelative(true)
-      .allianceRelativeControl(false);
+  /** Clone's the angular velocity input stream and converts it to a fieldRelative input stream. */
+  SwerveInputStream driveDirectAngle =
+      driveAngularVelocity
+          .copy()
+          .withControllerHeadingAxis(driverXbox::getRightX, driverXbox::getRightY)
+          .headingWhile(true);
 
-  SwerveInputStream driveAngularVelocityKeyboard = SwerveInputStream.of(drivebase.getSwerveDrive(),
-      () -> -driverXbox.getLeftY(),
-      () -> -driverXbox.getLeftX())
-      .withControllerRotationAxis(() -> driverXbox.getRawAxis(
-          2))
-      .deadband(OperatorConstants.DEADBAND)
-      .scaleTranslation(0.8)
-      .allianceRelativeControl(true);
+  /** Clone's the angular velocity input stream and converts it to a robotRelative input stream. */
+  SwerveInputStream driveRobotOriented =
+      driveAngularVelocity.copy().robotRelative(true).allianceRelativeControl(false);
+
+  SwerveInputStream driveAngularVelocityKeyboard =
+      SwerveInputStream.of(
+              drivebase.getSwerveDrive(),
+              () -> -driverXbox.getLeftY(),
+              () -> -driverXbox.getLeftX())
+          .withControllerRotationAxis(() -> driverXbox.getRawAxis(2))
+          .deadband(OperatorConstants.DEADBAND)
+          .scaleTranslation(0.8)
+          .allianceRelativeControl(true);
   // Derive the heading axis with math!
-  SwerveInputStream driveDirectAngleKeyboard = driveAngularVelocityKeyboard.copy()
-      .withControllerHeadingAxis(() -> Math.sin(driverXbox.getRawAxis(2) * Math.PI) * (Math.PI * 2),
-          () -> Math.cos(driverXbox.getRawAxis(2) * Math.PI) * (Math.PI * 2))
-      .headingWhile(true).translationHeadingOffset(true).translationHeadingOffset(Rotation2d.fromDegrees(0));
+  SwerveInputStream driveDirectAngleKeyboard =
+      driveAngularVelocityKeyboard
+          .copy()
+          .withControllerHeadingAxis(
+              () -> Math.sin(driverXbox.getRawAxis(2) * Math.PI) * (Math.PI * 2),
+              () -> Math.cos(driverXbox.getRawAxis(2) * Math.PI) * (Math.PI * 2))
+          .headingWhile(true)
+          .translationHeadingOffset(true)
+          .translationHeadingOffset(Rotation2d.fromDegrees(0));
 
-//   SwerveInputStream driveAngularVelocity = SwerveInputStream.of(drivebase.getSwerveDrive(),
-//   () -> driverJoystick.getY() * -1,
-//   () -> driverJoystick.getX() * -1)
-//   .withControllerRotationAxis(driverJoystick::getTwist)
-//   .deadband(OperatorConstants.DEADBAND)
-//   .scaleTranslation(0.8)
-//   .allianceRelativeControl(true);
+  //   SwerveInputStream driveAngularVelocity = SwerveInputStream.of(drivebase.getSwerveDrive(),
+  //   () -> driverJoystick.getY() * -1,
+  //   () -> driverJoystick.getX() * -1)
+  //   .withControllerRotationAxis(driverJoystick::getTwist)
+  //   .deadband(OperatorConstants.DEADBAND)
+  //   .scaleTranslation(0.8)
+  //   .allianceRelativeControl(true);
 
+  // SwerveInputStream driveAngularVelocityKeyboard =
+  // SwerveInputStream.of(drivebase.getSwerveDrive(),
+  //   () -> -driverJoystick.getY(),
+  //   () -> -driverJoystick.getX())
+  //   .withControllerRotationAxis(() -> driverJoystick.getTwist())
+  //   .deadband(OperatorConstants.DEADBAND)
+  //   .scaleTranslation(0.8)
+  //   .allianceRelativeControl(true);
+  // // Derive the heading axis with math!
+  // SwerveInputStream driveDirectAngleKeyboard = driveAngularVelocityKeyboard.copy()
+  //   .withControllerHeadingAxis(() -> Math.sin(driverJoystick.getTwist() * Math.PI) * (Math.PI *
+  // 2),
+  //       () -> Math.cos(driverJoystick.getTwist() * Math.PI) * (Math.PI * 2))
+  //
+  // .headingWhile(true).translationHeadingOffset(true).translationHeadingOffset(Rotation2d.fromDegrees(0));
 
-
-
-// SwerveInputStream driveAngularVelocityKeyboard = SwerveInputStream.of(drivebase.getSwerveDrive(),
-//   () -> -driverJoystick.getY(),
-//   () -> -driverJoystick.getX())
-//   .withControllerRotationAxis(() -> driverJoystick.getTwist())
-//   .deadband(OperatorConstants.DEADBAND)
-//   .scaleTranslation(0.8)
-//   .allianceRelativeControl(true);
-// // Derive the heading axis with math!
-// SwerveInputStream driveDirectAngleKeyboard = driveAngularVelocityKeyboard.copy()
-//   .withControllerHeadingAxis(() -> Math.sin(driverJoystick.getTwist() * Math.PI) * (Math.PI * 2),
-//       () -> Math.cos(driverJoystick.getTwist() * Math.PI) * (Math.PI * 2))
-//   .headingWhile(true).translationHeadingOffset(true).translationHeadingOffset(Rotation2d.fromDegrees(0));
-
-  /**
-   * The container for the robot. Contains subsystems, OI devices, and commands.
-   */
+  /** The container for the robot. Contains subsystems, OI devices, and commands. */
   private RobotContainer() {
     // Configure the trigger bindings
     configureBindings();
@@ -164,30 +147,28 @@ public class RobotContainer {
   }
 
   /**
-   * Use this method to define your trigger->command mappings. Triggers can be
-   * created via the
-   * {@link Trigger#Trigger(java.util.function.BooleanSupplier)} constructor with
-   * an arbitrary predicate, or via the
-   * named factories in
-   * {@link edu.wpi.first.wpilibj2.command.button.CommandGenericHID}'s subclasses
-   * for
-   * {@link CommandXboxController
-   * Xbox}/{@link edu.wpi.first.wpilibj2.command.button.CommandPS4Controller PS4}
-   * controllers or {@link edu.wpi.first.wpilibj2.command.button.CommandJoystick
-   * Flight joysticks}.
+   * Use this method to define your trigger->command mappings. Triggers can be created via the
+   * {@link Trigger#Trigger(java.util.function.BooleanSupplier)} constructor with an arbitrary
+   * predicate, or via the named factories in {@link
+   * edu.wpi.first.wpilibj2.command.button.CommandGenericHID}'s subclasses for {@link
+   * CommandXboxController Xbox}/{@link edu.wpi.first.wpilibj2.command.button.CommandPS4Controller
+   * PS4} controllers or {@link edu.wpi.first.wpilibj2.command.button.CommandJoystick Flight
+   * joysticks}.
    */
   private void configureBindings() {
-    
+
     driverXbox.y().onTrue(Commands.runOnce(() -> toggleOffset()));
 
     Command driveFieldOrientedDirectAngle = drivebase.driveFieldOriented(driveDirectAngle);
     Command driveFieldOrientedAnglularVelocity = drivebase.driveFieldOriented(driveAngularVelocity);
     Command driveRobotOrientedAngularVelocity = drivebase.driveFieldOriented(driveRobotOriented);
-    Command driveSetpointGen = drivebase.driveWithSetpointGeneratorFieldRelative(
-        driveDirectAngle);
-    Command driveFieldOrientedDirectAngleKeyboard = drivebase.driveFieldOriented(driveDirectAngleKeyboard);
-    Command driveFieldOrientedAnglularVelocityKeyboard = drivebase.driveFieldOriented(driveAngularVelocityKeyboard);
-    Command driveSetpointGenKeyboard = drivebase.driveWithSetpointGeneratorFieldRelative(driveDirectAngleKeyboard);
+    Command driveSetpointGen = drivebase.driveWithSetpointGeneratorFieldRelative(driveDirectAngle);
+    Command driveFieldOrientedDirectAngleKeyboard =
+        drivebase.driveFieldOriented(driveDirectAngleKeyboard);
+    Command driveFieldOrientedAnglularVelocityKeyboard =
+        drivebase.driveFieldOriented(driveAngularVelocityKeyboard);
+    Command driveSetpointGenKeyboard =
+        drivebase.driveWithSetpointGeneratorFieldRelative(driveDirectAngleKeyboard);
 
     if (RobotBase.isSimulation()) {
       drivebase.setDefaultCommand(driveFieldOrientedAnglularVelocity);
@@ -196,39 +177,37 @@ public class RobotContainer {
     }
 
     if (Robot.isSimulation()) {
-      Pose2d target = new Pose2d(new Translation2d(1, 4),
-          Rotation2d.fromDegrees(90));
+      Pose2d target = new Pose2d(new Translation2d(1, 4), Rotation2d.fromDegrees(90));
       // drivebase.getSwerveDrive().field.getObject("targetPose").setPose(target);
-      driveDirectAngleKeyboard.driveToPose(() -> target,
+      driveDirectAngleKeyboard.driveToPose(
+          () -> target,
+          new ProfiledPIDController(5, 0, 0, new Constraints(5, 2)),
           new ProfiledPIDController(
-              5,
-              0,
-              0,
-              new Constraints(5, 2)),
-          new ProfiledPIDController(
-              5,
-              0,
-              0,
-              new Constraints(
-                  Units.degreesToRadians(360),
-                  Units.degreesToRadians(180))));
-      driverXbox.start().onTrue(Commands.runOnce(() -> drivebase.resetOdometry(new Pose2d(3, 3, new Rotation2d()))));
-       // Button B
-      driverXbox.button(3).onTrue(Commands.runOnce(() -> toggleOffset()));     
-           
-      //driverXbox.button(1).whileTrue(drivebase.sysIdDriveMotorCommand());
-      driverXbox.button(2).whileTrue(
-          Commands.runEnd(() -> driveDirectAngleKeyboard.driveToPoseEnabled(true),
-              () -> driveDirectAngleKeyboard.driveToPoseEnabled(false)));
+              5, 0, 0, new Constraints(Units.degreesToRadians(360), Units.degreesToRadians(180))));
+      driverXbox
+          .start()
+          .onTrue(
+              Commands.runOnce(() -> drivebase.resetOdometry(new Pose2d(3, 3, new Rotation2d()))));
+      // Button B
+      driverXbox.button(3).onTrue(Commands.runOnce(() -> toggleOffset()));
+
+      // driverXbox.button(1).whileTrue(drivebase.sysIdDriveMotorCommand());
+      driverXbox
+          .button(2)
+          .whileTrue(
+              Commands.runEnd(
+                  () -> driveDirectAngleKeyboard.driveToPoseEnabled(true),
+                  () -> driveDirectAngleKeyboard.driveToPoseEnabled(false)));
 
       // driverXbox.b().whileTrue(
       // drivebase.driveToPose(
       // new Pose2d(new Translation2d(4, 4), Rotation2d.fromDegrees(0)))
       // );
-      
+
     }
     if (DriverStation.isTest()) {
-      drivebase.setDefaultCommand(driveFieldOrientedAnglularVelocity); // Overrides drive command above!
+      drivebase.setDefaultCommand(
+          driveFieldOrientedAnglularVelocity); // Overrides drive command above!
 
       driverXbox.x().whileTrue(Commands.runOnce(drivebase::lock, drivebase).repeatedly());
       driverXbox.y().whileTrue(drivebase.driveToDistanceCommand(1.0, 0.2));
@@ -237,8 +216,9 @@ public class RobotContainer {
       driverXbox.leftBumper().onTrue(Commands.none());
       driverXbox.rightBumper().onTrue(Commands.none());
     } else {
-      
-      // driverXbox.a().onTrue(new DriveToHub(drivebase, getHubCenter(), SCORING_DISTANCE, getScoringSide(), SCORING_ARC_WIDTH_DEGREES));
+
+      // driverXbox.a().onTrue(new DriveToHub(drivebase, getHubCenter(), SCORING_DISTANCE,
+      // getScoringSide(), SCORING_ARC_WIDTH_DEGREES));
       // driverXbox.x().toggleOnTrue(
       //   new HubArcDrive(drivebase,
       //     driverXbox::getLeftX,
@@ -247,37 +227,36 @@ public class RobotContainer {
       //     getScoringSide()
       //   )
       // );
-      //driverXbox.x().onTrue(Commands.runOnce(drivebase::addFakeVisionReading));
+      // driverXbox.x().onTrue(Commands.runOnce(drivebase::addFakeVisionReading));
       driverXbox.start().onTrue(Commands.runOnce(drivebase::zeroGyro));
       driverXbox.back().whileTrue(drivebase.centerModulesCommand());
       driverXbox.leftBumper().whileTrue(Commands.runOnce(drivebase::lock, drivebase).repeatedly());
-      //driverXbox.rightBumper().onTrue(new AlignWithAprilTag());
-      //driverXbox.b().whileTrue(new RunIntake())
-       //   .onFalse(new RetractIntake());
+      // driverXbox.rightBumper().onTrue(new AlignWithAprilTag());
+      // driverXbox.b().whileTrue(new RunIntake())
+      //   .onFalse(new RetractIntake());
       driverXbox.y().whileTrue(new MoveIndexer(Constants.MotorConstants.DESIRED_INDEXER_RPM));
       driverXbox.a().whileTrue(new MoveShooter(Constants.MotorConstants.DESIRED_SHOOTER_RPM));
       driverXbox.x().onTrue(new SpeedUpThenIndex());
     }
   }
-/*     if (DriverStation.isTest()) {
-      drivebase.setDefaultCommand(driveFieldOrientedAnglularVelocity); // Overrides drive command above!
 
-      driverJoystick.button(12).whileTrue(Commands.runOnce(drivebase::lock, drivebase).repeatedly());
-      driverJoystick.button(11).whileTrue(drivebase.driveToDistanceCommand(1.0, 0.2));
-      driverJoystick.button(3).onTrue((Commands.runOnce(drivebase::zeroGyro)));
-      driverJoystick.button(4).whileTrue(drivebase.centerModulesCommand());
-      driverJoystick.button(1).onTrue(Commands.none());
-      driverJoystick.button(6).onTrue(Commands.none());
-    } else {
-      driverJoystick.button(12).whileTrue(Commands.runOnce(drivebase::lock, drivebase).repeatedly());
-      driverJoystick.button(11).whileTrue(drivebase.driveToDistanceCommand(1.0, 0.2));
-      driverJoystick.button(3).onTrue((Commands.runOnce(drivebase::zeroGyro)));
-      driverJoystick.button(4).whileTrue(drivebase.centerModulesCommand());
-      driverJoystick.button(1).onTrue(Commands.none());
-      driverJoystick.button(6).onTrue(Commands.none());
-    } */
+  /*     if (DriverStation.isTest()) {
+    drivebase.setDefaultCommand(driveFieldOrientedAnglularVelocity); // Overrides drive command above!
 
-  
+    driverJoystick.button(12).whileTrue(Commands.runOnce(drivebase::lock, drivebase).repeatedly());
+    driverJoystick.button(11).whileTrue(drivebase.driveToDistanceCommand(1.0, 0.2));
+    driverJoystick.button(3).onTrue((Commands.runOnce(drivebase::zeroGyro)));
+    driverJoystick.button(4).whileTrue(drivebase.centerModulesCommand());
+    driverJoystick.button(1).onTrue(Commands.none());
+    driverJoystick.button(6).onTrue(Commands.none());
+  } else {
+    driverJoystick.button(12).whileTrue(Commands.runOnce(drivebase::lock, drivebase).repeatedly());
+    driverJoystick.button(11).whileTrue(drivebase.driveToDistanceCommand(1.0, 0.2));
+    driverJoystick.button(3).onTrue((Commands.runOnce(drivebase::zeroGyro)));
+    driverJoystick.button(4).whileTrue(drivebase.centerModulesCommand());
+    driverJoystick.button(1).onTrue(Commands.none());
+    driverJoystick.button(6).onTrue(Commands.none());
+  } */
 
   /**
    * Use this to pass the autonomous command to the main {@link Robot} class.
@@ -286,31 +265,32 @@ public class RobotContainer {
    */
   public Command getAutonomousCommand() {
     // An example command will be run in autonomous
-    return autoChooser.getSelected();      
+    return autoChooser.getSelected();
   }
 
   public Command driveToTag(int tagId) {
-    Transform2d offset = new Transform2d(
-        new Translation2d(0.75, 0.0),  // 0.75 meters in front of tag
-        Rotation2d.fromDegrees(180)    // face tag
-    );
-  
+    Transform2d offset =
+        new Transform2d(
+            new Translation2d(0.75, 0.0), // 0.75 meters in front of tag
+            Rotation2d.fromDegrees(180) // face tag
+            );
+
     Pose2d targPose = Vision.getAprilTagPose(tagId, offset);
     if (targPose == null) {
-        return new InstantCommand(); // do nothing
+      return new InstantCommand(); // do nothing
     }
-  
+
     return drivebase.driveToPose(targPose);
   }
 
   public boolean getUseLeftOffset() {
     return useLeftOffset;
   }
+
   public void toggleOffset() {
     useLeftOffset = !useLeftOffset;
   }
 
-  
   public void setMotorBrake(boolean brake) {
     drivebase.setMotorBrake(brake);
   }
@@ -334,18 +314,18 @@ public class RobotContainer {
 
   private boolean isRedAlliance() {
     var alliance = DriverStation.getAlliance();
-    
+
     if (alliance.isPresent()) {
       return alliance.get() == DriverStation.Alliance.Red;
     }
-  
+
     // Default to blue if no alliance data
     return false;
   }
 
   private Translation2d getHubCenter() {
     boolean isRedAlliance = isRedAlliance();
-  
+
     if (isRedAlliance) {
       return RED_HUB_CENTER;
     } else {
@@ -355,7 +335,7 @@ public class RobotContainer {
 
   private Rotation2d getScoringSide() {
     boolean isRedAlliance = isRedAlliance();
-  
+
     if (isRedAlliance) {
       return RED_SCORING_SIDE;
     } else {
@@ -363,5 +343,3 @@ public class RobotContainer {
     }
   }
 }
-
-

--- a/src/main/java/frc/robot/commands/ShootOnTheMove.java
+++ b/src/main/java/frc/robot/commands/ShootOnTheMove.java
@@ -7,35 +7,43 @@ import edu.wpi.first.math.MathUtil;
 import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.math.geometry.Translation2d;
 import edu.wpi.first.math.kinematics.ChassisSpeeds;
-import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
-import edu.wpi.first.wpilibj2.command.Command;
-import frc.robot.subsystems.swervedrive.SwerveSubsystem;
-import frc.robot.subsystems.Shooter;
 import edu.wpi.first.math.util.Units;
- import edu.wpi.first.math.interpolation.InterpolatingDoubleTreeMap;
+import edu.wpi.first.wpilibj2.command.Command;
+import frc.robot.subsystems.Shooter;
+import frc.robot.subsystems.swervedrive.SwerveSubsystem;
 import java.util.function.DoubleSupplier;
-//Shoot on the move command, this command has very similar heading control to the hub arc drive command, where error is calculated, time of flight is considered to compenstae for drift
-//and the robot continues to aim to hub, the differe is, the robot is free to move in both the x and y directions, this makes time of flight calculations more complicated, and needs to be tuned
-//as explained in the thread below, we made a interpolating double tree map, or essentially a look up table, this helps calculate differnt time of flight at different distances in both x and y
-//must find different distances and times for tuning, the heading aim is essentially the same as hub arc drive, the differnce is calculating time of flight, as distance changes, and shooter speed is involved, as ballls now are affected by x and y velocity of robot.
-//the command iterates to constantly update shot data, imagine the first shot 5 meters away with the robot moving sideways, the lookup table says it takes 1 sec to get ther for example
-//but since we are moving, we will actually be 6 meters from the hub, so loop iterates and sees time of flight is now 1.5 seconds, causing more drift, meaning aim more to compensate, and this proccess repeats until the changes are so slight, there is no impact.
-//https://www.chiefdelphi.com/t/shoot-on-the-move-from-the-code-perspective/511815/27
+
+// Shoot on the move command, this command has very similar heading control to the hub arc drive
+// command, where error is calculated, time of flight is considered to compenstae for drift
+// and the robot continues to aim to hub, the differe is, the robot is free to move in both the x
+// and y directions, this makes time of flight calculations more complicated, and needs to be tuned
+// as explained in the thread below, we made a interpolating double tree map, or essentially a look
+// up table, this helps calculate differnt time of flight at different distances in both x and y
+// must find different distances and times for tuning, the heading aim is essentially the same as
+// hub arc drive, the differnce is calculating time of flight, as distance changes, and shooter
+// speed is involved, as ballls now are affected by x and y velocity of robot.
+// the command iterates to constantly update shot data, imagine the first shot 5 meters away with
+// the robot moving sideways, the lookup table says it takes 1 sec to get ther for example
+// but since we are moving, we will actually be 6 meters from the hub, so loop iterates and sees
+// time of flight is now 1.5 seconds, causing more drift, meaning aim more to compensate, and this
+// proccess repeats until the changes are so slight, there is no impact.
+// https://www.chiefdelphi.com/t/shoot-on-the-move-from-the-code-perspective/511815/27
 public class ShootOnTheMove extends Command {
 
   private final SwerveSubsystem swerve;
   private final Shooter shooter;
 
   private final double WHEEL_RADIUS_METERS = Units.inchesToMeters(2.0);
-  private final DoubleSupplier forwardInput;  
-  private final DoubleSupplier strafeInput;   
+  private final DoubleSupplier forwardInput;
+  private final DoubleSupplier strafeInput;
   private final Translation2d hubCenter;
   private final InterpolatingDoubleTreeMap timeOfFlightMap = new InterpolatingDoubleTreeMap();
-  
-  public ShootOnTheMove(SwerveSubsystem swerve,
-                        DoubleSupplier forwardInput,
-                        DoubleSupplier strafeInput,
-                        Translation2d hubCenter) {
+
+  public ShootOnTheMove(
+      SwerveSubsystem swerve,
+      DoubleSupplier forwardInput,
+      DoubleSupplier strafeInput,
+      Translation2d hubCenter) {
     this.swerve = swerve;
     this.shooter = Shooter.getInstance();
     this.forwardInput = forwardInput;
@@ -43,16 +51,14 @@ public class ShootOnTheMove extends Command {
     this.hubCenter = hubCenter;
 
     addRequirements(swerve);
-    //distance and time
+    // distance and time
     timeOfFlightMap.put(2.0, 0.40);
     timeOfFlightMap.put(4.0, 0.75);
     timeOfFlightMap.put(6.0, 1.10);
   }
 
   @Override
-  public void initialize() {
-
-  }
+  public void initialize() {}
 
   @Override
   public void execute() {
@@ -61,28 +67,26 @@ public class ShootOnTheMove extends Command {
     Rotation2d currentHeading = swerve.getHeading();
 
     ChassisSpeeds robotVelocity = swerve.getFieldVelocity();
-    Translation2d robotVel = new Translation2d(
-        robotVelocity.vxMetersPerSecond,
-        robotVelocity.vyMetersPerSecond
-    );
+    Translation2d robotVel =
+        new Translation2d(robotVelocity.vxMetersPerSecond, robotVelocity.vyMetersPerSecond);
 
     double distanceToHub = robotPos.getDistance(hubCenter);
 
-
     double timeOfFlight = timeOfFlightMap.get(distanceToHub);
 
-    Translation2d compensatedTarget = hubCenter;  // will be refined each iteration
-    Translation2d shooterVecResult  = Translation2d.kZero;
-    double targetShooterSpeed = 0.0;    
+    Translation2d compensatedTarget = hubCenter; // will be refined each iteration
+    Translation2d shooterVecResult = Translation2d.kZero;
+    double targetShooterSpeed = 0.0;
     for (int i = 0; i < 3; i++) {
 
-      // how far the piece drifts during flight due to robot motion 
+      // how far the piece drifts during flight due to robot motion
       Translation2d drift = robotVel.times(timeOfFlight);
 
-      //compensated target, pretty much creates a new target, and then with the drift, the ball will end up in the hub
+      // compensated target, pretty much creates a new target, and then with the drift, the ball
+      // will end up in the hub
       compensatedTarget = hubCenter.minus(drift);
 
-      //vector from robot to compensated target
+      // vector from robot to compensated target
       Translation2d toTarget = compensatedTarget.minus(robotPos);
       double distToCompTarget = toTarget.getNorm();
 
@@ -91,8 +95,8 @@ public class ShootOnTheMove extends Command {
       // The piece must travel toTarget in timeOfFlight seconds.
       Translation2d requiredFieldVel = toTarget.times(1.0 / timeOfFlight);
 
-      //what the shooter itself must produce
-     
+      // what the shooter itself must produce
+
       shooterVecResult = requiredFieldVel.minus(robotVel);
       targetShooterSpeed = shooterVecResult.getNorm();
 
@@ -100,8 +104,6 @@ public class ShootOnTheMove extends Command {
       if (targetShooterSpeed < 0.1) {
         targetShooterSpeed = 10;
       }
-
-
     }
 
     Rotation2d compensatedAim = compensatedTarget.minus(robotPos).getAngle();
@@ -110,33 +112,29 @@ public class ShootOnTheMove extends Command {
 
     headingError = Math.atan2(Math.sin(headingError), Math.cos(headingError));
 
-    double headingSpeed = headingError * 3;// tune pid
+    double headingSpeed = headingError * 3; // tune pid
     double maxHeadingSpeed = swerve.getSwerveDrive().getMaximumChassisAngularVelocity() * 0.6;
     headingSpeed = MathUtil.clamp(headingSpeed, -maxHeadingSpeed, maxHeadingSpeed);
 
-    double maxV  = swerve.getSwerveDrive().getMaximumChassisVelocity();
+    double maxV = swerve.getSwerveDrive().getMaximumChassisVelocity();
     double fieldVx = forwardInput.getAsDouble() * maxV * 0.6;
-    double fieldVy = strafeInput.getAsDouble()  * maxV * 0.6;
+    double fieldVy = strafeInput.getAsDouble() * maxV * 0.6;
 
-
-    ChassisSpeeds speeds = ChassisSpeeds.fromFieldRelativeSpeeds(
-        fieldVx, fieldVy, headingSpeed, currentHeading
-    );
+    ChassisSpeeds speeds =
+        ChassisSpeeds.fromFieldRelativeSpeeds(fieldVx, fieldVy, headingSpeed, currentHeading);
     swerve.drive(speeds);
     double shooterRPM = (targetShooterSpeed / (2.0 * Math.PI * WHEEL_RADIUS_METERS)) * 60.0;
     shooter.moveToVelocityWithPID(shooterRPM);
-
   }
 
   @Override
   public void end(boolean interrupted) {
     swerve.drive(new ChassisSpeeds(0, 0, 0));
-
   }
 
   @Override
   public boolean isFinished() {
-  
+
     return false;
   }
 }

--- a/src/main/java/frc/robot/commands/SpeedUpThenIndex.java
+++ b/src/main/java/frc/robot/commands/SpeedUpThenIndex.java
@@ -5,18 +5,20 @@
 package frc.robot.commands;
 
 import edu.wpi.first.wpilibj2.command.Command;
-import edu.wpi.first.wpilibj2.command.Commands;
 import edu.wpi.first.wpilibj2.command.CommandScheduler;
+import edu.wpi.first.wpilibj2.command.Commands;
 import edu.wpi.first.wpilibj2.command.SequentialCommandGroup;
-import frc.robot.subsystems.Shooter;
-import frc.robot.subsystems.Indexer;
 import frc.robot.Constants;
-import frc.robot.Constants.MotorConstants;
+import frc.robot.subsystems.Indexer;
+import frc.robot.subsystems.Shooter;
+
 /* You should consider using the more terse Command factories API instead https://docs.wpilib.org/en/stable/docs/software/commandbased/organizing-command-based.html#defining-commands */
 public class SpeedUpThenIndex extends Command {
   /** Creates a new SpeedUpThenIndex. */
   private Shooter shooter;
+
   private Indexer indexer;
+
   public SpeedUpThenIndex() {
     // Use addRequirements() here to declare subsystem dependencies.
     shooter = Shooter.getInstance();
@@ -27,25 +29,31 @@ public class SpeedUpThenIndex extends Command {
 
   // Called when the command is initially scheduled.
   @Override
-  public void initialize() {
-
-  }
+  public void initialize() {}
 
   // Called every time the scheduler runs while the command is scheduled.
   @Override
   public void execute() {
-    CommandScheduler.getInstance().schedule(new MoveShooter(Constants.MotorConstants.DESIRED_SHOOTER_RPM));
-    final Command waitUntilSpeed = Commands.waitUntil(() -> shooter.getMotorVelocity() == Constants.MotorConstants.DESIRED_SHOOTER_RPM);
-    CommandScheduler.getInstance().schedule(new SequentialCommandGroup(waitUntilSpeed, new MoveIndexer(Constants.MotorConstants.DESIRED_INDEXER_RPM)));
+    CommandScheduler.getInstance()
+        .schedule(new MoveShooter(Constants.MotorConstants.DESIRED_SHOOTER_RPM));
+    final Command waitUntilSpeed =
+        Commands.waitUntil(
+            () -> shooter.getMotorVelocity() == Constants.MotorConstants.DESIRED_SHOOTER_RPM);
+    CommandScheduler.getInstance()
+        .schedule(
+            new SequentialCommandGroup(
+                waitUntilSpeed, new MoveIndexer(Constants.MotorConstants.DESIRED_INDEXER_RPM)));
   }
 
   // Called once the command ends or is interrupted.
   @Override
   public void end(boolean interrupted) {
     CommandScheduler.getInstance().schedule(new MoveShooter(0));
-    CommandScheduler.getInstance().schedule(new MoveIndexer(-Constants.MotorConstants.DESIRED_INDEXER_RPM));
+    CommandScheduler.getInstance()
+        .schedule(new MoveIndexer(-Constants.MotorConstants.DESIRED_INDEXER_RPM));
     final Command waitTime = Commands.waitSeconds(0.25);
-    CommandScheduler.getInstance().schedule(new SequentialCommandGroup(waitTime, new MoveIndexer(0)));
+    CommandScheduler.getInstance()
+        .schedule(new SequentialCommandGroup(waitTime, new MoveIndexer(0)));
   }
 
   // Returns true when the command should end.

--- a/src/main/java/frc/robot/subsystems/Actuator.java
+++ b/src/main/java/frc/robot/subsystems/Actuator.java
@@ -4,100 +4,108 @@
 
 package frc.robot.subsystems;
 
-import com.revrobotics.RelativeEncoder;
-import com.revrobotics.spark.SparkAbsoluteEncoder;
 import com.revrobotics.PersistMode;
+import com.revrobotics.RelativeEncoder;
 import com.revrobotics.ResetMode;
+import com.revrobotics.spark.FeedbackSensor;
+import com.revrobotics.spark.SparkAbsoluteEncoder;
 import com.revrobotics.spark.SparkLowLevel;
 import com.revrobotics.spark.SparkMax;
-import com.revrobotics.spark.FeedbackSensor;
 import com.revrobotics.spark.config.SoftLimitConfig;
 import com.revrobotics.spark.config.SparkMaxConfig;
-
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 
 public class Actuator extends SubsystemBase {
-    private SparkMax motor;
-    private RelativeEncoder encoder;
-    private SparkAbsoluteEncoder absoluteEncoder;
-    private boolean useThroughBoreEncoder;
+  private SparkMax motor;
+  private RelativeEncoder encoder;
+  private SparkAbsoluteEncoder absoluteEncoder;
+  private boolean useThroughBoreEncoder;
 
-    public Actuator(int kID, double kP, double kI, double kD, double kMinOutput, double kMaxOutput, double kF, double kIz,
-            float kUpperSoftLimit, float kLowerSoftLimit, boolean inverted, boolean useThroughBoreEncoder,
-            boolean useSoftLimits) {
+  public Actuator(
+      int kID,
+      double kP,
+      double kI,
+      double kD,
+      double kMinOutput,
+      double kMaxOutput,
+      double kF,
+      double kIz,
+      float kUpperSoftLimit,
+      float kLowerSoftLimit,
+      boolean inverted,
+      boolean useThroughBoreEncoder,
+      boolean useSoftLimits) {
 
-        motor = new SparkMax(kID, SparkLowLevel.MotorType.kBrushless);
-        SparkMaxConfig motorConfig = new SparkMaxConfig();
+    motor = new SparkMax(kID, SparkLowLevel.MotorType.kBrushless);
+    SparkMaxConfig motorConfig = new SparkMaxConfig();
 
-        motorConfig.inverted(inverted);
-        motorConfig.idleMode(SparkMaxConfig.IdleMode.kBrake);
-        motorConfig.smartCurrentLimit(40);
+    motorConfig.inverted(inverted);
+    motorConfig.idleMode(SparkMaxConfig.IdleMode.kBrake);
+    motorConfig.smartCurrentLimit(40);
 
-        FeedbackSensor feedBackSensor = FeedbackSensor.kPrimaryEncoder;
-        if (useThroughBoreEncoder == true) {
-            feedBackSensor = FeedbackSensor.kAbsoluteEncoder;
-        }
-        motorConfig.closedLoop
-                .feedbackSensor(feedBackSensor)
-                .p(kP)
-                .i(kI)
-                .d(kD)
-                .outputRange(kMinOutput, kMaxOutput)
-                .iZone(kIz);
-        motorConfig.closedLoop.feedForward
-                .kV(12.0 * kF);
-        if (useThroughBoreEncoder == true) {
-            absoluteEncoder = motor.getAbsoluteEncoder();
-        } else {
-            encoder = motor.getEncoder();
-            encoder.setPosition(0);
-        }
-
-        if (useSoftLimits == true) {
-
-            SoftLimitConfig softLimitConfig = new SoftLimitConfig();
-            softLimitConfig.forwardSoftLimitEnabled(true);
-            softLimitConfig.forwardSoftLimit(kUpperSoftLimit);
-            softLimitConfig.reverseSoftLimitEnabled(true);
-            softLimitConfig.reverseSoftLimit(kLowerSoftLimit);
-
-            motorConfig.apply(softLimitConfig);
-        }
-        motor.configure(motorConfig, ResetMode.kResetSafeParameters, PersistMode.kPersistParameters);
-        this.useThroughBoreEncoder = useThroughBoreEncoder;
-
+    FeedbackSensor feedBackSensor = FeedbackSensor.kPrimaryEncoder;
+    if (useThroughBoreEncoder == true) {
+      feedBackSensor = FeedbackSensor.kAbsoluteEncoder;
+    }
+    motorConfig
+        .closedLoop
+        .feedbackSensor(feedBackSensor)
+        .p(kP)
+        .i(kI)
+        .d(kD)
+        .outputRange(kMinOutput, kMaxOutput)
+        .iZone(kIz);
+    motorConfig.closedLoop.feedForward.kV(12.0 * kF);
+    if (useThroughBoreEncoder == true) {
+      absoluteEncoder = motor.getAbsoluteEncoder();
+    } else {
+      encoder = motor.getEncoder();
+      encoder.setPosition(0);
     }
 
-    public double getPosition() {
-        if (useThroughBoreEncoder == true) {
-            if (absoluteEncoder == null) {
-                return 0;
-            }
-            return absoluteEncoder.getPosition();
-        } else {
-            if (encoder == null) {
-                return 0;
-            }
-            return encoder.getPosition();
-        }
+    if (useSoftLimits == true) {
 
-    }
+      SoftLimitConfig softLimitConfig = new SoftLimitConfig();
+      softLimitConfig.forwardSoftLimitEnabled(true);
+      softLimitConfig.forwardSoftLimit(kUpperSoftLimit);
+      softLimitConfig.reverseSoftLimitEnabled(true);
+      softLimitConfig.reverseSoftLimit(kLowerSoftLimit);
 
-    /* -1 <= position <= 1 */
-    public void moveToPositionWithPID(double position) {
-        motor.getClosedLoopController().setSetpoint(position, SparkMax.ControlType.kPosition);
+      motorConfig.apply(softLimitConfig);
     }
+    motor.configure(motorConfig, ResetMode.kResetSafeParameters, PersistMode.kPersistParameters);
+    this.useThroughBoreEncoder = useThroughBoreEncoder;
+  }
 
-    public void moveToVelocityWithPID(double rpm) {
-        motor.getClosedLoopController().setSetpoint(rpm, SparkMax.ControlType.kVelocity);
+  public double getPosition() {
+    if (useThroughBoreEncoder == true) {
+      if (absoluteEncoder == null) {
+        return 0;
+      }
+      return absoluteEncoder.getPosition();
+    } else {
+      if (encoder == null) {
+        return 0;
+      }
+      return encoder.getPosition();
     }
+  }
 
-    /* -1.0 <= speed <= 1.0 */
-    public void move(double speed) {
-        motor.set(speed);
-    }
+  /* -1 <= position <= 1 */
+  public void moveToPositionWithPID(double position) {
+    motor.getClosedLoopController().setSetpoint(position, SparkMax.ControlType.kPosition);
+  }
 
-    public SparkMax getMotor() {
-        return motor;
-    }
+  public void moveToVelocityWithPID(double rpm) {
+    motor.getClosedLoopController().setSetpoint(rpm, SparkMax.ControlType.kVelocity);
+  }
+
+  /* -1.0 <= speed <= 1.0 */
+  public void move(double speed) {
+    motor.set(speed);
+  }
+
+  public SparkMax getMotor() {
+    return motor;
+  }
 }

--- a/src/main/java/frc/robot/subsystems/Hanger.java
+++ b/src/main/java/frc/robot/subsystems/Hanger.java
@@ -6,7 +6,20 @@ public class Hanger extends Actuator {
   private static Hanger instance;
 
   private Hanger() {
-    super(Constants.CANDeviceIDs.kHangerID, Constants.HangerConstants.P, Constants.HangerConstants.I, Constants.HangerConstants.D, Constants.HangerConstants.MinOutput, Constants.HangerConstants.MaxOutput, Constants.HangerConstants.FF, Constants.HangerConstants.Iz, 0, 0, false, false, false);
+    super(
+        Constants.CANDeviceIDs.kHangerID,
+        Constants.HangerConstants.P,
+        Constants.HangerConstants.I,
+        Constants.HangerConstants.D,
+        Constants.HangerConstants.MinOutput,
+        Constants.HangerConstants.MaxOutput,
+        Constants.HangerConstants.FF,
+        Constants.HangerConstants.Iz,
+        0,
+        0,
+        false,
+        false,
+        false);
   }
 
   public static Hanger getInstance() {

--- a/src/main/java/frc/robot/subsystems/Indexer.java
+++ b/src/main/java/frc/robot/subsystems/Indexer.java
@@ -1,10 +1,8 @@
 package frc.robot.subsystems;
 
-import edu.wpi.first.wpilibj2.command.SubsystemBase;
-import com.revrobotics.spark.SparkLowLevel;
-import com.revrobotics.spark.SparkMax;
 import com.revrobotics.PersistMode;
 import com.revrobotics.ResetMode;
+import com.revrobotics.spark.SparkMax;
 import com.revrobotics.spark.config.SparkMaxConfig;
 import frc.robot.Constants;
 
@@ -14,15 +12,29 @@ public class Indexer extends Actuator {
   private static Indexer instance;
 
   private Indexer() {
-    super(Constants.CANDeviceIDs.kIndexerID, Constants.IndexerConstants.P, Constants.IndexerConstants.I, Constants.IndexerConstants.D, Constants.IndexerConstants.MinOutput, Constants.IndexerConstants.MaxOutput, Constants.IndexerConstants.FF, Constants.IndexerConstants.Iz, 0, 0, true, false, false);
-    motor = /*new SparkMax(Constants.CANDeviceIDs.kIndexerID, SparkLowLevel.MotorType.kBrushless);*/getMotor();
+    super(
+        Constants.CANDeviceIDs.kIndexerID,
+        Constants.IndexerConstants.P,
+        Constants.IndexerConstants.I,
+        Constants.IndexerConstants.D,
+        Constants.IndexerConstants.MinOutput,
+        Constants.IndexerConstants.MaxOutput,
+        Constants.IndexerConstants.FF,
+        Constants.IndexerConstants.Iz,
+        0,
+        0,
+        true,
+        false,
+        false);
+    motor = /*new SparkMax(Constants.CANDeviceIDs.kIndexerID, SparkLowLevel.MotorType.kBrushless);*/
+        getMotor();
     motorConfig = new SparkMaxConfig();
 
     motorConfig
-      /*.inverted(true)*/
-      .idleMode(SparkMaxConfig.IdleMode.kCoast)
-      .smartCurrentLimit(20);
-    
+        /*.inverted(true)*/
+        .idleMode(SparkMaxConfig.IdleMode.kCoast)
+        .smartCurrentLimit(20);
+
     motor.configure(motorConfig, ResetMode.kNoResetSafeParameters, PersistMode.kPersistParameters);
   }
 

--- a/src/main/java/frc/robot/subsystems/Intake.java
+++ b/src/main/java/frc/robot/subsystems/Intake.java
@@ -1,11 +1,11 @@
 package frc.robot.subsystems;
 
-import edu.wpi.first.wpilibj2.command.SubsystemBase;
-import com.revrobotics.spark.SparkLowLevel;
-import com.revrobotics.spark.SparkMax;
 import com.revrobotics.PersistMode;
 import com.revrobotics.ResetMode;
+import com.revrobotics.spark.SparkLowLevel;
+import com.revrobotics.spark.SparkMax;
 import com.revrobotics.spark.config.SparkMaxConfig;
+import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import frc.robot.Constants;
 
 public class Intake extends SubsystemBase {
@@ -18,9 +18,9 @@ public class Intake extends SubsystemBase {
     motorConfig = new SparkMaxConfig();
 
     motorConfig
-      //.inverted(true)
-      .idleMode(SparkMaxConfig.IdleMode.kCoast)
-      .smartCurrentLimit(40);
+        // .inverted(true)
+        .idleMode(SparkMaxConfig.IdleMode.kCoast)
+        .smartCurrentLimit(40);
 
     motor.configure(motorConfig, ResetMode.kResetSafeParameters, PersistMode.kPersistParameters);
   }
@@ -35,5 +35,4 @@ public class Intake extends SubsystemBase {
     }
     return instance;
   }
-
 }

--- a/src/main/java/frc/robot/subsystems/IntakeActuator.java
+++ b/src/main/java/frc/robot/subsystems/IntakeActuator.java
@@ -6,7 +6,20 @@ public class IntakeActuator extends Actuator {
   private static IntakeActuator instance;
 
   private IntakeActuator() {
-    super(Constants.CANDeviceIDs.kIntakeActuatorID, Constants.IntakeConstants.P, Constants.IntakeConstants.I, Constants.IntakeConstants.D, Constants.IntakeConstants.MinOutput, Constants.IntakeConstants.MaxOutput, Constants.IntakeConstants.FF, Constants.IntakeConstants.Iz, 0, 0, false, false, false);
+    super(
+        Constants.CANDeviceIDs.kIntakeActuatorID,
+        Constants.IntakeConstants.P,
+        Constants.IntakeConstants.I,
+        Constants.IntakeConstants.D,
+        Constants.IntakeConstants.MinOutput,
+        Constants.IntakeConstants.MaxOutput,
+        Constants.IntakeConstants.FF,
+        Constants.IntakeConstants.Iz,
+        0,
+        0,
+        false,
+        false,
+        false);
   }
 
   public static IntakeActuator getInstance() {

--- a/src/main/java/frc/robot/subsystems/Shooter.java
+++ b/src/main/java/frc/robot/subsystems/Shooter.java
@@ -1,18 +1,11 @@
 package frc.robot.subsystems;
 
-import com.revrobotics.spark.SparkMax;
-import com.revrobotics.spark.config.LimitSwitchConfig;
-import com.revrobotics.spark.config.SparkBaseConfig;
-import com.revrobotics.spark.config.SparkBaseConfig.IdleMode;
-import com.revrobotics.spark.config.SparkMaxConfig;
-
 import com.revrobotics.PersistMode;
-import com.revrobotics.ResetMode;
-import com.revrobotics.spark.SparkLowLevel;
 import com.revrobotics.RelativeEncoder;
-import com.revrobotics.sim.SparkMaxAlternateEncoderSim;
-
-import edu.wpi.first.wpilibj2.command.SubsystemBase;
+import com.revrobotics.ResetMode;
+import com.revrobotics.spark.SparkMax;
+import com.revrobotics.spark.config.SparkBaseConfig;
+import com.revrobotics.spark.config.SparkMaxConfig;
 import frc.robot.Constants;
 
 public class Shooter extends Actuator {
@@ -23,15 +16,28 @@ public class Shooter extends Actuator {
   private SparkMaxConfig motorConfig;
 
   private Shooter() {
-    super(Constants.CANDeviceIDs.kShooterID, Constants.ShooterConstants.P, Constants.ShooterConstants.I, Constants.ShooterConstants.D, Constants.ShooterConstants.MinOutput, Constants.ShooterConstants.MaxOutput, Constants.ShooterConstants.FF, Constants.ShooterConstants.Iz, 0, 0, false, false, false);
+    super(
+        Constants.CANDeviceIDs.kShooterID,
+        Constants.ShooterConstants.P,
+        Constants.ShooterConstants.I,
+        Constants.ShooterConstants.D,
+        Constants.ShooterConstants.MinOutput,
+        Constants.ShooterConstants.MaxOutput,
+        Constants.ShooterConstants.FF,
+        Constants.ShooterConstants.Iz,
+        0,
+        0,
+        false,
+        false,
+        false);
     motor = getMotor();
-    
+
     motorConfig = new SparkMaxConfig();
     motorConfig.idleMode(SparkBaseConfig.IdleMode.kCoast);
     motorConfig.smartCurrentLimit(40);
     motorEncoder = motor.getEncoder();
-    
-    motor.configure(motorConfig,ResetMode.kNoResetSafeParameters, PersistMode.kPersistParameters);
+
+    motor.configure(motorConfig, ResetMode.kNoResetSafeParameters, PersistMode.kPersistParameters);
   }
 
   public double getMotorVelocity() {

--- a/src/main/java/frc/robot/subsystems/swervedrive/SwerveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/swervedrive/SwerveSubsystem.java
@@ -33,22 +33,17 @@ import edu.wpi.first.wpilibj2.command.Commands;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import edu.wpi.first.wpilibj2.command.button.RobotModeTriggers;
 import edu.wpi.first.wpilibj2.command.sysid.SysIdRoutine.Config;
-import frc.robot.Constants;
 import frc.robot.Cameras;
+import frc.robot.Constants;
 import java.io.File;
 import java.io.IOException;
-import java.lang.annotation.Target;
 import java.util.Arrays;
-import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.DoubleSupplier;
 import java.util.function.Supplier;
 import org.json.simple.parser.ParseException;
-import org.photonvision.PhotonCamera;
 import org.photonvision.targeting.PhotonPipelineResult;
-import org.photonvision.targeting.PhotonTrackedTarget;
-
 import swervelib.SwerveController;
 import swervelib.SwerveDrive;
 import swervelib.SwerveDriveTest;
@@ -58,24 +53,20 @@ import swervelib.parser.SwerveDriveConfiguration;
 import swervelib.parser.SwerveParser;
 import swervelib.telemetry.SwerveDriveTelemetry;
 import swervelib.telemetry.SwerveDriveTelemetry.TelemetryVerbosity;
-import swervelib.SwerveInputStream;
 
 public class SwerveSubsystem extends SubsystemBase {
 
-  /**
-   * Swerve drive object.
-   */
+  /** Swerve drive object. */
   private final SwerveDrive swerveDrive;
-  /**
-   * Enable vision odometry updates while driving.
-   */
+
+  /** Enable vision odometry updates while driving. */
   private final boolean visionDriveTest = true;
-  /**
-   * PhotonVision class to keep an accurate odometry.
-   */
+
+  /** PhotonVision class to keep an accurate odometry. */
   private Vision vision;
 
   private SwerveSubsystem instance;
+
   /**
    * Initialize {@link SwerveDrive} with the directory provided.
    *
@@ -83,17 +74,16 @@ public class SwerveSubsystem extends SubsystemBase {
    */
   public SwerveSubsystem(File directory) {
     boolean blueAlliance = false;
-    Pose2d startingPose = blueAlliance ? new Pose2d(new Translation2d(Meter.of(1),
-        Meter.of(4)),
-        Rotation2d.fromDegrees(0))
-        : new Pose2d(new Translation2d(Meter.of(16),
-            Meter.of(4)),
-            Rotation2d.fromDegrees(180));
+    Pose2d startingPose =
+        blueAlliance
+            ? new Pose2d(new Translation2d(Meter.of(1), Meter.of(4)), Rotation2d.fromDegrees(0))
+            : new Pose2d(new Translation2d(Meter.of(16), Meter.of(4)), Rotation2d.fromDegrees(180));
     // Configure the Telemetry before creating the SwerveDrive to avoid unnecessary
     // objects being created.
     SwerveDriveTelemetry.verbosity = TelemetryVerbosity.HIGH;
     try {
-      swerveDrive = new SwerveParser(directory).createSwerveDrive(Constants.MAX_SPEED, startingPose);
+      swerveDrive =
+          new SwerveParser(directory).createSwerveDrive(Constants.MAX_SPEED, startingPose);
       // Alternative method if you don't want to supply the conversion factor via JSON
       // files.
       // swerveDrive = new SwerveParser(directory).createSwerveDrive(maximumSpeed,
@@ -101,17 +91,19 @@ public class SwerveSubsystem extends SubsystemBase {
     } catch (Exception e) {
       throw new RuntimeException(e);
     }
-    swerveDrive.setHeadingCorrection(false); // Heading correction should only be used while controlling the robot via
-                                             // angle.
-    swerveDrive.setCosineCompensator(false);// !SwerveDriveTelemetry.isSimulation); // Disables cosine compensation for
-                                            // simulations since it causes discrepancies not seen in real life.
-    swerveDrive.setAngularVelocityCompensation(true,
-        true,
+    swerveDrive.setHeadingCorrection(
+        false); // Heading correction should only be used while controlling the robot via
+    // angle.
+    swerveDrive.setCosineCompensator(
+        false); // !SwerveDriveTelemetry.isSimulation); // Disables cosine compensation for
+    // simulations since it causes discrepancies not seen in real life.
+    swerveDrive.setAngularVelocityCompensation(
+        true, true,
         0.1); // Correct for skew that gets worse as angular velocity increases. Start with a
-              // coefficient of 0.1.
-    swerveDrive.setModuleEncoderAutoSynchronize(false,
-        1); // Enable if you want to resynchronize your absolute encoders and motor encoders
-            // periodically when they are not moving.
+    // coefficient of 0.1.
+    swerveDrive.setModuleEncoderAutoSynchronize(
+        false, 1); // Enable if you want to resynchronize your absolute encoders and motor encoders
+    // periodically when they are not moving.
     // swerveDrive.pushOffsetsToEncoders(); // Set the absolute encoder to be used
     // over the internal encoder and push the offsets onto it. Throws warning if not
     // possible
@@ -128,23 +120,22 @@ public class SwerveSubsystem extends SubsystemBase {
   /**
    * Construct the swerve drive.
    *
-   * @param driveCfg      SwerveDriveConfiguration for the swerve.
+   * @param driveCfg SwerveDriveConfiguration for the swerve.
    * @param controllerCfg Swerve Controller.
    */
-  public SwerveSubsystem(SwerveDriveConfiguration driveCfg, SwerveControllerConfiguration controllerCfg) {
-    swerveDrive = new SwerveDrive(driveCfg,
-        controllerCfg,
-        Constants.MAX_SPEED,
-        new Pose2d(new Translation2d(Meter.of(2), Meter.of(0)),
-            Rotation2d.fromDegrees(0)));
+  public SwerveSubsystem(
+      SwerveDriveConfiguration driveCfg, SwerveControllerConfiguration controllerCfg) {
+    swerveDrive =
+        new SwerveDrive(
+            driveCfg,
+            controllerCfg,
+            Constants.MAX_SPEED,
+            new Pose2d(new Translation2d(Meter.of(2), Meter.of(0)), Rotation2d.fromDegrees(0)));
   }
 
-  /**
-   * Setup the photon vision class.
-   */
+  /** Setup the photon vision class. */
   public void setupPhotonVision() {
     vision = new Vision(swerveDrive::getPose, swerveDrive.field);
-    
   }
 
   @Override
@@ -154,18 +145,13 @@ public class SwerveSubsystem extends SubsystemBase {
       swerveDrive.updateOdometry();
       vision.updatePoseEstimation(swerveDrive);
       vision.updateVisionField();
-
     }
-  
   }
 
   @Override
-  public void simulationPeriodic() {
-  }
+  public void simulationPeriodic() {}
 
-  /**
-   * Setup AutoBuilder for PathPlanner.
-   */
+  /** Setup AutoBuilder for PathPlanner. */
   public void setupPathPlanner() {
     // Load the RobotConfig from the GUI settings. You should probably
     // store this in your Constants file
@@ -200,8 +186,8 @@ public class SwerveSubsystem extends SubsystemBase {
               new PIDConstants(5.0, 0.0, 0.0),
               // Translation PID constants
               new PIDConstants(5.0, 0.0, 0.0)
-          // Rotation PID constants
-          ),
+              // Rotation PID constants
+              ),
           config,
           // The robot configuration
           () -> {
@@ -217,8 +203,8 @@ public class SwerveSubsystem extends SubsystemBase {
             return false;
           },
           this
-      // Reference to this subsystem to set requirements
-      );
+          // Reference to this subsystem to set requirements
+          );
 
     } catch (Exception e) {
       // Handle exception as needed
@@ -237,20 +223,25 @@ public class SwerveSubsystem extends SubsystemBase {
    */
   public Command aimAtTarget(Cameras camera) {
 
-    return run(() -> {
-      Optional<PhotonPipelineResult> resultO = camera.getBestResult();
-      if (resultO.isPresent()) {
-        var result = resultO.get();
-        if (result.hasTargets()) {
-          drive(getTargetSpeeds(0,
-              0,
-              Rotation2d.fromDegrees(result.getBestTarget()
-                  .getYaw()))); // Not sure if this will work, more math may be required.
-        }
-      }
-    });
+    return run(
+        () -> {
+          Optional<PhotonPipelineResult> resultO = camera.getBestResult();
+          if (resultO.isPresent()) {
+            var result = resultO.get();
+            if (result.hasTargets()) {
+              drive(
+                  getTargetSpeeds(
+                      0,
+                      0,
+                      Rotation2d.fromDegrees(
+                          result
+                              .getBestTarget()
+                              .getYaw()))); // Not sure if this will work, more math may be
+              // required.
+            }
+          }
+        });
   }
-  
 
   /**
    * Get the path follower with events.
@@ -272,50 +263,57 @@ public class SwerveSubsystem extends SubsystemBase {
    */
   public Command driveToPose(Pose2d pose) {
     // Create the constraints to use while pathfinding
-    PathConstraints constraints = new PathConstraints(
-        swerveDrive.getMaximumChassisVelocity(), 4.0,
-        swerveDrive.getMaximumChassisAngularVelocity(), Units.degreesToRadians(720));
+    PathConstraints constraints =
+        new PathConstraints(
+            swerveDrive.getMaximumChassisVelocity(),
+            4.0,
+            swerveDrive.getMaximumChassisAngularVelocity(),
+            Units.degreesToRadians(720));
 
     // Since AutoBuilder is configured, we can use it to build pathfinding commands
     return AutoBuilder.pathfindToPose(
         pose,
         constraints,
         edu.wpi.first.units.Units.MetersPerSecond.of(0) // Goal end velocity in meters/sec
-    );
+        );
   }
 
   /**
-   * Drive with {@link SwerveSetpointGenerator} from 254, implemented by
-   * PathPlanner.
+   * Drive with {@link SwerveSetpointGenerator} from 254, implemented by PathPlanner.
    *
-   * @param robotRelativeChassisSpeed Robot relative {@link ChassisSpeeds} to
-   *                                  achieve.
+   * @param robotRelativeChassisSpeed Robot relative {@link ChassisSpeeds} to achieve.
    * @return {@link Command} to run.
-   * @throws IOException    If the PathPlanner GUI settings is invalid
+   * @throws IOException If the PathPlanner GUI settings is invalid
    * @throws ParseException If PathPlanner GUI settings is nonexistent.
    */
   private Command driveWithSetpointGenerator(Supplier<ChassisSpeeds> robotRelativeChassisSpeed)
       throws IOException, ParseException {
-    SwerveSetpointGenerator setpointGenerator = new SwerveSetpointGenerator(RobotConfig.fromGUISettings(),
-        swerveDrive.getMaximumChassisAngularVelocity());
-    AtomicReference<SwerveSetpoint> prevSetpoint = new AtomicReference<>(
-        new SwerveSetpoint(swerveDrive.getRobotVelocity(),
-            swerveDrive.getStates(),
-            DriveFeedforwards.zeros(swerveDrive.getModules().length)));
+    SwerveSetpointGenerator setpointGenerator =
+        new SwerveSetpointGenerator(
+            RobotConfig.fromGUISettings(), swerveDrive.getMaximumChassisAngularVelocity());
+    AtomicReference<SwerveSetpoint> prevSetpoint =
+        new AtomicReference<>(
+            new SwerveSetpoint(
+                swerveDrive.getRobotVelocity(),
+                swerveDrive.getStates(),
+                DriveFeedforwards.zeros(swerveDrive.getModules().length)));
     AtomicReference<Double> previousTime = new AtomicReference<>();
 
-    return startRun(() -> previousTime.set(Timer.getFPGATimestamp()),
+    return startRun(
+        () -> previousTime.set(Timer.getFPGATimestamp()),
         () -> {
           double newTime = Timer.getFPGATimestamp();
-          SwerveSetpoint newSetpoint = setpointGenerator.generateSetpoint(prevSetpoint.get(),
-              robotRelativeChassisSpeed.get(),
-              newTime - previousTime.get());
-          swerveDrive.drive(newSetpoint.robotRelativeSpeeds(),
+          SwerveSetpoint newSetpoint =
+              setpointGenerator.generateSetpoint(
+                  prevSetpoint.get(),
+                  robotRelativeChassisSpeed.get(),
+                  newTime - previousTime.get());
+          swerveDrive.drive(
+              newSetpoint.robotRelativeSpeeds(),
               newSetpoint.moduleStates(),
               newSetpoint.feedforwards().linearForces());
           prevSetpoint.set(newSetpoint);
           previousTime.set(newTime);
-
         });
   }
 
@@ -325,17 +323,17 @@ public class SwerveSubsystem extends SubsystemBase {
    * @param fieldRelativeSpeeds Field-Relative {@link ChassisSpeeds}
    * @return Command to drive the robot using the setpoint generator.
    */
-  public Command driveWithSetpointGeneratorFieldRelative(Supplier<ChassisSpeeds> fieldRelativeSpeeds) {
+  public Command driveWithSetpointGeneratorFieldRelative(
+      Supplier<ChassisSpeeds> fieldRelativeSpeeds) {
     try {
-      return driveWithSetpointGenerator(() -> {
-        return ChassisSpeeds.fromFieldRelativeSpeeds(fieldRelativeSpeeds.get(), getHeading());
-
-      });
+      return driveWithSetpointGenerator(
+          () -> {
+            return ChassisSpeeds.fromFieldRelativeSpeeds(fieldRelativeSpeeds.get(), getHeading());
+          });
     } catch (Exception e) {
       DriverStation.reportError(e.toString(), true);
     }
     return Commands.none();
-
   }
 
   /**
@@ -345,10 +343,10 @@ public class SwerveSubsystem extends SubsystemBase {
    */
   public Command sysIdDriveMotorCommand() {
     return SwerveDriveTest.generateSysIdCommand(
-        SwerveDriveTest.setDriveSysIdRoutine(
-            new Config(),
-            this, swerveDrive, 12, true),
-        3.0, 5.0, 3.0);
+        SwerveDriveTest.setDriveSysIdRoutine(new Config(), this, swerveDrive, 12, true),
+        3.0,
+        5.0,
+        3.0);
   }
 
   /**
@@ -358,10 +356,7 @@ public class SwerveSubsystem extends SubsystemBase {
    */
   public Command sysIdAngleMotorCommand() {
     return SwerveDriveTest.generateSysIdCommand(
-        SwerveDriveTest.setAngleSysIdRoutine(
-            new Config(),
-            this, swerveDrive),
-        3.0, 5.0, 3.0);
+        SwerveDriveTest.setAngleSysIdRoutine(new Config(), this, swerveDrive), 3.0, 5.0, 3.0);
   }
 
   /**
@@ -370,28 +365,26 @@ public class SwerveSubsystem extends SubsystemBase {
    * @return a Command that centers the modules of the SwerveDrive subsystem
    */
   public Command centerModulesCommand() {
-    return run(() -> Arrays.asList(swerveDrive.getModules())
-        .forEach(it -> it.setAngle(0.0)));
+    return run(() -> Arrays.asList(swerveDrive.getModules()).forEach(it -> it.setAngle(0.0)));
   }
 
   /**
-   * Returns a Command that drives the swerve drive to a specific distance at a
-   * given speed.
+   * Returns a Command that drives the swerve drive to a specific distance at a given speed.
    *
-   * @param distanceInMeters       the distance to drive in meters
-   * @param speedInMetersPerSecond the speed at which to drive in meters per
-   *                               second
-   * @return a Command that drives the swerve drive to a specific distance at a
-   *         given speed
+   * @param distanceInMeters the distance to drive in meters
+   * @param speedInMetersPerSecond the speed at which to drive in meters per second
+   * @return a Command that drives the swerve drive to a specific distance at a given speed
    */
   public Command driveToDistanceCommand(double distanceInMeters, double speedInMetersPerSecond) {
     return run(() -> drive(new ChassisSpeeds(speedInMetersPerSecond, 0, 0)))
-        .until(() -> swerveDrive.getPose().getTranslation().getDistance(new Translation2d(0, 0)) > distanceInMeters);
+        .until(
+            () ->
+                swerveDrive.getPose().getTranslation().getDistance(new Translation2d(0, 0))
+                    > distanceInMeters);
   }
 
   /**
-   * Replaces the swerve module feedforward with a new SimpleMotorFeedforward
-   * object.
+   * Replaces the swerve module feedforward with a new SimpleMotorFeedforward object.
    *
    * @param kS the static gain of the feedforward
    * @param kV the velocity gain of the feedforward
@@ -402,85 +395,83 @@ public class SwerveSubsystem extends SubsystemBase {
   }
 
   /**
-   * Command to drive the robot using translative values and heading as angular
-   * velocity.
+   * Command to drive the robot using translative values and heading as angular velocity.
    *
-   * @param translationX     Translation in the X direction. Cubed for smoother
-   *                         controls.
-   * @param translationY     Translation in the Y direction. Cubed for smoother
-   *                         controls.
-   * @param angularRotationX Angular velocity of the robot to set. Cubed for
-   *                         smoother controls.
+   * @param translationX Translation in the X direction. Cubed for smoother controls.
+   * @param translationY Translation in the Y direction. Cubed for smoother controls.
+   * @param angularRotationX Angular velocity of the robot to set. Cubed for smoother controls.
    * @return Drive command.
    */
-  public Command driveCommand(DoubleSupplier translationX, DoubleSupplier translationY,
-      DoubleSupplier angularRotationX) {
-    return run(() -> {
-      // Make the robot move
-      swerveDrive.drive(SwerveMath.scaleTranslation(new Translation2d(
-          translationX.getAsDouble() * swerveDrive.getMaximumChassisVelocity(),
-          translationY.getAsDouble() * swerveDrive.getMaximumChassisVelocity()), 0.8),
-          Math.pow(angularRotationX.getAsDouble(), 3) * swerveDrive.getMaximumChassisAngularVelocity(),
-          true,
-          false);
-    });
+  public Command driveCommand(
+      DoubleSupplier translationX, DoubleSupplier translationY, DoubleSupplier angularRotationX) {
+    return run(
+        () -> {
+          // Make the robot move
+          swerveDrive.drive(
+              SwerveMath.scaleTranslation(
+                  new Translation2d(
+                      translationX.getAsDouble() * swerveDrive.getMaximumChassisVelocity(),
+                      translationY.getAsDouble() * swerveDrive.getMaximumChassisVelocity()),
+                  0.8),
+              Math.pow(angularRotationX.getAsDouble(), 3)
+                  * swerveDrive.getMaximumChassisAngularVelocity(),
+              true,
+              false);
+        });
   }
 
   /**
-   * Command to drive the robot using translative values and heading as a
-   * setpoint.
+   * Command to drive the robot using translative values and heading as a setpoint.
    *
-   * @param translationX Translation in the X direction. Cubed for smoother
-   *                     controls.
-   * @param translationY Translation in the Y direction. Cubed for smoother
-   *                     controls.
-   * @param headingX     Heading X to calculate angle of the joystick.
-   * @param headingY     Heading Y to calculate angle of the joystick.
+   * @param translationX Translation in the X direction. Cubed for smoother controls.
+   * @param translationY Translation in the Y direction. Cubed for smoother controls.
+   * @param headingX Heading X to calculate angle of the joystick.
+   * @param headingY Heading Y to calculate angle of the joystick.
    * @return Drive command.
    */
-  public Command driveCommand(DoubleSupplier translationX, DoubleSupplier translationY, DoubleSupplier headingX,
+  public Command driveCommand(
+      DoubleSupplier translationX,
+      DoubleSupplier translationY,
+      DoubleSupplier headingX,
       DoubleSupplier headingY) {
     // swerveDrive.setHeadingCorrection(true); // Normally you would want heading
     // correction for this kind of control.
-    return run(() -> {
+    return run(
+        () -> {
+          Translation2d scaledInputs =
+              SwerveMath.scaleTranslation(
+                  new Translation2d(translationX.getAsDouble(), translationY.getAsDouble()), 0.8);
 
-      Translation2d scaledInputs = SwerveMath.scaleTranslation(new Translation2d(translationX.getAsDouble(),
-          translationY.getAsDouble()), 0.8);
-
-      // Make the robot move
-      driveFieldOriented(swerveDrive.swerveController.getTargetSpeeds(scaledInputs.getX(), scaledInputs.getY(),
-          headingX.getAsDouble(),
-          headingY.getAsDouble(),
-          swerveDrive.getOdometryHeading().getRadians(),
-          swerveDrive.getMaximumChassisVelocity()));
-    });
+          // Make the robot move
+          driveFieldOriented(
+              swerveDrive.swerveController.getTargetSpeeds(
+                  scaledInputs.getX(),
+                  scaledInputs.getY(),
+                  headingX.getAsDouble(),
+                  headingY.getAsDouble(),
+                  swerveDrive.getOdometryHeading().getRadians(),
+                  swerveDrive.getMaximumChassisVelocity()));
+        });
   }
 
   /**
-   * The primary method for controlling the drivebase. Takes a
-   * {@link Translation2d} and a rotation rate, and
-   * calculates and commands module states accordingly. Can use either open-loop
-   * or closed-loop velocity control for
-   * the wheel velocities. Also has field- and robot-relative modes, which affect
-   * how the translation vector is used.
+   * The primary method for controlling the drivebase. Takes a {@link Translation2d} and a rotation
+   * rate, and calculates and commands module states accordingly. Can use either open-loop or
+   * closed-loop velocity control for the wheel velocities. Also has field- and robot-relative
+   * modes, which affect how the translation vector is used.
    *
-   * @param translation   {@link Translation2d} that is the commanded linear
-   *                      velocity of the robot, in meters per
-   *                      second. In robot-relative mode, positive x is torwards
-   *                      the bow (front) and positive y is
-   *                      torwards port (left). In field-relative mode, positive x
-   *                      is away from the alliance wall
-   *                      (field North) and positive y is torwards the left wall
-   *                      when looking through the driver station
-   *                      glass (field West).
-   * @param rotation      Robot angular rate, in radians per second. CCW positive.
-   *                      Unaffected by field/robot
-   *                      relativity.
-   * @param fieldRelative Drive mode. True for field-relative, false for
-   *                      robot-relative.
+   * @param translation {@link Translation2d} that is the commanded linear velocity of the robot, in
+   *     meters per second. In robot-relative mode, positive x is torwards the bow (front) and
+   *     positive y is torwards port (left). In field-relative mode, positive x is away from the
+   *     alliance wall (field North) and positive y is torwards the left wall when looking through
+   *     the driver station glass (field West).
+   * @param rotation Robot angular rate, in radians per second. CCW positive. Unaffected by
+   *     field/robot relativity.
+   * @param fieldRelative Drive mode. True for field-relative, false for robot-relative.
    */
   public void drive(Translation2d translation, double rotation, boolean fieldRelative) {
-    swerveDrive.drive(translation,
+    swerveDrive.drive(
+        translation,
         rotation,
         fieldRelative,
         false); // Open loop is disabled since it shouldn't be used most of the time.
@@ -501,9 +492,10 @@ public class SwerveSubsystem extends SubsystemBase {
    * @param velocity Velocity according to the field.
    */
   public Command driveFieldOriented(Supplier<ChassisSpeeds> velocity) {
-    return run(() -> {
-      swerveDrive.driveFieldOriented(velocity.get());
-    });
+    return run(
+        () -> {
+          swerveDrive.driveFieldOriented(velocity.get());
+        });
   }
 
   /**
@@ -525,11 +517,9 @@ public class SwerveSubsystem extends SubsystemBase {
   }
 
   /**
-   * Resets odometry to the given pose. Gyro angle and module positions do not
-   * need to be reset when calling this
-   * method. However, if either gyro angle or module position is reset, this must
-   * be called in order for odometry to
-   * keep working.
+   * Resets odometry to the given pose. Gyro angle and module positions do not need to be reset when
+   * calling this method. However, if either gyro angle or module position is reset, this must be
+   * called in order for odometry to keep working.
    *
    * @param initialHolonomicPose The pose to set the odometry to
    */
@@ -538,8 +528,7 @@ public class SwerveSubsystem extends SubsystemBase {
   }
 
   /**
-   * Gets the current pose (position and rotation) of the robot, as reported by
-   * odometry.
+   * Gets the current pose (position and rotation) of the robot, as reported by odometry.
    *
    * @return The robot's pose
    */
@@ -566,8 +555,7 @@ public class SwerveSubsystem extends SubsystemBase {
   }
 
   /**
-   * Resets the gyro angle to zero and resets odometry to the same position, but
-   * facing toward 0.
+   * Resets the gyro angle to zero and resets odometry to the same position, but facing toward 0.
    */
   public void zeroGyro() {
     swerveDrive.zeroGyro();
@@ -576,8 +564,7 @@ public class SwerveSubsystem extends SubsystemBase {
   /**
    * Checks if the alliance is red, defaults to false if alliance isn't available.
    *
-   * @return true if the red alliance, false if blue. Defaults to false if none is
-   *         available.
+   * @return true if the red alliance, false if blue. Defaults to false if none is available.
    */
   private boolean isRedAlliance() {
     var alliance = DriverStation.getAlliance();
@@ -585,10 +572,9 @@ public class SwerveSubsystem extends SubsystemBase {
   }
 
   /**
-   * This will zero (calibrate) the robot to assume the current position is facing
-   * forward
-   * <p>
-   * If red alliance rotate the robot 180 after the drviebase zero command
+   * This will zero (calibrate) the robot to assume the current position is facing forward
+   *
+   * <p>If red alliance rotate the robot 180 after the drviebase zero command
    */
   public void zeroGyroWithAlliance() {
     if (isRedAlliance()) {
@@ -610,10 +596,9 @@ public class SwerveSubsystem extends SubsystemBase {
   }
 
   /**
-   * Gets the current yaw angle of the robot, as reported by the swerve pose
-   * estimator in the underlying drivebase.
-   * Note, this is not the raw gyro reading, this may be corrected from calls to
-   * resetOdometry().
+   * Gets the current yaw angle of the robot, as reported by the swerve pose estimator in the
+   * underlying drivebase. Note, this is not the raw gyro reading, this may be corrected from calls
+   * to resetOdometry().
    *
    * @return The yaw angle
    */
@@ -622,19 +607,20 @@ public class SwerveSubsystem extends SubsystemBase {
   }
 
   /**
-   * Get the chassis speeds based on controller input of 2 joysticks. One for
-   * speeds in which direction. The other for
-   * the angle of the robot.
+   * Get the chassis speeds based on controller input of 2 joysticks. One for speeds in which
+   * direction. The other for the angle of the robot.
    *
-   * @param xInput   X joystick input for the robot to move in the X direction.
-   * @param yInput   Y joystick input for the robot to move in the Y direction.
+   * @param xInput X joystick input for the robot to move in the X direction.
+   * @param yInput Y joystick input for the robot to move in the Y direction.
    * @param headingX X joystick which controls the angle of the robot.
    * @param headingY Y joystick which controls the angle of the robot.
    * @return {@link ChassisSpeeds} which can be sent to the Swerve Drive.
    */
-  public ChassisSpeeds getTargetSpeeds(double xInput, double yInput, double headingX, double headingY) {
+  public ChassisSpeeds getTargetSpeeds(
+      double xInput, double yInput, double headingX, double headingY) {
     Translation2d scaledInputs = SwerveMath.cubeTranslation(new Translation2d(xInput, yInput));
-    return swerveDrive.swerveController.getTargetSpeeds(scaledInputs.getX(),
+    return swerveDrive.swerveController.getTargetSpeeds(
+        scaledInputs.getX(),
         scaledInputs.getY(),
         headingX,
         headingY,
@@ -643,19 +629,19 @@ public class SwerveSubsystem extends SubsystemBase {
   }
 
   /**
-   * Get the chassis speeds based on controller input of 1 joystick and one angle.
-   * Control the robot at an offset of
-   * 90deg.
+   * Get the chassis speeds based on controller input of 1 joystick and one angle. Control the robot
+   * at an offset of 90deg.
    *
    * @param xInput X joystick input for the robot to move in the X direction.
    * @param yInput Y joystick input for the robot to move in the Y direction.
-   * @param angle  The angle in as a {@link Rotation2d}.
+   * @param angle The angle in as a {@link Rotation2d}.
    * @return {@link ChassisSpeeds} which can be sent to the Swerve Drive.
    */
   public ChassisSpeeds getTargetSpeeds(double xInput, double yInput, Rotation2d angle) {
     Translation2d scaledInputs = SwerveMath.cubeTranslation(new Translation2d(xInput, yInput));
 
-    return swerveDrive.swerveController.getTargetSpeeds(scaledInputs.getX(),
+    return swerveDrive.swerveController.getTargetSpeeds(
+        scaledInputs.getX(),
         scaledInputs.getY(),
         angle.getRadians(),
         getHeading().getRadians(),
@@ -698,9 +684,7 @@ public class SwerveSubsystem extends SubsystemBase {
     return swerveDrive.swerveDriveConfiguration;
   }
 
-  /**
-   * Lock the swerve drive to prevent it from moving.
-   */
+  /** Lock the swerve drive to prevent it from moving. */
   public void lock() {
     swerveDrive.lockPose();
   }
@@ -714,11 +698,10 @@ public class SwerveSubsystem extends SubsystemBase {
     return swerveDrive.getPitch();
   }
 
-  /**
-   * Add a fake vision reading for testing purposes.
-   */
+  /** Add a fake vision reading for testing purposes. */
   public void addFakeVisionReading() {
-    swerveDrive.addVisionMeasurement(new Pose2d(3, 3, Rotation2d.fromDegrees(65)), Timer.getFPGATimestamp());
+    swerveDrive.addVisionMeasurement(
+        new Pose2d(3, 3, Rotation2d.fromDegrees(65)), Timer.getFPGATimestamp());
   }
 
   /**
@@ -733,5 +716,4 @@ public class SwerveSubsystem extends SubsystemBase {
   public Vision getVision() {
     return vision;
   }
-
 }

--- a/src/main/java/frc/robot/subsystems/swervedrive/Vision.java
+++ b/src/main/java/frc/robot/subsystems/swervedrive/Vision.java
@@ -1,29 +1,10 @@
 package frc.robot.subsystems.swervedrive;
 
-import static edu.wpi.first.units.Units.Microseconds;
-import static edu.wpi.first.units.Units.Milliseconds;
-import static edu.wpi.first.units.Units.Seconds;
-
 import edu.wpi.first.apriltag.AprilTagFieldLayout;
 import edu.wpi.first.apriltag.AprilTagFields;
-import edu.wpi.first.math.Matrix;
-import edu.wpi.first.math.VecBuilder;
-import edu.wpi.first.math.Vector;
 import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.math.geometry.Pose3d;
-import edu.wpi.first.math.geometry.Rotation2d;
-import edu.wpi.first.math.geometry.Rotation3d;
 import edu.wpi.first.math.geometry.Transform2d;
-import edu.wpi.first.math.geometry.Transform3d;
-import edu.wpi.first.math.geometry.Translation2d;
-import edu.wpi.first.math.geometry.Translation3d;
-import edu.wpi.first.math.numbers.N1;
-import edu.wpi.first.math.numbers.N2;
-import edu.wpi.first.math.numbers.N3;
-import edu.wpi.first.math.util.Units;
-import edu.wpi.first.networktables.NetworkTablesJNI;
-import edu.wpi.first.wpilibj.Alert;
-import edu.wpi.first.wpilibj.Alert.AlertType;
 import edu.wpi.first.wpilibj.smartdashboard.Field2d;
 import frc.robot.Cameras;
 import frc.robot.Robot;
@@ -34,55 +15,35 @@ import java.util.List;
 import java.util.Optional;
 import java.util.function.Supplier;
 import org.photonvision.EstimatedRobotPose;
-import org.photonvision.PhotonCamera;
-import org.photonvision.PhotonPoseEstimator;
-import org.photonvision.PhotonTargetSortMode;
-import org.photonvision.PhotonPoseEstimator.PoseStrategy;
 import org.photonvision.PhotonUtils;
-import org.photonvision.simulation.PhotonCameraSim;
-import org.photonvision.simulation.SimCameraProperties;
 import org.photonvision.simulation.VisionSystemSim;
 import org.photonvision.targeting.PhotonPipelineResult;
 import org.photonvision.targeting.PhotonTrackedTarget;
-import swervelib.telemetry.SwerveDriveTelemetry;
-import swervelib.telemetry.SwerveDriveTelemetry.TelemetryVerbosity;
-import swervelib.SwerveInputStream;
 import swervelib.SwerveDrive;
 
-
 /**
- * Example PhotonVision class to aid in the pursuit of accurate odometry. Taken
- * from
+ * Example PhotonVision class to aid in the pursuit of accurate odometry. Taken from
  * https://gitlab.com/ironclad_code/ironclad-2024/-/blob/master/src/main/java/frc/robot/vision/Vision.java?ref_type=heads
  */
 public class Vision {
 
-  /**
-   * April Tag Field Layout of the year.
-   */
-  public static final AprilTagFieldLayout fieldLayout = AprilTagFieldLayout.loadField(
-      AprilTagFields.kDefaultField);
-  /**
-   * Ambiguity defined as a value between (0,1). Used in
-   * {@link Vision#filterPose}.
-   */
+  /** April Tag Field Layout of the year. */
+  public static final AprilTagFieldLayout fieldLayout =
+      AprilTagFieldLayout.loadField(AprilTagFields.kDefaultField);
+
+  /** Ambiguity defined as a value between (0,1). Used in {@link Vision#filterPose}. */
   private final double maximumAmbiguity = 0.25;
-  /**
-   * Photon Vision Simulation
-   */
+
+  /** Photon Vision Simulation */
   public VisionSystemSim visionSim;
-  /**
-   * Count of times that the odom thinks we're more than 10meters away from the
-   * april tag.
-   */
+
+  /** Count of times that the odom thinks we're more than 10meters away from the april tag. */
   private double longDistangePoseEstimationCount = 0;
-  /**
-   * Current pose from the pose estimator using wheel odometry.
-   */
+
+  /** Current pose from the pose estimator using wheel odometry. */
   private Supplier<Pose2d> currentPose;
-  /**
-   * Field from {@link swervelib.SwerveDrive#field}
-   */
+
+  /** Field from {@link swervelib.SwerveDrive#field} */
   private Field2d field2d;
 
   List<PoseObservation> poseObservations = new LinkedList<>();
@@ -92,9 +53,8 @@ public class Vision {
   /**
    * Constructor for the Vision class.
    *
-   * @param currentPose Current pose supplier, should reference
-   *                    {@link SwerveDrive#getPose()}
-   * @param field       Current field, should be {@link SwerveDrive#field}
+   * @param currentPose Current pose supplier, should reference {@link SwerveDrive#getPose()}
+   * @param field Current field, should be {@link SwerveDrive#field}
    */
   public Vision(Supplier<Pose2d> currentPose, Field2d field) {
     this.currentPose = currentPose;
@@ -115,10 +75,9 @@ public class Vision {
   /**
    * Calculates a target pose relative to an AprilTag on the field.
    *
-   * @param aprilTag    The ID of the AprilTag.
-   * @param robotOffset The offset {@link Transform2d} of the robot to apply to
-   *                    the pose for the robot to position
-   *                    itself correctly.
+   * @param aprilTag The ID of the AprilTag.
+   * @param robotOffset The offset {@link Transform2d} of the robot to apply to the pose for the
+   *     robot to position itself correctly.
    * @return The target pose of the AprilTag.
    */
   public static Pose2d getAprilTagPose(int aprilTag, Transform2d robotOffset) {
@@ -126,14 +85,13 @@ public class Vision {
     if (aprilTagPose3d.isPresent()) {
       return aprilTagPose3d.get().toPose2d().transformBy(robotOffset);
     } else {
-      throw new RuntimeException("Cannot get AprilTag " + aprilTag + " from field " + fieldLayout.toString());
+      throw new RuntimeException(
+          "Cannot get AprilTag " + aprilTag + " from field " + fieldLayout.toString());
     }
-
   }
 
   /**
-   * Update the pose estimation inside of {@link SwerveDrive} with all of the
-   * given poses.
+   * Update the pose estimation inside of {@link SwerveDrive} with all of the given poses.
    *
    * @param swerveDrive {@link SwerveDrive} instance.
    */
@@ -155,23 +113,22 @@ public class Vision {
       Optional<EstimatedRobotPose> poseEst = getEstimatedGlobalPose(camera);
       if (poseEst.isPresent()) {
         var pose = poseEst.get();
-        swerveDrive.addVisionMeasurement(pose.estimatedPose.toPose2d(),
-            pose.timestampSeconds,
-            camera.curStdDevs);
+        swerveDrive.addVisionMeasurement(
+            pose.estimatedPose.toPose2d(), pose.timestampSeconds, camera.curStdDevs);
       }
     }
-
   }
 
   /**
    * Generates the estimated robot pose. Returns empty if:
+   *
    * <ul>
-   * <li>No Pose Estimates could be generated</li>
-   * <li>The generated pose estimate was considered not accurate</li>
+   *   <li>No Pose Estimates could be generated
+   *   <li>The generated pose estimate was considered not accurate
    * </ul>
    *
-   * @return an {@link EstimatedRobotPose} with an estimated pose, timestamp, and
-   *         targets used to create the estimate
+   * @return an {@link EstimatedRobotPose} with an estimated pose, timestamp, and targets used to
+   *     create the estimate
    */
   public Optional<EstimatedRobotPose> getEstimatedGlobalPose(Cameras camera) {
     Optional<EstimatedRobotPose> poseEst = camera.getEstimatedGlobalPose();
@@ -179,9 +136,7 @@ public class Vision {
       Field2d debugField = visionSim.getDebugField();
       // Uncomment to enable outputting of vision targets in sim.
       poseEst.ifPresentOrElse(
-          est -> debugField
-              .getObject("VisionEstimation")
-              .setPose(est.estimatedPose.toPose2d()),
+          est -> debugField.getObject("VisionEstimation").setPose(est.estimatedPose.toPose2d()),
           () -> {
             debugField.getObject("VisionEstimation").setPoses();
           });
@@ -190,14 +145,13 @@ public class Vision {
   }
 
   /**
-   * Filter pose via the ambiguity and find best estimate between all of the
-   * camera's throwing out distances more than
-   * 10m for a short amount of time.
+   * Filter pose via the ambiguity and find best estimate between all of the camera's throwing out
+   * distances more than 10m for a short amount of time.
    *
    * @param pose Estimated robot pose.
    * @return Could be empty if there isn't a good reading.
    */
-  
+
   /**
    * Get distance of the robot from the AprilTag pose.
    *
@@ -206,13 +160,14 @@ public class Vision {
    */
   public double getDistanceFromAprilTag(int id) {
     Optional<Pose3d> tag = fieldLayout.getTagPose(id);
-    return tag.map(pose3d -> PhotonUtils.getDistanceToPose(currentPose.get(), pose3d.toPose2d())).orElse(-1.0);
+    return tag.map(pose3d -> PhotonUtils.getDistanceToPose(currentPose.get(), pose3d.toPose2d()))
+        .orElse(-1.0);
   }
 
   /**
    * Get tracked target from a camera of AprilTagID
    *
-   * @param id     AprilTag ID
+   * @param id AprilTag ID
    * @param camera Camera to check.
    * @return Tracked target.
    */
@@ -228,7 +183,6 @@ public class Vision {
       }
     }
     return target;
-
   }
 
   /**
@@ -241,8 +195,8 @@ public class Vision {
   }
 
   /**
-   * Open up the photon vision camera streams on the localhost, assumes running
-   * photon vision on localhost.
+   * Open up the photon vision camera streams on the localhost, assumes running photon vision on
+   * localhost.
    */
   private void openSimCameraViews() {
     if (Desktop.isDesktopSupported() && Desktop.getDesktop().isSupported(Desktop.Action.BROWSE)) {
@@ -279,9 +233,7 @@ public class Vision {
     return bestCamEnum; // can be null if no camera sees the target
   }
 
-  /**
-   * Update the {@link Field2d} to include tracked targets/
-   */
+  /** Update the {@link Field2d} to include tracked targets/ */
   public void updateVisionField() {
 
     List<PhotonTrackedTarget> targets = new ArrayList<PhotonTrackedTarget>();
@@ -306,8 +258,10 @@ public class Vision {
   }
 
   public static record PoseObservation(
-      double timestamp, Pose3d pose, double ambiguity, int tagCount, double averageTagDistance,
-      PhotonPipelineResult bestResult) {
-  }
-
+      double timestamp,
+      Pose3d pose,
+      double ambiguity,
+      int tagCount,
+      double averageTagDistance,
+      PhotonPipelineResult bestResult) {}
 }

--- a/src/main/java/frc/robot/util/ElasticUtil.java
+++ b/src/main/java/frc/robot/util/ElasticUtil.java
@@ -1,85 +1,81 @@
 package frc.robot.util;
 
-import frc.robot.util.Elastic;
 import frc.robot.util.Elastic.Notification;
 import frc.robot.util.Elastic.NotificationLevel;
 
 /**
- * Utility wrapper for Elastic Dashboard notifications.
- * Provides simple static methods for sending notifications at different severity levels.
+ * Utility wrapper for Elastic Dashboard notifications. Provides simple static methods for sending
+ * notifications at different severity levels.
  */
 public final class ElasticUtil {
 
-    private ElasticUtil() {
-        // Prevent instantiation
-    }
+  private ElasticUtil() {
+    // Prevent instantiation
+  }
 
-    /**
-     * Sends an informational notification to Elastic Dashboard.
-     * @param title The notification title
-     * @param message The notification message
-     */
-    public static void sendInfo(String title, String message) {
-        Elastic.sendNotification(
-            new Notification(NotificationLevel.INFO, title, message)
-        );
-    }
+  /**
+   * Sends an informational notification to Elastic Dashboard.
+   *
+   * @param title The notification title
+   * @param message The notification message
+   */
+  public static void sendInfo(String title, String message) {
+    Elastic.sendNotification(new Notification(NotificationLevel.INFO, title, message));
+  }
 
-    /**
-     * Sends a warning notification to Elastic Dashboard.
-     * @param title The notification title
-     * @param message The notification message
-     */
-    public static void sendWarning(String title, String message) {
-        Elastic.sendNotification(
-            new Notification(NotificationLevel.WARNING, title, message)
-        );
-    }
+  /**
+   * Sends a warning notification to Elastic Dashboard.
+   *
+   * @param title The notification title
+   * @param message The notification message
+   */
+  public static void sendWarning(String title, String message) {
+    Elastic.sendNotification(new Notification(NotificationLevel.WARNING, title, message));
+  }
 
-    /**
-     * Sends an error notification to Elastic Dashboard.
-     * @param title The notification title
-     * @param message The notification message
-     */
-    public static void sendError(String title, String message) {
-        Elastic.sendNotification(
-            new Notification(NotificationLevel.ERROR, title, message)
-        );
-    }
+  /**
+   * Sends an error notification to Elastic Dashboard.
+   *
+   * @param title The notification title
+   * @param message The notification message
+   */
+  public static void sendError(String title, String message) {
+    Elastic.sendNotification(new Notification(NotificationLevel.ERROR, title, message));
+  }
 
-    /**
-     * Sends an informational notification with custom display time.
-     * @param title The notification title
-     * @param message The notification message
-     * @param displayTimeMs How long to display the notification in milliseconds
-     */
-    public static void sendInfo(String title, String message, int displayTimeMs) {
-        Elastic.sendNotification(
-            new Notification(NotificationLevel.INFO, title, message, displayTimeMs)
-        );
-    }
+  /**
+   * Sends an informational notification with custom display time.
+   *
+   * @param title The notification title
+   * @param message The notification message
+   * @param displayTimeMs How long to display the notification in milliseconds
+   */
+  public static void sendInfo(String title, String message, int displayTimeMs) {
+    Elastic.sendNotification(
+        new Notification(NotificationLevel.INFO, title, message, displayTimeMs));
+  }
 
-    /**
-     * Sends a warning notification with custom display time.
-     * @param title The notification title
-     * @param message The notification message
-     * @param displayTimeMs How long to display the notification in milliseconds
-     */
-    public static void sendWarning(String title, String message, int displayTimeMs) {
-        Elastic.sendNotification(
-            new Notification(NotificationLevel.WARNING, title, message, displayTimeMs)
-        );
-    }
+  /**
+   * Sends a warning notification with custom display time.
+   *
+   * @param title The notification title
+   * @param message The notification message
+   * @param displayTimeMs How long to display the notification in milliseconds
+   */
+  public static void sendWarning(String title, String message, int displayTimeMs) {
+    Elastic.sendNotification(
+        new Notification(NotificationLevel.WARNING, title, message, displayTimeMs));
+  }
 
-    /**
-     * Sends an error notification with custom display time.
-     * @param title The notification title
-     * @param message The notification message
-     * @param displayTimeMs How long to display the notification in milliseconds
-     */
-    public static void sendError(String title, String message, int displayTimeMs) {
-        Elastic.sendNotification(
-            new Notification(NotificationLevel.ERROR, title, message, displayTimeMs)
-        );
-    }
+  /**
+   * Sends an error notification with custom display time.
+   *
+   * @param title The notification title
+   * @param message The notification message
+   * @param displayTimeMs How long to display the notification in milliseconds
+   */
+  public static void sendError(String title, String message, int displayTimeMs) {
+    Elastic.sendNotification(
+        new Notification(NotificationLevel.ERROR, title, message, displayTimeMs));
+  }
 }


### PR DESCRIPTION
## Summary

Applies google-java-format to every file that gets modified in the telemetry PR stack. No logic changes at all, just consistent formatting so the diffs in later PRs only show real code changes instead of whitespace noise.

This also updates vendordeps to current versions (REVLib, YAGSL, PathPlanner, PhotonVision, Studica) and cleans up stale PathPlanner autos/paths that were left over from early prototyping.

## What changed

- **All existing Java source files** reformatted to google-java-format (Robot.java, RobotContainer.java, Constants.java, all commands, all subsystems, Cameras.java, Vision.java, swerve drive classes)
- **build.gradle** updated with current dependency versions and Spotless config
- **vendordeps/** updated to latest stable releases
- **PathPlanner paths/autos** removed stale `New Auto`, `New New Auto`, `test.auto`, and 7 prototype paths
- **.gitattributes** added for cross-platform line ending consistency
- **.gitignore** updated for build artifacts

## Why a separate formatting PR

I split formatting into its own PR because mixing whitespace changes with logic changes makes code review basically impossible. With this merged first, every subsequent PR in the stack shows only the actual code I wrote, nothing else.

