### PR TITLE
telemetry-pr01-foundation: SafeLog, EventMarker, TunableNumber, LED/PDH constants

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -220,6 +220,92 @@ public final class Constants {
     }
   }
 
+  public static final class LEDConstants {
+    public static final int PWM_PORT = 0;
+    public static final int STRIP_LENGTH = 60;
+    public static final double DIM_DISABLED = 0.15;
+  }
+
+  /**
+   * PDH channel map. Maps physical PDH channel (0-23) to a human-readable circuit name. Update this
+   * when wiring changes. Channels without a label are logged as "Ch{N}".
+   */
+  public static final class PDHChannelMap {
+    public static final int NUM_CHANNELS = 24;
+
+    // Channel labels: index = PDH channel number, value = circuit name
+    // Update these to match your actual wiring harness
+    private static final String[] LABELS = {
+      "FrontLeftDrive", // 0
+      "FrontLeftTurn", // 1
+      "FrontRightDrive", // 2
+      "FrontRightTurn", // 3
+      "BackLeftDrive", // 4
+      "BackLeftTurn", // 5
+      "BackRightDrive", // 6
+      "BackRightTurn", // 7
+      "Shooter", // 8
+      "Indexer", // 9
+      "Agitator", // 10
+      "Intake", // 11
+      "IntakeActuator", // 12
+      "Hanger", // 13
+      "Ch14", // 14 - unused/unknown
+      "Ch15", // 15 - unused/unknown
+      "Ch16", // 16 - unused/unknown
+      "Ch17", // 17 - unused/unknown
+      "Ch18", // 18 - unused/unknown
+      "Ch19", // 19 - unused/unknown
+      "Radio", // 20
+      "RoboRIO", // 21
+      "Ch22", // 22 - unused/unknown
+      "Ch23", // 23 - unused/unknown
+    };
+
+    /** Alert when any single channel exceeds this current (amps). */
+    public static final double CHANNEL_OVERCURRENT_AMPS = 40.0;
+
+    public static String getLabel(int channel) {
+      if (channel >= 0 && channel < LABELS.length) {
+        return LABELS[channel];
+      }
+      return "Ch" + channel;
+    }
+  }
+
+  /** Jam protection: 3-layer debounce + auto-reverse + disable after max attempts */
+  public static final class JamProtectionConstants {
+    // Intake jam protection
+    public static final double INTAKE_JAM_CURRENT_AMPS = 25.0;
+    public static final double INTAKE_JAM_VELOCITY_RPM = 100.0;
+    public static final double INTAKE_STARTUP_IGNORE_SEC = 0.5;
+    public static final double INTAKE_JAM_CONFIRM_SEC = 0.3;
+    public static final double INTAKE_REVERSE_SEC = 0.4;
+    public static final double INTAKE_COOLDOWN_SEC = 0.15;
+    public static final double INTAKE_REVERSE_POWER = -0.4;
+    public static final int INTAKE_MAX_ATTEMPTS = 3;
+
+    // Indexer jam protection
+    public static final double INDEXER_JAM_CURRENT_AMPS = 25.0;
+    public static final double INDEXER_JAM_VELOCITY_RPM = 50.0;
+    public static final double INDEXER_STARTUP_IGNORE_SEC = 0.5;
+    public static final double INDEXER_JAM_CONFIRM_SEC = 0.25;
+    public static final double INDEXER_REVERSE_SEC = 0.3;
+    public static final double INDEXER_COOLDOWN_SEC = 0.15;
+    public static final double INDEXER_REVERSE_POWER = -0.3;
+    public static final int INDEXER_MAX_ATTEMPTS = 3;
+
+    // Agitator jam protection
+    public static final double AGITATOR_JAM_CURRENT_AMPS = 15.0;
+    public static final double AGITATOR_JAM_VELOCITY_RPM = 50.0;
+    public static final double AGITATOR_STARTUP_IGNORE_SEC = 0.5;
+    public static final double AGITATOR_JAM_CONFIRM_SEC = 0.3;
+    public static final double AGITATOR_REVERSE_SEC = 0.4;
+    public static final double AGITATOR_COOLDOWN_SEC = 0.15;
+    public static final double AGITATOR_REVERSE_POWER = -0.3;
+    public static final int AGITATOR_MAX_ATTEMPTS = 3;
+  }
+
   /** Stall = high current + low velocity for debounce time */
   public static final class StallDetectionConstants {
     // Shooter stall thresholds

--- a/src/main/java/frc/robot/telemetry/SafeLog.java
+++ b/src/main/java/frc/robot/telemetry/SafeLog.java
@@ -7,19 +7,12 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import org.littletonrobotics.junction.Logger;
 
-/**
- * Per-signal crash isolation for Logger.recordOutput() calls. One failure never affects other
- * signals or crashes the robot.
- */
+/** Wraps Logger.recordOutput() so one bad signal can't crash the whole robot. */
 public final class SafeLog {
   private static final AtomicInteger cycleFailures = new AtomicInteger(0);
   private static final AtomicReference<String> lastFailedKey = new AtomicReference<>("");
 
   private SafeLog() {}
-
-  // =========================================================================
-  // Primitive type logging
-  // =========================================================================
 
   public static void put(String key, double value) {
     try {
@@ -61,10 +54,6 @@ public final class SafeLog {
     }
   }
 
-  // =========================================================================
-  // Array type logging
-  // =========================================================================
-
   public static void put(String key, double[] value) {
     try {
       Logger.recordOutput(key, value);
@@ -88,10 +77,6 @@ public final class SafeLog {
       recordFailure(key);
     }
   }
-
-  // =========================================================================
-  // WPILib geometry types
-  // =========================================================================
 
   public static void put(String key, Pose2d value) {
     try {
@@ -125,11 +110,7 @@ public final class SafeLog {
     }
   }
 
-  // =========================================================================
-  // Action execution (for external calls like EventMarker, CycleTracker)
-  // =========================================================================
-
-  /** Run an action; swallow any exception. */
+  /** Run an action, swallowing any exception. */
   public static void run(Runnable action) {
     try {
       action.run();
@@ -137,10 +118,6 @@ public final class SafeLog {
       // swallow
     }
   }
-
-  // =========================================================================
-  // Failure tracking
-  // =========================================================================
 
   private static void recordFailure(String key) {
     cycleFailures.incrementAndGet();

--- a/src/main/java/frc/robot/util/EventMarker.java
+++ b/src/main/java/frc/robot/util/EventMarker.java
@@ -26,7 +26,6 @@ public class EventMarker {
   private static volatile String latestCategory = "";
   private static volatile double latestTimestamp = 0;
 
-  // Event categories
   public static final String SHOT = "SHOT";
   public static final String INTAKE = "INTAKE";
   public static final String AUTO = "AUTO";
@@ -36,12 +35,10 @@ public class EventMarker {
   public static final String MODE = "MODE";
   public static final String JAM = "JAM";
 
-  private EventMarker() {} // Static utility class
+  private EventMarker() {}
 
-  /** Mark an event. */
   public static synchronized void mark(String category, String description) {
     try {
-      // Check per-cycle cap first
       if (currentCycleEvents.size() >= MAX_CYCLE_EVENTS) {
         droppedEventsThisCycle++;
         return;
@@ -97,7 +94,6 @@ public class EventMarker {
     droppedEventsThisCycle = 0;
   }
 
-  // ===== Shot events =====
   public static void shotFired() {
     mark(SHOT, "Ball fired");
   }
@@ -106,7 +102,6 @@ public class EventMarker {
     mark(SHOT, "Shot #" + shotNumber);
   }
 
-  // ===== Intake events =====
   public static void ballIntaked() {
     mark(INTAKE, "Ball acquired");
   }
@@ -115,7 +110,6 @@ public class EventMarker {
     mark(INTAKE, "Ball ejected");
   }
 
-  // ===== Auto events =====
   public static void autoStart(String autoName) {
     mark(AUTO, "Started: " + autoName);
   }
@@ -128,7 +122,6 @@ public class EventMarker {
     mark(AUTO, "Completed");
   }
 
-  // ===== Climb events =====
   public static void climbStart() {
     mark(CLIMB, "Climb initiated");
   }
@@ -137,7 +130,6 @@ public class EventMarker {
     mark(CLIMB, "Climb complete");
   }
 
-  // ===== Vision events =====
   public static void visionLock() {
     mark(VISION, "Target locked");
   }
@@ -146,12 +138,10 @@ public class EventMarker {
     mark(VISION, "Target lost");
   }
 
-  // ===== Mode events =====
   public static void modeChange(String mode) {
     mark(MODE, mode);
   }
 
-  // ===== Jam events =====
   public static void jamDetected(String subsystem) {
     mark(JAM, subsystem + " jam detected");
   }

--- a/src/main/java/frc/robot/util/TunableNumber.java
+++ b/src/main/java/frc/robot/util/TunableNumber.java
@@ -1,5 +1,6 @@
 package frc.robot.util;
 
+import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import frc.robot.Constants;
 import java.util.function.DoubleSupplier;
@@ -21,9 +22,9 @@ public class TunableNumber implements DoubleSupplier {
     }
   }
 
-  /** Current value (from dashboard if tuning, else default). */
+  /** Current value (from dashboard if tuning and not on FMS, else default). */
   public double get() {
-    if (!Constants.TUNING_MODE) {
+    if (!Constants.TUNING_MODE || DriverStation.isFMSAttached()) {
       return defaultValue;
     }
 
@@ -42,7 +43,7 @@ public class TunableNumber implements DoubleSupplier {
 
   /** True if value changed since last check. */
   public boolean hasChanged() {
-    if (!Constants.TUNING_MODE) {
+    if (!Constants.TUNING_MODE || DriverStation.isFMSAttached()) {
       return false;
     }
 
@@ -70,7 +71,7 @@ public class TunableNumber implements DoubleSupplier {
   }
 
   public static boolean tuningEnabled() {
-    return Constants.TUNING_MODE;
+    return Constants.TUNING_MODE && !DriverStation.isFMSAttached();
   }
 
   /** Run action if any tunable changed. */


### PR DESCRIPTION
 ## Summary

This is the first PR in my telemetry system series. It adds the foundation classesthat everything else builds on.

- **SafeLog**: Wrapper around `Logger.recordOutput()` that catches exceptions per-signal, so if one bad value comes through it won't crash the whole robot or block other signals from logging. Cleaned up the section comments to keep it concise.
- **EventMarker**: Timestamped event logging for shots, intakes, climbs, vision locks, jams, and mode changes. Each event gets a category, description, and match timestamp so we can see exactly when things happened in the logs. Has a per-cycle cap (10 events) to prevent log spam.
- **TunableNumber**: Added FMS lockout so tunable values (PID gains, RPM setpoints, etc.) automatically freeze to their defaults when we're connected to the field. Prevents accidental tuning changes during a real match.
- **Constants additions**: Added `LEDConstants` (PWM port, strip length, dim brightness), `PDHChannelMap` (human-readable labels for all 24 PDH channels so logs say "Shooter" instead of "Ch8"), and `JamProtectionConstants` (current/velocity thresholds, timing, and reverse power for intake, indexer, and agitator jam detection).

## What this changes in existing code

- `SafeLog.java`: Removed verbose section-header comments, shortened the class javadoc. No behavior changes.
- `EventMarker.java`: Same cleanup, removed redundant section comments. No behavior changes.
- `TunableNumber.java`: Added `DriverStation.isFMSAttached()` check to `get()`, `hasChanged()`, and `tuningEnabled()`. This is the only functional change in existing code. When FMS is connected, tunables return their compile-time defaults no matter what.