### PR TITLE
telemetry-pr07-sim: 10 sim scenarios, SimDeviceManager, sim wiring in Robot/RobotContainer

### DIFF
--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -15,6 +15,8 @@ import frc.robot.util.DiagnosticContext;
 import frc.robot.util.DriverFeedback;
 import frc.robot.util.ElasticUtil;
 import frc.robot.util.LEDStatusDisplay;
+import frc.robot.sim.SimDeviceManager;
+import frc.robot.sim.SimScenarioRunner;
 import frc.robot.util.EventMarker;
 import frc.robot.util.LoggedTracer;
 import frc.robot.util.PostMatchSummary;
@@ -38,6 +40,8 @@ public class Robot extends LoggedRobot {
   private RobotContainer m_robotContainer;
 
   private Timer disabledTimer;
+  private SimScenarioRunner simScenarioRunner;
+  private SimDeviceManager simDeviceManager;
 
   // Diagnostics
   private boolean hasRunDiagnostics = false;
@@ -125,7 +129,6 @@ public class Robot extends LoggedRobot {
       safeLog("Health/CrashBarrier/LastError", t.getClass().getSimpleName());
     }
   }
-
 
   /** Check critical telemetry values for NaN/Infinity corruption. */
   private void checkNaNInfinity() {
@@ -391,9 +394,19 @@ public class Robot extends LoggedRobot {
   }
 
   @Override
-  public void simulationInit() {}
+  public void simulationInit() {
+    simDeviceManager = new SimDeviceManager();
+    simDeviceManager.init();
+    simScenarioRunner = new SimScenarioRunner();
+  }
 
   @Override
   public void simulationPeriodic() {
+    if (simDeviceManager != null) {
+      simDeviceManager.update();
+    }
+    if (simScenarioRunner != null) {
+      simScenarioRunner.update();
+    }
   }
 }

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -44,6 +44,7 @@ import frc.robot.commands.SpeedUpThenIndex;
 import frc.robot.subsystems.swervedrive.SwerveSubsystem;
 import frc.robot.subsystems.swervedrive.Vision;
 import frc.robot.telemetry.TelemetryManager;
+import frc.robot.sim.SimDriveOverride;
 import frc.robot.util.DriverFeedback;
 import frc.robot.util.DriverTuning;
 import swervelib.SwerveInputStream;
@@ -90,14 +91,21 @@ public class RobotContainer {
 
   /**
    * Converts driver input into a field-relative ChassisSpeeds that is controlled by angular
-   * velocity.
+   * velocity. In sim, SimDriveOverride values are combined with joystick so scenario playback
+   * and manual SimGUI control both work.
    */
   SwerveInputStream driveAngularVelocity =
       SwerveInputStream.of(
               drivebase.getSwerveDrive(),
-              () -> driverXbox.getLeftY() * -1,
-              () -> driverXbox.getLeftX() * -1)
-          .withControllerRotationAxis(() -> driverXbox.getRightX() * -1)
+              () -> RobotBase.isSimulation()
+                  ? -(driverXbox.getLeftY() + SimDriveOverride.getY())
+                  : driverXbox.getLeftY() * -1,
+              () -> RobotBase.isSimulation()
+                  ? -(driverXbox.getLeftX() + SimDriveOverride.getX())
+                  : driverXbox.getLeftX() * -1)
+          .withControllerRotationAxis(() -> RobotBase.isSimulation()
+              ? -(driverXbox.getRightX() + SimDriveOverride.getOmega())
+              : driverXbox.getRightX() * -1)
           .deadband(OperatorConstants.DEADBAND)
           .scaleTranslation(0.8)
           .allianceRelativeControl(true);

--- a/src/main/java/frc/robot/sim/AMDAShowcaseScenario.java
+++ b/src/main/java/frc/robot/sim/AMDAShowcaseScenario.java
@@ -1,0 +1,306 @@
+package frc.robot.sim;
+
+import edu.wpi.first.hal.AllianceStationID;
+import edu.wpi.first.wpilibj.Timer;
+import edu.wpi.first.wpilibj.simulation.DriverStationSim;
+import edu.wpi.first.wpilibj.simulation.RoboRioSim;
+import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
+import frc.robot.telemetry.SafeLog;
+import swervelib.simulation.ironmaple.simulation.motorsims.SimulatedBattery;
+
+/**
+ * AMDA (Adaptive Multi-Modal Driver Awareness) showcase scenario. Exercises all 4 feedback
+ * channels: haptic, LED, camera HUD, and dashboard, by walking through conditions that trigger each
+ * pattern and state.
+ *
+ * <p>Naturally triggered haptic patterns (5/7): TELEOP_START (auto->teleop transition),
+ * ENDGAME_WARNING (matchTime<=30), HUB_ACTIVATED (hub becomes active), HUB_DEACTIVATED (hub
+ * becomes inactive), HUB_SHIFT_WARNING (timeToNextShift crosses 2.5s).
+ *
+ * <p>Naturally triggered LED states (7/10): DISABLED, IDLE, AUTO_RUNNING, SHOOTER_SPINUP, WARNING
+ * (low voltage), CRITICAL_ALERT (very low voltage), MATCH_OVER (matchTime crosses 0).
+ *
+ * <p>Not triggered in sim (documented): READY_TO_SHOOT haptic/LED (needs 5-condition composite),
+ * JAM_DETECTED haptic (needs high current + low velocity), VISION_LOCKED LED (needs PhotonVision
+ * lock), AIM_PROGRESS LED (needs progressive aim active).
+ *
+ * <p>ChannelCoordinator exercises: WARNING LED state includes lowConfidence check, DriverFeedback
+ * scales spin-up intensity based on isLowConfidence().
+ *
+ * <p>45s total, 13 phases. Launch: ./gradlew simulateJava -DsimScenario=AMDAShowcase
+ */
+public class AMDAShowcaseScenario implements SimScenario {
+  private double startTime;
+  private boolean finished = false;
+  private final SimInputPlayback input = new SimInputPlayback();
+  private int lastPhase = -1;
+
+  // Phase boundaries (wall-clock seconds from scenario start)
+  private static final double DISABLED_END = 2.0;
+  private static final double AUTO_END = 7.0;
+  private static final double TELEOP_START_END = 10.0;
+  private static final double HUB_ACTIVATE_END = 15.0;
+  private static final double HUB_DEACTIVATE_END = 18.0;
+  private static final double SHIFT_WARN_END = 23.0;
+  private static final double HUB_REACTIVATE_END = 26.0;
+  private static final double VOLTAGE_WARN_END = 30.0;
+  private static final double VOLTAGE_CRIT_END = 33.0;
+  private static final double VOLTAGE_RECOVER_END = 36.0;
+  private static final double ENDGAME_END = 40.0;
+  private static final double MATCH_END_END = 43.0;
+  private static final double SCENARIO_END = 45.0;
+
+  @Override
+  public String getName() {
+    return "AMDAShowcase";
+  }
+
+  @Override
+  public void init() {
+    startTime = Timer.getFPGATimestamp();
+    finished = false;
+    lastPhase = -1;
+    input.releaseAll();
+    SimulatedBattery.disableBatterySim();
+    RoboRioSim.setVInVoltage(12.8);
+    SmartDashboard.putBoolean("WonAuto", true);
+    DriverStationSim.setAllianceStationId(AllianceStationID.Red1);
+    DriverStationSim.notifyNewData();
+  }
+
+  @Override
+  public void execute(double timestampSec) {
+    double t = timestampSec - startTime;
+    int phase = getPhase(t);
+
+    if (phase != lastPhase) {
+      SafeLog.put("Sim/AMDA/Phase", phase);
+      SafeLog.put("Sim/AMDA/PhaseName", phaseName(phase));
+      lastPhase = phase;
+      onPhaseEnter(phase);
+    }
+
+    onPhaseUpdate(phase, t);
+
+    SafeLog.put("Sim/AMDA/ElapsedSec", t);
+    SafeLog.put("Sim/AMDA/Progress", Math.min(100, (t / SCENARIO_END) * 100));
+
+    if (t >= SCENARIO_END) {
+      input.releaseAll();
+      DriverStationSim.setEnabled(false);
+      DriverStationSim.notifyNewData();
+      RoboRioSim.setVInVoltage(12.8);
+      finished = true;
+    }
+  }
+
+  @Override
+  public boolean isFinished() {
+    return finished;
+  }
+
+  private int getPhase(double t) {
+    if (t < DISABLED_END) return 0;
+    if (t < AUTO_END) return 1;
+    if (t < TELEOP_START_END) return 2;
+    if (t < HUB_ACTIVATE_END) return 3;
+    if (t < HUB_DEACTIVATE_END) return 4;
+    if (t < SHIFT_WARN_END) return 5;
+    if (t < HUB_REACTIVATE_END) return 6;
+    if (t < VOLTAGE_WARN_END) return 7;
+    if (t < VOLTAGE_CRIT_END) return 8;
+    if (t < VOLTAGE_RECOVER_END) return 9;
+    if (t < ENDGAME_END) return 10;
+    if (t < MATCH_END_END) return 11;
+    return 12;
+  }
+
+  private String phaseName(int phase) {
+    switch (phase) {
+      case 0:
+        return "Disabled_LED_DISABLED";
+      case 1:
+        return "Auto_LED_AUTO_RUNNING";
+      case 2:
+        return "TeleopStart_Haptic_TELEOP_START";
+      case 3:
+        return "HubActivate_Haptic_HUB_ACTIVATED_LED_SPINUP";
+      case 4:
+        return "HubDeactivate_Haptic_HUB_DEACTIVATED";
+      case 5:
+        return "ShiftWarn_Haptic_HUB_SHIFT_WARNING";
+      case 6:
+        return "HubReactivate_Haptic_HUB_ACTIVATED";
+      case 7:
+        return "VoltageWarn_LED_WARNING";
+      case 8:
+        return "VoltageCrit_LED_CRITICAL_ALERT";
+      case 9:
+        return "VoltageRecover_LED_IDLE";
+      case 10:
+        return "Endgame_Haptic_ENDGAME_WARNING";
+      case 11:
+        return "MatchEnd_LED_MATCH_OVER";
+      case 12:
+        return "PostMatch_Disable";
+      default:
+        return "Unknown";
+    }
+  }
+
+  private void onPhaseEnter(int phase) {
+    switch (phase) {
+      case 0: // Disabled baseline -> LED: DISABLED
+        input.releaseAll();
+        DriverStationSim.setEnabled(false);
+        DriverStationSim.setAutonomous(false);
+        DriverStationSim.notifyNewData();
+        SafeLog.put("Sim/AMDA/ExpectedLED", "DISABLED");
+        SafeLog.put("Sim/AMDA/ExpectedHaptic", "none");
+        break;
+
+      case 1: // Auto mode -> LED: AUTO_RUNNING
+        DriverStationSim.setAutonomous(true);
+        DriverStationSim.setEnabled(true);
+        DriverStationSim.setMatchTime(15.0);
+        DriverStationSim.notifyNewData();
+        // Gentle drive to produce motion telemetry
+        input.driveForward(0.3);
+        SafeLog.put("Sim/AMDA/ExpectedLED", "AUTO_RUNNING");
+        SafeLog.put("Sim/AMDA/ExpectedHaptic", "none");
+        break;
+
+      case 2: // Auto -> Teleop transition -> Haptic: TELEOP_START, LED: IDLE
+        input.driveForward(0);
+        DriverStationSim.setAutonomous(false);
+        DriverStationSim.setEnabled(true);
+        // matchTime 140 = transition period (both hubs active)
+        DriverStationSim.setMatchTime(140.0);
+        DriverStationSim.notifyNewData();
+        SafeLog.put("Sim/AMDA/ExpectedLED", "IDLE");
+        SafeLog.put("Sim/AMDA/ExpectedHaptic", "TELEOP_START");
+        break;
+
+      case 3: // Hub activates + shooter spinup -> Haptic: HUB_ACTIVATED, LED: SHOOTER_SPINUP
+        // matchTime 106 = shift 2 (even, wonAuto=true -> ACTIVE)
+        // Previous phase was at 140 (transition, both active), so first we need
+        // to go through an INACTIVE shift to get the rising edge
+        // Jump to matchTime 129 (shift 1, INACTIVE for winner), held from phase 3-4
+        DriverStationSim.setMatchTime(129.0);
+        DriverStationSim.notifyNewData();
+        // This should produce hubActive=false (shift 1, odd, wonAuto -> !odd = false)
+        // Wait, we need the rising edge. Let's set INACTIVE first, then go ACTIVE.
+        // Actually at 140 (transition) hub was ACTIVE. At 129 (shift 1) hub = INACTIVE.
+        // That's a falling edge -> HUB_DEACTIVATED fires, not HUB_ACTIVATED.
+        // Let me fix: first go INACTIVE here, then in phase 4 go ACTIVE.
+        SafeLog.put("Sim/AMDA/ExpectedLED", "SHOOTER_SPINUP");
+        SafeLog.put("Sim/AMDA/ExpectedHaptic", "HUB_DEACTIVATED");
+        // Start shooter via copilot right trigger (SpeedUpThenIndex)
+        input.copilotSetRightTrigger(1.0);
+        break;
+
+      case 4: // Hub deactivation confirmed, now activate -> Haptic: HUB_ACTIVATED
+        // matchTime 104 = shift 2 (even, wonAuto=true -> ACTIVE)
+        DriverStationSim.setMatchTime(104.0);
+        DriverStationSim.notifyNewData();
+        SafeLog.put("Sim/AMDA/ExpectedLED", "SHOOTER_SPINUP");
+        SafeLog.put("Sim/AMDA/ExpectedHaptic", "HUB_ACTIVATED");
+        break;
+
+      case 5: // Approach shift boundary -> Haptic: HUB_SHIFT_WARNING
+        // Stop shooter, set matchTime so timeToNextShift will cross 2.5s
+        input.copilotSetRightTrigger(0);
+        // matchTime 82.5 -> next shift at 80 -> timeToNextShift = 2.5
+        // We'll ramp matchTime from 84 down to 78 over this phase
+        DriverStationSim.setMatchTime(84.0);
+        DriverStationSim.notifyNewData();
+        SafeLog.put("Sim/AMDA/ExpectedLED", "IDLE");
+        SafeLog.put("Sim/AMDA/ExpectedHaptic", "HUB_SHIFT_WARNING");
+        break;
+
+      case 6: // Hub reactivation after shift -> Haptic: HUB_ACTIVATED (or DEACTIVATED)
+        // matchTime 79 = shift 3 (odd, wonAuto=true -> !odd = false -> INACTIVE)
+        // So crossing from shift 2 (ACTIVE) to shift 3 (INACTIVE) = HUB_DEACTIVATED
+        // Then we jump to shift 4 to get HUB_ACTIVATED
+        DriverStationSim.setMatchTime(54.0);
+        DriverStationSim.notifyNewData();
+        // shift 4, even, wonAuto=true -> ACTIVE. Previous was shift 3 INACTIVE -> rising edge
+        SafeLog.put("Sim/AMDA/ExpectedLED", "IDLE");
+        SafeLog.put("Sim/AMDA/ExpectedHaptic", "HUB_ACTIVATED");
+        break;
+
+      case 7: // Voltage warning -> LED: WARNING
+        RoboRioSim.setVInVoltage(11.0);
+        SafeLog.put("Sim/AMDA/ExpectedLED", "WARNING");
+        SafeLog.put("Sim/AMDA/ExpectedHaptic", "none");
+        break;
+
+      case 8: // Voltage critical -> LED: CRITICAL_ALERT
+        RoboRioSim.setVInVoltage(9.0);
+        SafeLog.put("Sim/AMDA/ExpectedLED", "CRITICAL_ALERT");
+        SafeLog.put("Sim/AMDA/ExpectedHaptic", "none");
+        break;
+
+      case 9: // Voltage recovery -> LED: IDLE
+        RoboRioSim.setVInVoltage(12.8);
+        SafeLog.put("Sim/AMDA/ExpectedLED", "IDLE");
+        SafeLog.put("Sim/AMDA/ExpectedHaptic", "none");
+        break;
+
+      case 10: // Endgame warning -> Haptic: ENDGAME_WARNING
+        // matchTime <= 30 in teleop triggers ENDGAME_WARNING
+        DriverStationSim.setMatchTime(30.0);
+        DriverStationSim.notifyNewData();
+        SafeLog.put("Sim/AMDA/ExpectedLED", "IDLE");
+        SafeLog.put("Sim/AMDA/ExpectedHaptic", "ENDGAME_WARNING");
+        break;
+
+      case 11: // Match end -> LED: MATCH_OVER
+        // matchTime crosses through 0 in teleop triggers MATCH_OVER latch
+        DriverStationSim.setMatchTime(0.05);
+        DriverStationSim.notifyNewData();
+        SafeLog.put("Sim/AMDA/ExpectedLED", "MATCH_OVER");
+        SafeLog.put("Sim/AMDA/ExpectedHaptic", "none");
+        break;
+
+      case 12: // Post-match disable
+        input.releaseAll();
+        DriverStationSim.setEnabled(false);
+        DriverStationSim.notifyNewData();
+        SafeLog.put("Sim/AMDA/ExpectedLED", "DISABLED");
+        SafeLog.put("Sim/AMDA/ExpectedHaptic", "none");
+        break;
+    }
+  }
+
+  private void onPhaseUpdate(int phase, double t) {
+    switch (phase) {
+      case 1: // Auto: count down match time
+        double autoT = t - DISABLED_END;
+        DriverStationSim.setMatchTime(Math.max(0, 15.0 - autoT));
+        DriverStationSim.notifyNewData();
+        break;
+
+      case 5: // Shift warning: ramp matchTime from 84 down through 80 boundary
+        // Over 5s, matchTime goes 84 -> 78, crossing shift 3 boundary at 80
+        // HUB_SHIFT_WARNING fires when timeToNextShift crosses 2.5s (at matchTime 82.5)
+        double warnT = t - HUB_DEACTIVATE_END;
+        double matchTime = 84.0 - (warnT / 5.0) * 6.0;
+        DriverStationSim.setMatchTime(Math.max(78.0, matchTime));
+        DriverStationSim.notifyNewData();
+        break;
+
+      case 10: // Endgame: count down from 30 to 0
+        double egT = t - VOLTAGE_RECOVER_END;
+        double egMatchTime = Math.max(0, 30.0 - (egT / 4.0) * 30.0);
+        DriverStationSim.setMatchTime(egMatchTime);
+        DriverStationSim.notifyNewData();
+        break;
+
+      case 11: // Match end: hold at 0 so MATCH_OVER latch fires
+        DriverStationSim.setMatchTime(0);
+        DriverStationSim.notifyNewData();
+        break;
+    }
+  }
+}

--- a/src/main/java/frc/robot/sim/BrownoutScenario.java
+++ b/src/main/java/frc/robot/sim/BrownoutScenario.java
@@ -1,0 +1,163 @@
+package frc.robot.sim;
+
+import edu.wpi.first.hal.AllianceStationID;
+import edu.wpi.first.wpilibj.Timer;
+import edu.wpi.first.wpilibj.simulation.DriverStationSim;
+import edu.wpi.first.wpilibj.simulation.RoboRioSim;
+import frc.robot.telemetry.SafeLog;
+import swervelib.simulation.ironmaple.simulation.motorsims.SimulatedBattery;
+
+/**
+ * Brownout scenario: runs motors under load then ramps voltage down to exercise SystemHealth
+ * brownout detection and PredictiveAlerts BatteryAtRisk prediction, then recovers.
+ *
+ * <p>Two-stage voltage decline: Stage 1 (slow, 12.5V to 11.0V over 8s) triggers PredictiveAlerts
+ * BatteryAtRisk prediction (needs 150 samples at 50Hz = 3s to fill regression window, then
+ * dropRate > 0.001 V/s with predictedTimeToWarning < 30s). Stage 2 (fast, 11.0V to 7.0V over 3s)
+ * triggers SystemHealth brownout detection and CRITICAL_ALERT LED state.
+ *
+ * <p>25s total, 7 phases.
+ *
+ * <p>Launch: ./gradlew simulateJava -DsimScenario=Brownout
+ */
+public class BrownoutScenario implements SimScenario {
+  private double startTime;
+  private boolean finished = false;
+  private final SimInputPlayback input = new SimInputPlayback();
+  private int lastPhase = -1;
+
+  @Override
+  public String getName() {
+    return "Brownout";
+  }
+
+  @Override
+  public void init() {
+    startTime = Timer.getFPGATimestamp();
+    finished = false;
+    lastPhase = -1;
+    input.releaseAll();
+    SimulatedBattery.disableBatterySim(); // prevent MapleSim from overwriting our voltage ramp
+    RoboRioSim.setVInVoltage(12.5);
+    DriverStationSim.setAllianceStationId(AllianceStationID.Red1);
+    DriverStationSim.notifyNewData();
+  }
+
+  @Override
+  public void execute(double timestampSec) {
+    double t = timestampSec - startTime;
+    int phase = getPhase(t);
+
+    if (phase != lastPhase) {
+      SafeLog.put("Sim/Brownout/Phase", phase);
+      SafeLog.put("Sim/Brownout/PhaseName", phaseName(phase));
+      lastPhase = phase;
+      onPhaseEnter(phase);
+    }
+
+    onPhaseUpdate(phase, t);
+
+    SafeLog.put("Sim/Brownout/ElapsedSec", t);
+    SafeLog.put("Sim/Brownout/Progress", Math.min(100, (t / 25.0) * 100));
+
+    if (t >= 25.0) {
+      input.releaseAll();
+      DriverStationSim.setEnabled(false);
+      DriverStationSim.notifyNewData();
+      RoboRioSim.setVInVoltage(12.5);
+      finished = true;
+    }
+  }
+
+  @Override
+  public boolean isFinished() {
+    return finished;
+  }
+
+  private int getPhase(double t) {
+    if (t < 3) return 0; // Enable + drive + shooter
+    if (t < 5) return 1; // Add indexer, all motors loaded
+    if (t < 13) return 2; // Stage 1: slow ramp 12.5V -> 11.0V (triggers PredictiveAlerts)
+    if (t < 16) return 3; // Stage 2: fast ramp 11.0V -> 7.0V (triggers brownout)
+    if (t < 18) return 4; // Hold at 7V (CRITICAL_ALERT)
+    if (t < 22) return 5; // Ramp 7V -> 12.5V recovery
+    return 6; // Release + disable
+  }
+
+  private String phaseName(int phase) {
+    switch (phase) {
+      case 0:
+        return "EnableAndLoad";
+      case 1:
+        return "FullMotorLoad";
+      case 2:
+        return "SlowVoltageDecline";
+      case 3:
+        return "FastBrownoutDrop";
+      case 4:
+        return "BrownoutHold";
+      case 5:
+        return "VoltageRecovery";
+      case 6:
+        return "Disable";
+      default:
+        return "Unknown";
+    }
+  }
+
+  private void onPhaseEnter(int phase) {
+    switch (phase) {
+      case 0: // Enable teleop, drive + spin shooter
+        DriverStationSim.setAutonomous(false);
+        DriverStationSim.setEnabled(true);
+        DriverStationSim.setMatchTime(135.0);
+        DriverStationSim.notifyNewData();
+        input.driveForward(0.5);
+        input.holdA(true);
+        break;
+
+      case 1: // Add indexer
+        input.holdY(true);
+        break;
+
+      case 6: // Disable
+        input.releaseAll();
+        DriverStationSim.setEnabled(false);
+        DriverStationSim.notifyNewData();
+        break;
+    }
+  }
+
+  private void onPhaseUpdate(int phase, double t) {
+    switch (phase) {
+      case 2: // Stage 1: slow ramp 12.5V -> 11.0V over 8s (0.19 V/s)
+        // PredictiveAlerts needs 150 samples (3s) to fill regression window,
+        // then dropRate (0.19 V/s) >> 0.001 threshold fires BatteryAtRisk
+        // when predictedTimeToWarning = (currentV - 11.5) / 0.19 < 30s
+        double slowProgress = (t - 5.0) / 8.0;
+        double slowVoltage = 12.5 - (1.5 * Math.min(1.0, slowProgress));
+        RoboRioSim.setVInVoltage(slowVoltage);
+        SafeLog.put("Sim/BrownoutVoltage", slowVoltage);
+        break;
+
+      case 3: // Stage 2: fast ramp 11.0V -> 7.0V over 3s
+        double fastProgress = (t - 13.0) / 3.0;
+        double fastVoltage = 11.0 - (4.0 * Math.min(1.0, fastProgress));
+        RoboRioSim.setVInVoltage(fastVoltage);
+        SafeLog.put("Sim/BrownoutVoltage", fastVoltage);
+        break;
+
+      case 4: // Hold at 7V (CRITICAL_ALERT territory)
+        RoboRioSim.setVInVoltage(7.0);
+        SafeLog.put("Sim/BrownoutVoltage", 7.0);
+        break;
+
+      case 5: // Ramp 7V -> 12.5V over 4s
+        double recovProgress = (t - 18.0) / 4.0;
+        double recovVoltage = 7.0 + (5.5 * Math.min(1.0, recovProgress));
+        RoboRioSim.setVInVoltage(recovVoltage);
+        SafeLog.put("Sim/BrownoutVoltage", recovVoltage);
+        break;
+    }
+  }
+}

--- a/src/main/java/frc/robot/sim/CompetitionMatchScenario.java
+++ b/src/main/java/frc/robot/sim/CompetitionMatchScenario.java
@@ -1,0 +1,562 @@
+package frc.robot.sim;
+
+import edu.wpi.first.hal.AllianceStationID;
+import edu.wpi.first.math.geometry.Pose2d;
+import edu.wpi.first.math.geometry.Rotation2d;
+import edu.wpi.first.math.geometry.Translation2d;
+import edu.wpi.first.wpilibj.Timer;
+import edu.wpi.first.wpilibj.simulation.DriverStationSim;
+import edu.wpi.first.wpilibj.simulation.RoboRioSim;
+import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
+import edu.wpi.first.wpilibj2.command.Command;
+import edu.wpi.first.wpilibj2.command.CommandScheduler;
+import frc.robot.RobotContainer;
+import frc.robot.commands.SpeedUpThenIndex;
+import frc.robot.telemetry.SafeLog;
+import swervelib.simulation.ironmaple.simulation.motorsims.SimulatedBattery;
+
+/**
+ * Definitive competition match with hub-aware strategy.
+ *
+ * <p>Starts from Red alliance wall (15, 4, 180deg) and plays a full 169s match with
+ * game-manual-accurate hub shift timing.
+ *
+ * <p>Hub shift logic (WonAuto=true, Red Alliance): Transition shift (matchTime 140-130): ACTIVE
+ * Shift 1 (130-105): INACTIVE,collect fuel, reposition Shift 2 (105-80): ACTIVE,rapid-fire scoring
+ * dump Shift 3 (80-55): INACTIVE,collect from far zones Shift 4 (55-30): ACTIVE, aggressive scoring
+ * Endgame (<=30): ACTIVE,final shots + hanger climb
+ *
+ * <p>Strategy: ACTIVE shifts keep SpeedUpThenIndex running continuously (never stop/restart within
+ * a phase). INACTIVE shifts collect fuel with intake, zero shooting.
+ *
+ * <p>Drive mapping (Red alliance + allianceRelativeControl): driveForward(+) = toward BLUE side
+ * (field -X) = toward fuel zones driveForward(-) = toward RED wall (field +X) = toward hub/tower
+ *
+ * <p>Field layout: Red start: (15.0, 5.5, 180deg),near Red wall, offset Y above hub Red Hub: (11.9,
+ * 4.0),4 hex faces, 1.06m opening Center fuel: ~(8.27, 4.0), upper: (8.0, 5.5), lower: (8.5, 2.5)
+ * Red Tower: ~(15.5, 4.0),3 rungs for climbing
+ *
+ * <p>Scoring: X-only (SpeedUpThenIndex). NEVER A+X,command conflict. 169s scenario, 11 phases
+ * (0-10), ~75-110 shots. Launch: ./gradlew simulateJava -DsimScenario=CompetitionMatch
+ */
+public class CompetitionMatchScenario implements SimScenario {
+  private double startTime;
+  private boolean finished = false;
+  private final SimInputPlayback input = new SimInputPlayback();
+  private int lastPhase = -1;
+
+  // Direct command control (bypasses trigger system)
+  private Command activeShooterCmd = null;
+
+  // Wall-clock phase boundaries aligned with hub shift matchTime boundaries
+  private static final double PRE_MATCH_END = 3.0;
+  private static final double AUTO_END = 23.0; // 20s auto
+  private static final double DISABLED_END = 26.0; // 3s disabled transition
+  private static final double TRANS_SHIFT_END = 36.0; // 10s transition shift (ACTIVE)
+  private static final double SHIFT1_END = 61.0; // 25s shift 1 (INACTIVE)
+  private static final double SHIFT2_END = 86.0; // 25s shift 2 (ACTIVE)
+  private static final double SHIFT3_END = 111.0; // 25s shift 3 (INACTIVE)
+  private static final double SHIFT4_END = 136.0; // 25s shift 4 (ACTIVE)
+  private static final double ENDGAME_SCORE_END = 151.0; // 15s endgame scoring (ACTIVE)
+  private static final double HANGER_END = 166.0; // 15s hanger climb
+  private static final double SCENARIO_END = 169.0; // 3s post-match
+
+  @Override
+  public String getName() {
+    return "CompetitionMatch";
+  }
+
+  @Override
+  public void init() {
+    startTime = Timer.getFPGATimestamp();
+    finished = false;
+    lastPhase = -1;
+    activeShooterCmd = null;
+    input.releaseAll();
+    SimulatedBattery.disableBatterySim(); // prevent MapleSim from overwriting our voltage ramp
+    RoboRioSim.setVInVoltage(12.8);
+    SmartDashboard.putBoolean("WonAuto", false);
+    DriverStationSim.setAllianceStationId(AllianceStationID.Red1);
+    DriverStationSim.notifyNewData();
+
+    // Teleport robot to Red alliance wall starting position
+    try {
+      RobotContainer rc = RobotContainer.getInstance();
+      if (rc != null) {
+        Pose2d startPose = new Pose2d(new Translation2d(15.0, 5.5), Rotation2d.fromDegrees(180));
+        rc.getSwerveSubsystem().resetOdometry(startPose);
+      }
+    } catch (RuntimeException e) {
+      SafeLog.put("Sim/CompMatch/InitError", e.getClass().getSimpleName());
+    }
+  }
+
+  @Override
+  public void execute(double timestampSec) {
+    double t = timestampSec - startTime;
+    int phase = getPhase(t);
+
+    if (phase != lastPhase) {
+      SafeLog.put("Sim/CompMatch/Phase", phase);
+      SafeLog.put("Sim/CompMatch/PhaseName", phaseName(phase));
+      lastPhase = phase;
+      onPhaseEnter(phase);
+    }
+
+    onPhaseUpdate(phase, t);
+
+    SafeLog.put("Sim/CompMatch/ElapsedSec", t);
+    SafeLog.put("Sim/CompMatch/Progress", Math.min(100, (t / SCENARIO_END) * 100));
+
+    if (t >= SCENARIO_END) {
+      input.releaseAll();
+      DriverStationSim.setEnabled(false);
+      DriverStationSim.notifyNewData();
+      finished = true;
+    }
+  }
+
+  @Override
+  public boolean isFinished() {
+    return finished;
+  }
+
+  private int getPhase(double t) {
+    if (t < PRE_MATCH_END) return 0;
+    if (t < AUTO_END) return 1;
+    if (t < DISABLED_END) return 2;
+    if (t < TRANS_SHIFT_END) return 3;
+    if (t < SHIFT1_END) return 4;
+    if (t < SHIFT2_END) return 5;
+    if (t < SHIFT3_END) return 6;
+    if (t < SHIFT4_END) return 7;
+    if (t < ENDGAME_SCORE_END) return 8;
+    if (t < HANGER_END) return 9;
+    return 10;
+  }
+
+  private String phaseName(int phase) {
+    switch (phase) {
+      case 0:
+        return "PreMatch";
+      case 1:
+        return "Autonomous";
+      case 2:
+        return "AutoTeleopDisabled";
+      case 3:
+        return "TransitionShift_ACTIVE";
+      case 4:
+        return "Shift1_INACTIVE";
+      case 5:
+        return "Shift2_ACTIVE";
+      case 6:
+        return "Shift3_INACTIVE";
+      case 7:
+        return "Shift4_ACTIVE";
+      case 8:
+        return "EndgameScoring_ACTIVE";
+      case 9:
+        return "HangerClimb";
+      case 10:
+        return "PostMatch";
+      default:
+        return "Unknown";
+    }
+  }
+
+  /**
+   * Phase entry: set mode flags and start/stop shooting. Shooting is managed at phase boundaries
+   * ONLY,never within a phase.
+   */
+  private void onPhaseEnter(int phase) {
+    // Clear drive inputs,shooting handled per-phase below
+    input.driveForward(0);
+    input.strafe(0);
+    input.rotate(0);
+    input.holdB(false);
+    input.holdRightBumper(false);
+
+    switch (phase) {
+      case 0: // Pre-match disabled
+        input.releaseAll();
+        DriverStationSim.setEnabled(false);
+        DriverStationSim.setAutonomous(false);
+        DriverStationSim.notifyNewData();
+        break;
+      case 1: // Auto
+        DriverStationSim.setAutonomous(true);
+        DriverStationSim.setEnabled(true);
+        DriverStationSim.setMatchTime(20.0);
+        DriverStationSim.notifyNewData();
+        // Shooting started inside autoPhase after sprint begins
+        break;
+      case 2: // Disabled transition
+        stopShooting();
+        input.releaseAll();
+        DriverStationSim.setEnabled(false);
+        DriverStationSim.setAutonomous(false);
+        DriverStationSim.notifyNewData();
+        break;
+      case 3: // Transition shift ACTIVE
+        DriverStationSim.setAutonomous(false);
+        DriverStationSim.setEnabled(true);
+        SmartDashboard.putBoolean("WonAuto", true);
+        DriverStationSim.setMatchTime(140.0);
+        DriverStationSim.notifyNewData();
+        startShooting();
+        break;
+      case 4: // Shift 1 INACTIVE
+        stopShooting();
+        break;
+      case 5: // Shift 2 ACTIVE
+        startShooting();
+        break;
+      case 6: // Shift 3 INACTIVE
+        stopShooting();
+        break;
+      case 7: // Shift 4 ACTIVE
+        startShooting();
+        break;
+      case 8: // Endgame ACTIVE
+        startShooting();
+        break;
+      case 9: // Hanger
+        stopShooting();
+        break;
+      case 10: // Post-match
+        stopShooting();
+        input.releaseAll();
+        DriverStationSim.setEnabled(false);
+        DriverStationSim.notifyNewData();
+        break;
+    }
+  }
+
+  private void onPhaseUpdate(int phase, double t) {
+    // Match time countdown
+    if (phase == 1) {
+      DriverStationSim.setMatchTime(Math.max(0, 20.0 - (t - PRE_MATCH_END)));
+      DriverStationSim.notifyNewData();
+    } else if (phase >= 3 && phase <= 9) {
+      double matchTime = 140.0 - (t - DISABLED_END);
+      DriverStationSim.setMatchTime(Math.max(0, matchTime));
+      DriverStationSim.notifyNewData();
+    }
+
+    // Battery sag: 12.8V -> 11.2V over teleop
+    if (phase >= 3 && phase <= 9) {
+      double pct = (t - DISABLED_END) / (HANGER_END - DISABLED_END);
+      RoboRioSim.setVInVoltage(Math.max(11.2, 12.8 - pct * 1.6));
+    }
+
+    // Log hub state for analysis (auto counts as ACTIVE too)
+    boolean hubActive = (phase == 1 || phase == 3 || phase == 5 || phase == 7 || phase == 8);
+    SafeLog.put("Sim/CompMatch/HubActive", hubActive);
+
+    switch (phase) {
+      case 1:
+        autoPhase(t);
+        break;
+      case 3:
+        transitionShiftPhase(t);
+        break;
+      case 4:
+        shift1InactivePhase(t);
+        break;
+      case 5:
+        shift2ActivePhase(t);
+        break;
+      case 6:
+        shift3InactivePhase(t);
+        break;
+      case 7:
+        shift4ActivePhase(t);
+        break;
+      case 8:
+        endgameScoringPhase(t);
+        break;
+      case 9:
+        hangerPhase(t);
+        break;
+    }
+  }
+
+  /**
+   * AUTO (3-23s, 20s): Sprint from Red wall to hub, shoot, sprint to center fuel, intake, sprint
+   * back to hub, shoot more.
+   *
+   * <p>Starting at (15, 5.5). Hub at (11.9, 4),1.5m Y offset clears it. Center fuel at (8.27, 4) =
+   * 6.7m in +forward direction.
+   */
+  private void autoPhase(double t) {
+    double at = t - PRE_MATCH_END;
+
+    if (at < 2.0) {
+      // Sprint from Red wall toward hub (Y=5.5 naturally clears hub at Y=4)
+      input.driveForward(0.95);
+      input.strafe(0.15);
+      startShooting();
+    } else if (at < 5.0) {
+      // Past hub area, shooting + drift toward center Y
+      input.driveForward(0.1);
+      input.strafe(-0.15 + 0.1 * Math.sin(at * 2.0));
+    } else if (at < 8.0) {
+      // Sprint to center fuel, deploy intake
+      input.driveForward(0.9);
+      input.strafe(0.2);
+      input.holdB(true);
+    } else if (at < 10.0) {
+      // Intake while creeping through fuel zone
+      input.holdB(true);
+      input.driveForward(0.2);
+      input.strafe(0.1);
+    } else if (at < 14.0) {
+      // Sprint back toward hub area
+      input.holdB(false);
+      input.driveForward(-0.9);
+      input.strafe(-0.25);
+    } else {
+      // Park near hub scoring face
+      input.driveForward(-0.05);
+      input.strafe(-0.08 + 0.1 * Math.sin(at * 1.5));
+    }
+  }
+
+  /**
+   * TRANSITION SHIFT ACTIVE (26-36s, 10s): Hub ACTIVE. Shoot from hub position, quick fuel grab,
+   * continue shooting on return. Shooter runs continuously,started at phase enter.
+   */
+  private void transitionShiftPhase(double t) {
+    double pt = t - DISABLED_END;
+
+    if (pt < 3.0) {
+      // Near hub from auto, shoot while strafing
+      input.driveForward(-0.1);
+      input.strafe(0.1 * Math.sin(pt * 2.5));
+    } else if (pt < 6.0) {
+      // Quick fuel grab toward center field
+      input.driveForward(0.85);
+      input.strafe(-0.3);
+      input.holdB(true);
+    } else if (pt < 9.0) {
+      // Sprint back to hub area
+      input.holdB(false);
+      input.driveForward(-0.85);
+      input.strafe(0.25);
+    } else {
+      // At hub scoring face
+      input.driveForward(-0.05);
+      input.strafe(0.08 * Math.sin(pt * 2.0));
+    }
+  }
+
+  /**
+   * SHIFT 1 INACTIVE (36-61s, 25s): Hub INACTIVE,NO SHOOTING. 3 fuel collection runs across
+   * different field zones. Ends repositioned near hub for shift 2 activation.
+   */
+  private void shift1InactivePhase(double t) {
+    double pt = t - TRANS_SHIFT_END;
+
+    if (pt < 8.0) {
+      // Run 1: Center fuel, go above hub (y > 5)
+      fuelRun(pt, 0.9, 0.8, -0.4);
+    } else if (pt < 16.0) {
+      // Run 2: Upper far fuel zone
+      fuelRun(pt - 8.0, 0.9, 0.9, -0.5);
+    } else if (pt < 22.0) {
+      // Run 3: Lower fuel, go below hub (y < 3)
+      fuelRun(pt - 16.0, 0.85, -0.9, 0.5);
+    } else {
+      // Reposition near hub scoring face
+      input.holdB(false);
+      input.driveForward(-0.7);
+      input.strafe(0.3);
+    }
+  }
+
+  /**
+   * SHIFT 2 ACTIVE (61-86s, 25s): Hub ACTIVE,rapid-fire scoring. Shooter runs continuously. 2 drive
+   * cycles sprint to fuel and back while shooter fires the whole time.
+   */
+  private void shift2ActivePhase(double t) {
+    double pt = t - SHIFT1_END;
+
+    if (pt < 3.0) {
+      // Immediate dump from pre-position, strafe for angle
+      input.driveForward(-0.1);
+      input.strafe(0.15 * Math.sin(pt * 3.0));
+    } else if (pt < 13.0) {
+      // Cycle 1: go above hub to fuel
+      activeDriveCycle(pt - 3.0, 0.9, 0.8, -0.5);
+    } else if (pt < 23.0) {
+      // Cycle 2: go below hub to fuel
+      activeDriveCycle(pt - 13.0, 0.9, -0.8, 0.5);
+    } else {
+      // Park near hub
+      input.driveForward(-0.05);
+      input.strafe(0.1 * Math.sin(pt * 2.0));
+    }
+  }
+
+  /**
+   * SHIFT 3 INACTIVE (86-111s, 25s): Hub INACTIVE,NO SHOOTING. Deep fuel collection with wider
+   * field coverage.
+   */
+  private void shift3InactivePhase(double t) {
+    double pt = t - SHIFT2_END;
+
+    if (pt < 8.0) {
+      // Run 1: Deep neutral, go below hub
+      fuelRun(pt, 0.95, -0.8, 0.5);
+    } else if (pt < 16.0) {
+      // Run 2: Upper far fuel
+      fuelRun(pt - 8.0, 0.95, 0.9, -0.4);
+    } else if (pt < 22.0) {
+      // Run 3: Lower far fuel
+      fuelRun(pt - 16.0, 0.90, -0.9, 0.5);
+    } else {
+      // Reposition near hub
+      input.holdB(false);
+      input.driveForward(-0.75);
+      input.strafe(-0.35);
+    }
+  }
+
+  /**
+   * SHIFT 4 ACTIVE (111-136s, 25s): Hub ACTIVE,aggressive scoring. Max speed cycles, battery
+   * sagging. Shooter runs continuously.
+   */
+  private void shift4ActivePhase(double t) {
+    double pt = t - SHIFT3_END;
+
+    if (pt < 3.0) {
+      // Immediate dump
+      input.driveForward(-0.1);
+      input.strafe(-0.15 * Math.sin(pt * 3.0));
+    } else if (pt < 13.0) {
+      // Cycle 1: go below hub to fuel, fast
+      activeDriveCycle(pt - 3.0, 0.95, -0.9, 0.6);
+    } else if (pt < 23.0) {
+      // Cycle 2: go above hub to fuel
+      activeDriveCycle(pt - 13.0, 0.95, 0.8, -0.5);
+    } else {
+      // Park near hub
+      input.driveForward(-0.05);
+      input.strafe(0.08 * Math.sin(pt * 2.5));
+    }
+  }
+
+  /**
+   * ENDGAME ACTIVE (136-151s, 15s): Both hubs ACTIVE. One quick drive cycle then park at hub and
+   * dump.
+   */
+  private void endgameScoringPhase(double t) {
+    double pt = t - SHIFT4_END;
+
+    if (pt < 8.0) {
+      // Quick cycle,go above hub
+      activeDriveCycle(pt, 0.9, 0.8, -0.5);
+    } else {
+      // Park at hub and dump
+      double ct = pt - 8.0;
+      if (ct < 2.0) {
+        input.driveForward(-0.85);
+        input.strafe(0.3);
+      } else {
+        input.driveForward(0);
+        input.strafe(0.08 * Math.sin(ct * 2.5));
+      }
+    }
+  }
+
+  /**
+   * HANGER CLIMB (151-166s, 15s): Sprint to Red Tower, deploy, climb. Tower near (15.5, 4.0),
+   * sprint forward (toward Red wall).
+   */
+  private void hangerPhase(double t) {
+    double pt = t - ENDGAME_SCORE_END;
+
+    if (pt < 3.5) {
+      // Sprint to tower (-fwd = toward Red wall)
+      input.driveForward(-0.95);
+      input.strafe(0);
+    } else if (pt < 4.5) {
+      input.driveForward(0);
+    } else if (pt < 11.5) {
+      // Deploy hanger
+      input.holdRightBumper(true);
+    } else {
+      // Release triggers ClimbHanger (onFalse)
+      input.holdRightBumper(false);
+    }
+  }
+
+  /**
+   * Fuel collection run (~8s) for INACTIVE shifts. Sprint to fuel (+fwd), intake, sprint partway
+   * back (-fwd). NO SHOOTING.
+   */
+  private void fuelRun(double ct, double speed, double outBias, double returnBias) {
+    if (ct < 3.0) {
+      // Sprint to fuel zone, gentle strafe (start Y=5.5 already clears hub)
+      input.driveForward(speed);
+      input.strafe(speed * 0.4 * outBias);
+    } else if (ct < 5.5) {
+      // Intake while creeping
+      input.holdB(true);
+      input.driveForward(0.25);
+      input.strafe(0.1 * outBias);
+    } else {
+      // Sprint partway back toward hub area
+      input.holdB(false);
+      input.driveForward(-speed * 0.8);
+      input.strafe(speed * 0.3 * returnBias);
+    }
+  }
+
+  /**
+   * Drive cycle during ACTIVE shift (~10s). Shooter stays running,no startShooting/stopShooting
+   * calls. Just drive and intake. Sprint to fuel (+fwd), intake, sprint to hub (-fwd), strafe.
+   */
+  private void activeDriveCycle(double ct, double speed, double outBias, double returnBias) {
+    if (ct < 2.5) {
+      // Sprint to fuel zone, gentle strafe (start Y=5.5 clears hub)
+      input.driveForward(speed);
+      input.strafe(speed * 0.4 * outBias);
+    } else if (ct < 4.5) {
+      // Intake while creeping
+      input.holdB(true);
+      input.driveForward(0.25);
+      input.strafe(0.1 * outBias);
+    } else if (ct < 7.0) {
+      // Sprint back to hub scoring face
+      input.holdB(false);
+      input.driveForward(-speed);
+      input.strafe(speed * 0.3 * returnBias);
+    } else {
+      // Near hub, strafe for shot angle variety
+      input.driveForward(-0.1);
+      input.strafe(0.12 * Math.sin(ct * 2.5));
+    }
+  }
+
+  private void startShooting() {
+    if (activeShooterCmd == null) {
+      try {
+        activeShooterCmd = new SpeedUpThenIndex();
+        CommandScheduler.getInstance().schedule(activeShooterCmd);
+      } catch (RuntimeException e) {
+        activeShooterCmd = null;
+      }
+    }
+  }
+
+  private void stopShooting() {
+    if (activeShooterCmd != null) {
+      try {
+        activeShooterCmd.cancel();
+      } catch (RuntimeException ignored) {
+      }
+      activeShooterCmd = null;
+    }
+  }
+}

--- a/src/main/java/frc/robot/sim/FaultInjectionScenario.java
+++ b/src/main/java/frc/robot/sim/FaultInjectionScenario.java
@@ -1,0 +1,193 @@
+package frc.robot.sim;
+
+import edu.wpi.first.hal.AllianceStationID;
+import edu.wpi.first.wpilibj.Timer;
+import edu.wpi.first.wpilibj.simulation.DriverStationSim;
+import edu.wpi.first.wpilibj.simulation.RoboRioSim;
+import frc.robot.telemetry.SafeLog;
+import swervelib.simulation.ironmaple.simulation.motorsims.SimulatedBattery;
+
+/**
+ * Fault injection scenario: tests brownout prediction, heavy load behavior, and recovery from
+ * degraded conditions.
+ *
+ * <p>60s total, 6 phases. Walks voltage through all 4 brownout risk levels (0=none, 1=watch,
+ * 2=warning, 3=imminent) while motors are running, then recovers.
+ *
+ * <p>Exercises: SystemHealth (brownout risk, voltage slope, CAN status), Shooter/Indexer/Intake
+ * (behavior under low voltage), AlertManager, PredictiveAlerts.
+ *
+ * <p>Launch: ./gradlew simulateJava -DsimScenario=FaultInjection
+ */
+public class FaultInjectionScenario implements SimScenario {
+  private double startTime;
+  private boolean finished = false;
+  private final SimInputPlayback input = new SimInputPlayback();
+  private int lastPhase = -1;
+
+  @Override
+  public String getName() {
+    return "FaultInjection";
+  }
+
+  @Override
+  public void init() {
+    startTime = Timer.getFPGATimestamp();
+    finished = false;
+    lastPhase = -1;
+    input.releaseAll();
+    SimulatedBattery.disableBatterySim(); // prevent MapleSim from overwriting our voltage ramp
+    RoboRioSim.setVInVoltage(12.5);
+    DriverStationSim.setAllianceStationId(AllianceStationID.Red1);
+    DriverStationSim.notifyNewData();
+  }
+
+  @Override
+  public void execute(double timestampSec) {
+    double t = timestampSec - startTime;
+    int phase = getPhase(t);
+
+    if (phase != lastPhase) {
+      SafeLog.put("Sim/FaultInject/Phase", phase);
+      SafeLog.put("Sim/FaultInject/PhaseName", phaseName(phase));
+      lastPhase = phase;
+      onPhaseEnter(phase);
+    }
+
+    onPhaseUpdate(phase, t);
+
+    SafeLog.put("Sim/FaultInject/ElapsedSec", t);
+    SafeLog.put("Sim/FaultInject/Progress", Math.min(100, (t / 60.0) * 100));
+
+    if (t >= 60.0) {
+      input.releaseAll();
+      DriverStationSim.setEnabled(false);
+      DriverStationSim.notifyNewData();
+      finished = true;
+    }
+  }
+
+  @Override
+  public boolean isFinished() {
+    return finished;
+  }
+
+  private int getPhase(double t) {
+    if (t < 5) return 0; // Healthy baseline
+    if (t < 15) return 1; // Gradual voltage drop to 10V (risk level 0→1)
+    if (t < 25) return 2; // Deep voltage drop to 8V (risk level 2→3)
+    if (t < 30) return 3; // Hold at critical (7.5V),brownout imminent
+    if (t < 40) return 4; // Recovery ramp back to 12.5V
+    if (t < 55) return 5; // Heavy load: all motors + moderate voltage (10.5V)
+    return 6; // Final recovery + disable
+  }
+
+  private String phaseName(int phase) {
+    switch (phase) {
+      case 0:
+        return "HealthyBaseline";
+      case 1:
+        return "GradualDrop";
+      case 2:
+        return "DeepDrop";
+      case 3:
+        return "CriticalHold";
+      case 4:
+        return "Recovery";
+      case 5:
+        return "HeavyLoad";
+      case 6:
+        return "FinalRecovery";
+      default:
+        return "Unknown";
+    }
+  }
+
+  private void onPhaseEnter(int phase) {
+    switch (phase) {
+      case 0: // Healthy baseline,enable teleop, start shooter
+        DriverStationSim.setAutonomous(false);
+        DriverStationSim.setEnabled(true);
+        DriverStationSim.setMatchTime(135.0);
+        DriverStationSim.notifyNewData();
+        input.holdA(true); // spin shooter for baseline
+        break;
+
+      case 1: // Gradual drop,keep shooting
+        break;
+
+      case 2: // Deep drop,motors struggling
+        break;
+
+      case 3: // Critical hold,worst case
+        break;
+
+      case 4: // Recovery,release motors, ramp voltage back
+        input.releaseAll();
+        break;
+
+      case 5: // Heavy load,all motors at reduced voltage
+        input.holdA(true); // shooter
+        input.holdY(true); // indexer
+        input.driveForward(0.8); // drive hard
+        break;
+
+      case 6: // Final recovery
+        input.releaseAll();
+        break;
+    }
+  }
+
+  private void onPhaseUpdate(int phase, double t) {
+    switch (phase) {
+      case 0: // Healthy: 12.5V steady
+        RoboRioSim.setVInVoltage(12.5);
+        break;
+
+      case 1: // Gradual: 12.5V → 10V over 10s
+        // Slope: -0.25 V/s,should trigger risk level 0, maybe 1
+        double dropT = t - 5.0;
+        double dropProgress = Math.min(1.0, dropT / 10.0);
+        RoboRioSim.setVInVoltage(12.5 - (2.5 * dropProgress));
+        DriverStationSim.setMatchTime(135.0 - t);
+        DriverStationSim.notifyNewData();
+        break;
+
+      case 2: // Deep: 10V → 8V over 10s
+        // Slope: -0.2 V/s,risk level 1→2→3 as voltage crosses thresholds
+        double deepT = t - 15.0;
+        double deepProgress = Math.min(1.0, deepT / 10.0);
+        RoboRioSim.setVInVoltage(10.0 - (2.0 * deepProgress));
+        DriverStationSim.setMatchTime(135.0 - t);
+        DriverStationSim.notifyNewData();
+        break;
+
+      case 3: // Critical: hold at 7.5V
+        // With motors running and slope < -2 V/s initially, risk level 3
+        RoboRioSim.setVInVoltage(7.5);
+        DriverStationSim.setMatchTime(135.0 - t);
+        DriverStationSim.notifyNewData();
+        break;
+
+      case 4: // Recovery: 7.5V → 12.5V over 10s
+        double recovT = t - 30.0;
+        double recovProgress = Math.min(1.0, recovT / 10.0);
+        RoboRioSim.setVInVoltage(7.5 + (5.0 * recovProgress));
+        DriverStationSim.setMatchTime(135.0 - t);
+        DriverStationSim.notifyNewData();
+        break;
+
+      case 5: // Heavy load: moderate voltage (10.5V) with all motors
+        // All 3 motors running draws high current at reduced voltage
+        RoboRioSim.setVInVoltage(10.5);
+        input.rotate(0.3); // add rotation too
+        DriverStationSim.setMatchTime(135.0 - t);
+        DriverStationSim.notifyNewData();
+        break;
+
+      case 6: // Final: restore healthy voltage
+        RoboRioSim.setVInVoltage(12.5);
+        break;
+    }
+  }
+}

--- a/src/main/java/frc/robot/sim/FullVideoShowcaseScenario.java
+++ b/src/main/java/frc/robot/sim/FullVideoShowcaseScenario.java
@@ -1,0 +1,547 @@
+package frc.robot.sim;
+
+import static frc.robot.Constants.HubScoringConstants.*;
+
+import edu.wpi.first.hal.AllianceStationID;
+import edu.wpi.first.math.geometry.Pose2d;
+import edu.wpi.first.math.geometry.Rotation2d;
+import edu.wpi.first.math.geometry.Translation2d;
+import edu.wpi.first.wpilibj.Timer;
+import edu.wpi.first.wpilibj.simulation.DriverStationSim;
+import edu.wpi.first.wpilibj.simulation.RoboRioSim;
+import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
+import edu.wpi.first.wpilibj2.command.Command;
+import edu.wpi.first.wpilibj2.command.CommandScheduler;
+import frc.robot.RobotContainer;
+import frc.robot.commands.HubArcDrive;
+import frc.robot.commands.SpeedUpThenIndex;
+import frc.robot.telemetry.SafeLog;
+import swervelib.simulation.ironmaple.simulation.motorsims.SimulatedBattery;
+
+/**
+ * Full 169s match for video recording that maximizes telemetry coverage.
+ *
+ * <p>Merges CompetitionMatch (full match structure, hub shifts, hanger climb) with VideoDemo
+ * (HubArcDrive orbit during active shifts).
+ *
+ * <p>Stays on the Red alliance side,no bump/ramp crossing (MapleSim collision body blocks the path,
+ * see Arena2026Rebuilt.java).
+ *
+ * <p>Hub shift logic (WonAuto=true, Red Alliance): Transition shift (matchTime 140-130): ACTIVE,
+ * close arc orbit Shift 1 (130-105): INACTIVE,3 fuel collection runs Shift 2 (105-80): ACTIVE, far
+ * arc orbit (visual variety) Shift 3 (80-55): INACTIVE,3 fuel collection runs Shift 4 (55-30):
+ * ACTIVE,close arc orbit Endgame (<=30): ACTIVE,far arc + final dump
+ *
+ * <p>Active shifts alternate close (1.06m) and far (2.0m) arc distances. Inactive shifts do fuel
+ * collection runs with intake deploy/retract.
+ *
+ * <p>Drive mapping (Red alliance + allianceRelativeControl): driveForward(+) = toward BLUE side
+ * (field -X) = toward fuel driveForward(-) = toward RED wall (field +X) = toward hub strafe(+) =
+ * field +Y = away from centerline
+ *
+ * <p>Launch: ./gradlew simulateJava -DsimScenario=FullVideoShowcase
+ */
+public class FullVideoShowcaseScenario implements SimScenario {
+  private double startTime;
+  private boolean finished = false;
+  private final SimInputPlayback input = new SimInputPlayback();
+  private int lastPhase = -1;
+
+  private Command arcDriveCmd = null;
+  private Command shooterCmd = null;
+
+  private static final double CLOSE_ARC = SCORING_DISTANCE; // 1.06m
+  private static final double FAR_ARC = 2.0;
+
+  // Phase boundaries,matches CompetitionMatch hub shift timing
+  private static final double PRE_MATCH_END = 3.0;
+  private static final double AUTO_END = 23.0; // 20s auto
+  private static final double DISABLED_END = 26.0; // 3s disabled transition
+  private static final double TRANS_SHIFT_END = 36.0; // 10s transition (ACTIVE)
+  private static final double SHIFT1_END = 61.0; // 25s shift 1 (INACTIVE)
+  private static final double SHIFT2_END = 86.0; // 25s shift 2 (ACTIVE)
+  private static final double SHIFT3_END = 111.0; // 25s shift 3 (INACTIVE)
+  private static final double SHIFT4_END = 136.0; // 25s shift 4 (ACTIVE)
+  private static final double ENDGAME_SCORE_END = 151.0; // 15s endgame (ACTIVE)
+  private static final double HANGER_END = 166.0; // 15s hanger climb
+  private static final double SCENARIO_END = 169.0; // 3s post-match
+
+  @Override
+  public String getName() {
+    return "FullVideoShowcase";
+  }
+
+  @Override
+  public void init() {
+    startTime = Timer.getFPGATimestamp();
+    finished = false;
+    lastPhase = -1;
+    arcDriveCmd = null;
+    shooterCmd = null;
+    input.releaseAll();
+
+    SimulatedBattery.disableBatterySim();
+    RoboRioSim.setVInVoltage(12.8);
+    SmartDashboard.putBoolean("WonAuto", false);
+    DriverStationSim.setAllianceStationId(AllianceStationID.Red1);
+    DriverStationSim.notifyNewData();
+
+    // Red alliance start,Y=5.5 naturally clears hub at Y=4.0
+    try {
+      RobotContainer rc = RobotContainer.getInstance();
+      if (rc != null) {
+        Pose2d startPose = new Pose2d(new Translation2d(15.0, 5.5), Rotation2d.fromDegrees(180));
+        rc.getSwerveSubsystem().resetOdometry(startPose);
+      }
+    } catch (RuntimeException e) {
+      SafeLog.put("Sim/FullShowcase/InitError", e.getClass().getSimpleName());
+    }
+  }
+
+  @Override
+  public void execute(double timestampSec) {
+    double t = timestampSec - startTime;
+    int phase = getPhase(t);
+
+    if (phase != lastPhase) {
+      SafeLog.put("Sim/FullShowcase/Phase", phase);
+      SafeLog.put("Sim/FullShowcase/PhaseName", phaseName(phase));
+      lastPhase = phase;
+      onPhaseEnter(phase);
+    }
+
+    onPhaseUpdate(phase, t);
+
+    SafeLog.put("Sim/FullShowcase/ElapsedSec", t);
+    SafeLog.put("Sim/FullShowcase/Progress", Math.min(100, (t / SCENARIO_END) * 100));
+
+    // Debug trace every ~1s via telemetry (not println)
+    if (((int) (t * 50)) % 50 == 0) {
+      double matchTime = phase == 1 ? 20.0 - (t - PRE_MATCH_END) : 140.0 - (t - DISABLED_END);
+      SafeLog.put("Sim/FullShowcase/MatchTime", matchTime);
+    }
+
+    if (t >= SCENARIO_END) {
+      stopAll();
+      input.releaseAll();
+      DriverStationSim.setEnabled(false);
+      DriverStationSim.notifyNewData();
+      finished = true;
+    }
+  }
+
+  @Override
+  public boolean isFinished() {
+    return finished;
+  }
+
+  private int getPhase(double t) {
+    if (t < PRE_MATCH_END) return 0;
+    if (t < AUTO_END) return 1;
+    if (t < DISABLED_END) return 2;
+    if (t < TRANS_SHIFT_END) return 3;
+    if (t < SHIFT1_END) return 4;
+    if (t < SHIFT2_END) return 5;
+    if (t < SHIFT3_END) return 6;
+    if (t < SHIFT4_END) return 7;
+    if (t < ENDGAME_SCORE_END) return 8;
+    if (t < HANGER_END) return 9;
+    return 10;
+  }
+
+  private String phaseName(int phase) {
+    switch (phase) {
+      case 0:
+        return "PreMatch";
+      case 1:
+        return "Auto";
+      case 2:
+        return "Disabled";
+      case 3:
+        return "TransShift_ACTIVE";
+      case 4:
+        return "Shift1_INACTIVE";
+      case 5:
+        return "Shift2_ACTIVE";
+      case 6:
+        return "Shift3_INACTIVE";
+      case 7:
+        return "Shift4_ACTIVE";
+      case 8:
+        return "Endgame_ACTIVE";
+      case 9:
+        return "HangerClimb";
+      case 10:
+        return "PostMatch";
+      default:
+        return "Unknown";
+    }
+  }
+
+  private void onPhaseEnter(int phase) {
+    input.driveForward(0);
+    input.strafe(0);
+    input.rotate(0);
+    input.holdB(false);
+    input.holdRightBumper(false);
+
+    switch (phase) {
+      case 0: // Pre-match disabled
+        input.releaseAll();
+        DriverStationSim.setEnabled(false);
+        DriverStationSim.setAutonomous(false);
+        DriverStationSim.notifyNewData();
+        break;
+
+      case 1: // Autonomous
+        DriverStationSim.setAutonomous(true);
+        DriverStationSim.setEnabled(true);
+        DriverStationSim.setMatchTime(20.0);
+        DriverStationSim.notifyNewData();
+        break;
+
+      case 2: // Disabled transition
+        stopAll();
+        input.releaseAll();
+        DriverStationSim.setEnabled(false);
+        DriverStationSim.setAutonomous(false);
+        DriverStationSim.notifyNewData();
+        break;
+
+      case 3: // Transition shift ACTIVE,close arc
+        DriverStationSim.setAutonomous(false);
+        DriverStationSim.setEnabled(true);
+        SmartDashboard.putBoolean("WonAuto", true);
+        DriverStationSim.setMatchTime(140.0);
+        DriverStationSim.notifyNewData();
+        startArcDrive(CLOSE_ARC);
+        startShooting();
+        break;
+
+      case 4: // Shift 1 INACTIVE,fuel collection
+        stopAll();
+        break;
+
+      case 5: // Shift 2 ACTIVE,far arc (visual variety)
+        startArcDrive(FAR_ARC);
+        startShooting();
+        break;
+
+      case 6: // Shift 3 INACTIVE,fuel collection
+        stopAll();
+        break;
+
+      case 7: // Shift 4 ACTIVE,close arc
+        startArcDrive(CLOSE_ARC);
+        startShooting();
+        break;
+
+      case 8: // Endgame ACTIVE,far arc
+        startArcDrive(FAR_ARC);
+        startShooting();
+        break;
+
+      case 9: // Hanger climb
+        stopAll();
+        break;
+
+      case 10: // Post-match
+        stopAll();
+        input.releaseAll();
+        DriverStationSim.setEnabled(false);
+        DriverStationSim.notifyNewData();
+        break;
+    }
+  }
+
+  private void onPhaseUpdate(int phase, double t) {
+    // Match time countdown
+    if (phase == 1) {
+      DriverStationSim.setMatchTime(Math.max(0, 20.0 - (t - PRE_MATCH_END)));
+      DriverStationSim.notifyNewData();
+    } else if (phase >= 3 && phase <= 9) {
+      double matchTime = 140.0 - (t - DISABLED_END);
+      DriverStationSim.setMatchTime(Math.max(0, matchTime));
+      DriverStationSim.notifyNewData();
+    }
+
+    // Battery sag: 12.8V -> 11.2V over teleop (steeper than VideoDemo)
+    if (phase >= 3 && phase <= 9) {
+      double pct = (t - DISABLED_END) / (HANGER_END - DISABLED_END);
+      RoboRioSim.setVInVoltage(Math.max(11.2, 12.8 - pct * 1.6));
+    }
+
+    switch (phase) {
+      case 1:
+        autoPhase(t);
+        break;
+      case 3:
+        activeArcPhase(t, DISABLED_END, CLOSE_ARC);
+        break;
+      case 4:
+        inactiveFuelPhase(t, TRANS_SHIFT_END);
+        break;
+      case 5:
+        activeArcWithFuelPhase(t, SHIFT1_END, FAR_ARC);
+        break;
+      case 6:
+        inactiveFuelPhase(t, SHIFT2_END);
+        break;
+      case 7:
+        activeArcWithFuelPhase(t, SHIFT3_END, CLOSE_ARC);
+        break;
+      case 8:
+        endgamePhase(t);
+        break;
+      case 9:
+        hangerPhase(t);
+        break;
+    }
+  }
+
+  /**
+   * AUTO (3-23s, 20s): Sprint from Red wall toward hub area, shoot, grab fuel, sprint back, shoot
+   * more. No arc drive in auto (no teleop command scheduler).
+   */
+  private void autoPhase(double t) {
+    double at = t - PRE_MATCH_END;
+
+    if (at < 2.0) {
+      // Sprint from Red wall (Y=5.5 clears hub at Y=4.0)
+      input.driveForward(0.95);
+      input.strafe(0.15);
+      startShooting();
+    } else if (at < 5.0) {
+      // Near hub area, shooting while drifting
+      input.driveForward(0.1);
+      input.strafe(-0.15 + 0.1 * Math.sin(at * 2.0));
+    } else if (at < 8.0) {
+      // Sprint to fuel zone, deploy intake
+      input.driveForward(0.9);
+      input.strafe(0.2);
+      input.holdB(true);
+    } else if (at < 10.0) {
+      // Creep through fuel
+      input.holdB(true);
+      input.driveForward(0.2);
+      input.strafe(0.1);
+    } else if (at < 14.0) {
+      // Sprint back toward hub
+      input.holdB(false);
+      input.driveForward(-0.9);
+      input.strafe(-0.25);
+    } else {
+      // Park near hub, strafing
+      input.driveForward(-0.05);
+      input.strafe(-0.08 + 0.1 * Math.sin(at * 1.5));
+    }
+  }
+
+  /**
+   * ACTIVE ARC PHASE (10s transition shift): Pure arc orbit + shooting. No fuel runs,just orbit the
+   * hub for the full duration.
+   */
+  private void activeArcPhase(double t, double phaseStart, double arcDist) {
+    double pt = t - phaseStart;
+    // Smooth oscillating strafe drives the arc sweep
+    input.strafe(Math.sin(pt * 0.4) * 0.5);
+  }
+
+  /**
+   * ACTIVE ARC WITH FUEL (25s shifts): Alternates between arc orbit (shooting) and fuel runs
+   * (intake). More dynamic than pure arc.
+   *
+   * <p>0-8s: Arc orbit with shooting 8-18s: Fuel run cycle (stop arc, intake, return) 18-25s:
+   * Resume arc orbit with shooting
+   */
+  private void activeArcWithFuelPhase(double t, double phaseStart, double arcDist) {
+    double pt = t - phaseStart;
+
+    if (pt < 8.0) {
+      // Arc orbit phase,strafe oscillation
+      input.strafe(Math.sin(pt * 0.4) * 0.5);
+    } else if (pt < 18.0) {
+      // Fuel run,temporarily stop arc drive for default drive
+      double ft = pt - 8.0;
+      if (ft < 0.1) {
+        // Cancel arc drive to free swerve for default drive
+        stopArcDrive();
+      }
+      if (ft < 3.0) {
+        // Sprint to fuel (above hub Y=5.5 clears hub)
+        input.driveForward(0.9);
+        input.strafe(0.3);
+        input.holdB(true);
+      } else if (ft < 5.5) {
+        // Creep through fuel zone
+        input.holdB(true);
+        input.driveForward(0.25);
+        input.strafe(0.1);
+      } else if (ft < 8.5) {
+        // Sprint back to hub area
+        input.holdB(false);
+        input.driveForward(-0.9);
+        input.strafe(-0.3);
+      } else {
+        // Settle near hub for arc resumption
+        input.driveForward(-0.05);
+        input.strafe(0.08 * Math.sin(ft * 2.0));
+      }
+    } else {
+      // Resume arc orbit
+      double at = pt - 18.0;
+      if (at < 0.1) {
+        startArcDrive(arcDist);
+      }
+      input.strafe(Math.sin(at * 0.45) * 0.55);
+    }
+  }
+
+  /**
+   * INACTIVE FUEL PHASE (25s): Hub INACTIVE,no shooting. 3 fuel collection runs across different
+   * field zones.
+   */
+  private void inactiveFuelPhase(double t, double phaseStart) {
+    double pt = t - phaseStart;
+
+    if (pt < 8.0) {
+      // Run 1: above hub (Y > 5)
+      fuelRun(pt, 0.9, 0.8, -0.4);
+    } else if (pt < 16.0) {
+      // Run 2: upper far fuel
+      fuelRun(pt - 8.0, 0.9, 0.9, -0.5);
+    } else if (pt < 22.0) {
+      // Run 3: below hub (Y < 3)
+      fuelRun(pt - 16.0, 0.85, -0.9, 0.5);
+    } else {
+      // Reposition near hub for next active shift
+      input.holdB(false);
+      input.driveForward(-0.7);
+      input.strafe(0.3);
+    }
+  }
+
+  /**
+   * ENDGAME (136-151s, 15s): Both hubs ACTIVE. Quick fuel run then arc orbit dump before hanger
+   * climb.
+   */
+  private void endgamePhase(double t) {
+    double pt = t - SHIFT4_END;
+
+    if (pt < 6.0) {
+      // Quick fuel grab
+      stopArcDrive();
+      if (pt < 2.5) {
+        input.driveForward(0.9);
+        input.strafe(0.3);
+        input.holdB(true);
+      } else if (pt < 4.0) {
+        input.holdB(true);
+        input.driveForward(0.2);
+      } else {
+        input.holdB(false);
+        input.driveForward(-0.9);
+        input.strafe(-0.3);
+      }
+    } else {
+      // Final arc orbit dump
+      double at = pt - 6.0;
+      if (at < 0.1) {
+        startArcDrive(FAR_ARC);
+      }
+      input.strafe(Math.sin(at * 0.5) * 0.6);
+    }
+  }
+
+  /** HANGER CLIMB (151-166s, 15s): Sprint to Red Tower, deploy, climb. */
+  private void hangerPhase(double t) {
+    double pt = t - ENDGAME_SCORE_END;
+
+    if (pt < 3.5) {
+      // Sprint to tower (-fwd = toward Red wall)
+      input.driveForward(-0.95);
+      input.strafe(0);
+    } else if (pt < 4.5) {
+      input.driveForward(0);
+    } else if (pt < 11.5) {
+      // Deploy hanger
+      input.holdRightBumper(true);
+    } else {
+      // Release triggers ClimbHanger (onFalse)
+      input.holdRightBumper(false);
+    }
+  }
+
+  /**
+   * Fuel collection run (~8s) for INACTIVE shifts. Sprint to fuel, intake, sprint partway back. NO
+   * SHOOTING.
+   */
+  private void fuelRun(double ct, double speed, double outBias, double returnBias) {
+    if (ct < 3.0) {
+      input.driveForward(speed);
+      input.strafe(speed * 0.4 * outBias);
+    } else if (ct < 5.5) {
+      input.holdB(true);
+      input.driveForward(0.25);
+      input.strafe(0.1 * outBias);
+    } else {
+      input.holdB(false);
+      input.driveForward(-speed * 0.8);
+      input.strafe(speed * 0.3 * returnBias);
+    }
+  }
+
+  private void startArcDrive(double distance) {
+    stopArcDrive(); // cancel any existing arc first
+    try {
+      RobotContainer rc = RobotContainer.getInstance();
+      if (rc == null) return;
+      var swerve = rc.getSwerveSubsystem();
+      arcDriveCmd =
+          new HubArcDrive(
+              swerve, SimDriveOverride::getX, RED_HUB_CENTER, distance, RED_SCORING_SIDE);
+      CommandScheduler.getInstance().schedule(arcDriveCmd);
+    } catch (RuntimeException e) {
+      SafeLog.put("Sim/FullShowcase/ArcError", e.getClass().getSimpleName());
+    }
+  }
+
+  private void stopArcDrive() {
+    if (arcDriveCmd != null) {
+      try {
+        arcDriveCmd.cancel();
+      } catch (RuntimeException ignored) {
+      }
+      arcDriveCmd = null;
+    }
+  }
+
+  private void startShooting() {
+    if (shooterCmd == null) {
+      try {
+        shooterCmd = new SpeedUpThenIndex();
+        CommandScheduler.getInstance().schedule(shooterCmd);
+      } catch (RuntimeException e) {
+        shooterCmd = null;
+      }
+    }
+  }
+
+  private void stopShooting() {
+    if (shooterCmd != null) {
+      try {
+        shooterCmd.cancel();
+      } catch (RuntimeException ignored) {
+      }
+      shooterCmd = null;
+    }
+  }
+
+  private void stopAll() {
+    stopArcDrive();
+    stopShooting();
+    input.driveForward(0);
+    input.strafe(0);
+    input.rotate(0);
+  }
+}

--- a/src/main/java/frc/robot/sim/HubShiftPracticeScenario.java
+++ b/src/main/java/frc/robot/sim/HubShiftPracticeScenario.java
@@ -1,0 +1,209 @@
+package frc.robot.sim;
+
+import edu.wpi.first.hal.AllianceStationID;
+import edu.wpi.first.wpilibj.Timer;
+import edu.wpi.first.wpilibj.simulation.DriverStationSim;
+import edu.wpi.first.wpilibj.simulation.RoboRioSim;
+import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
+import frc.robot.telemetry.SafeLog;
+import swervelib.simulation.ironmaple.simulation.motorsims.SimulatedBattery;
+
+/**
+ * Hub shift practice scenario for driver training. Runs a full teleop period (140s) with real-time
+ * match clock countdown so the driver can feel all hub shift haptics:
+ *
+ * <ul>
+ *   <li>HUB_ACTIVATED: hub becomes active (right-only pulse)
+ *   <li>HUB_DEACTIVATED: hub becomes inactive (left-only buzz)
+ *   <li>HUB_SHIFT_WARNING: 2.5s before each shift boundary (triple pulse)
+ * </ul>
+ *
+ * <p>Hub shift schedule (REBUILT Section 6.4):
+ *
+ * <pre>
+ *   Transition (140-130): BOTH ACTIVE
+ *   Shift 1 (130-105): Winner INACTIVE, Loser ACTIVE
+ *   Shift 2 (105-80):  Winner ACTIVE, Loser INACTIVE
+ *   Shift 3 (80-55):   Winner INACTIVE, Loser ACTIVE
+ *   Shift 4 (55-30):   Winner ACTIVE, Loser INACTIVE
+ *   Endgame (30-0):    BOTH ACTIVE
+ * </pre>
+ *
+ * <p>Dashboard controls (SmartDashboard):
+ *
+ * <ul>
+ *   <li>HubPractice/WonAuto (boolean): toggle alliance parity (default true = Red won auto)
+ *   <li>HubPractice/TimeScale (double): countdown speed multiplier (default 1.0, set 3.0 for 3x
+ *       fast)
+ *   <li>HubPractice/Restart (boolean): toggle to restart the countdown from 140s
+ * </ul>
+ *
+ * <p>Logged signals for dashboard:
+ *
+ * <ul>
+ *   <li>HubPractice/SimMatchTime: current simulated match time
+ *   <li>HubPractice/ShiftLabel: human-readable shift name
+ *   <li>HubPractice/Countdown: seconds until next shift boundary
+ * </ul>
+ *
+ * <p>Launch: ./gradlew simulateJava -DsimScenario=HubShiftPractice
+ */
+public class HubShiftPracticeScenario implements SimScenario {
+  private double startTime;
+  private double lastUpdateTime;
+  private double simMatchTime; // counts down from 140
+  private boolean finished = false;
+  private String lastShiftLabel = "";
+
+  // Hub shift boundaries (match time, descending)
+  private static final double TELEOP_START = 140.0;
+  private static final double SHIFT_1_START = 130.0;
+  private static final double SHIFT_2_START = 105.0;
+  private static final double SHIFT_3_START = 80.0;
+  private static final double SHIFT_4_START = 55.0;
+  private static final double ENDGAME_START = 30.0;
+
+  // Setup delay before teleop enable
+  private static final double SETUP_DELAY = 2.0;
+
+  @Override
+  public String getName() {
+    return "HubShiftPractice";
+  }
+
+  @Override
+  public void init() {
+    startTime = Timer.getFPGATimestamp();
+    lastUpdateTime = startTime;
+    simMatchTime = TELEOP_START;
+    finished = false;
+    lastShiftLabel = "";
+
+    SimulatedBattery.disableBatterySim();
+    RoboRioSim.setVInVoltage(12.8);
+
+    // Dashboard controls with defaults
+    SmartDashboard.putBoolean("HubPractice/WonAuto", true);
+    SmartDashboard.putNumber("HubPractice/TimeScale", 1.0);
+    SmartDashboard.putBoolean("HubPractice/Restart", false);
+
+    // Set alliance (Red1, wonAuto=true means Red won auto)
+    DriverStationSim.setAllianceStationId(AllianceStationID.Red1);
+
+    // Start disabled briefly, then enable teleop
+    DriverStationSim.setEnabled(false);
+    DriverStationSim.setAutonomous(false);
+    DriverStationSim.setTest(false);
+    DriverStationSim.notifyNewData();
+
+    SafeLog.put("HubPractice/SimMatchTime", simMatchTime);
+    SafeLog.put("HubPractice/ShiftLabel", "SETUP");
+    SafeLog.put("HubPractice/Countdown", 0.0);
+  }
+
+  @Override
+  public void execute(double timestampSec) {
+    double wallElapsed = timestampSec - startTime;
+
+    // Setup phase: wait briefly, then enable teleop
+    if (wallElapsed < SETUP_DELAY) {
+      SafeLog.put("HubPractice/ShiftLabel", "SETUP");
+      return;
+    }
+
+    // Enable teleop on first frame after setup
+    if (!DriverStationSim.getEnabled()) {
+      DriverStationSim.setEnabled(true);
+      DriverStationSim.setAutonomous(false);
+      DriverStationSim.notifyNewData();
+      lastUpdateTime = timestampSec;
+    }
+
+    // Check for restart toggle
+    boolean restart = SmartDashboard.getBoolean("HubPractice/Restart", false);
+    if (restart) {
+      SmartDashboard.putBoolean("HubPractice/Restart", false);
+      simMatchTime = TELEOP_START;
+      lastUpdateTime = timestampSec;
+    }
+
+    // Read dashboard controls
+    double timeScale = SmartDashboard.getNumber("HubPractice/TimeScale", 1.0);
+    timeScale = Math.max(0.25, Math.min(10.0, timeScale)); // clamp to [0.25, 10]
+    boolean wonAuto = SmartDashboard.getBoolean("HubPractice/WonAuto", true);
+
+    // Advance match time countdown
+    double dt = timestampSec - lastUpdateTime;
+    lastUpdateTime = timestampSec;
+    simMatchTime -= dt * timeScale;
+
+    // Loop: when match time hits 0, restart from 140
+    if (simMatchTime <= 0) {
+      simMatchTime = TELEOP_START;
+    }
+
+    // Push simulated match time to DriverStation
+    DriverStationSim.setMatchTime(simMatchTime);
+    SmartDashboard.putBoolean("WonAuto", wonAuto);
+    DriverStationSim.notifyNewData();
+
+    // Compute shift label and countdown for dashboard
+    String shiftLabel = computeShiftLabel(simMatchTime, wonAuto);
+    double countdown = computeCountdown(simMatchTime);
+
+    // Log for dashboard display
+    SafeLog.put("HubPractice/SimMatchTime", simMatchTime);
+    SafeLog.put("HubPractice/ShiftLabel", shiftLabel);
+    SafeLog.put("HubPractice/Countdown", countdown);
+
+    // Log phase transitions
+    if (!shiftLabel.equals(lastShiftLabel)) {
+      SafeLog.put("HubPractice/PreviousShift", lastShiftLabel);
+      lastShiftLabel = shiftLabel;
+    }
+  }
+
+  @Override
+  public boolean isFinished() {
+    return finished;
+  }
+
+  private String computeShiftLabel(double matchTime, boolean wonAuto) {
+    if (matchTime > SHIFT_1_START) {
+      return "TRANSITION (BOTH ACTIVE)";
+    }
+    int shift = computeShiftNumber(matchTime);
+    boolean hubActive = computeHubActive(matchTime, wonAuto);
+    if (matchTime <= ENDGAME_START) {
+      return "ENDGAME (BOTH ACTIVE)";
+    }
+    return "SHIFT " + shift + (hubActive ? " (YOUR HUB ACTIVE)" : " (YOUR HUB INACTIVE)");
+  }
+
+  private double computeCountdown(double matchTime) {
+    if (matchTime > SHIFT_1_START) return matchTime - SHIFT_1_START;
+    if (matchTime > SHIFT_2_START) return matchTime - SHIFT_2_START;
+    if (matchTime > SHIFT_3_START) return matchTime - SHIFT_3_START;
+    if (matchTime > SHIFT_4_START) return matchTime - SHIFT_4_START;
+    if (matchTime > ENDGAME_START) return matchTime - ENDGAME_START;
+    return matchTime; // countdown to end of match
+  }
+
+  private int computeShiftNumber(double matchTime) {
+    if (matchTime > SHIFT_1_START) return 0;
+    if (matchTime > SHIFT_2_START) return 1;
+    if (matchTime > SHIFT_3_START) return 2;
+    if (matchTime > SHIFT_4_START) return 3;
+    if (matchTime > ENDGAME_START) return 4;
+    return 5;
+  }
+
+  private boolean computeHubActive(double matchTime, boolean wonAuto) {
+    if (matchTime > SHIFT_1_START || matchTime <= ENDGAME_START) {
+      return true; // transition or endgame
+    }
+    int shift = computeShiftNumber(matchTime);
+    boolean oddShift = (shift % 2 == 1);
+    return wonAuto ? !oddShift : oddShift;
+  }
+}

--- a/src/main/java/frc/robot/sim/RapidFireScenario.java
+++ b/src/main/java/frc/robot/sim/RapidFireScenario.java
@@ -1,0 +1,146 @@
+package frc.robot.sim;
+
+import edu.wpi.first.hal.AllianceStationID;
+import edu.wpi.first.wpilibj.Timer;
+import edu.wpi.first.wpilibj.simulation.DriverStationSim;
+import edu.wpi.first.wpilibj.simulation.RoboRioSim;
+import frc.robot.telemetry.SafeLog;
+import swervelib.simulation.ironmaple.simulation.motorsims.SimulatedBattery;
+
+/**
+ * Rapid-fire scenario: pre-spins shooter then fires via SpeedUpThenIndex in fast 1.5s cycles.
+ * Exercises Shooter, Indexer signals.
+ *
+ * <p>13s total, 3 phases. Previously broken,never enabled the robot.
+ *
+ * <p>Launch: ./gradlew simulateJava -DsimScenario=RapidFire
+ */
+public class RapidFireScenario implements SimScenario {
+  private double startTime;
+  private boolean finished = false;
+  private final SimInputPlayback input = new SimInputPlayback();
+  private int lastPhase = -1;
+  private int shotCount = 0;
+  private boolean xPressed = false;
+
+  private static final double CYCLE_PERIOD = 1.5;
+  private static final double SPIN_TIME = 1.0;
+  private static final double FIRE_TIME = 0.3;
+
+  @Override
+  public String getName() {
+    return "RapidFire";
+  }
+
+  @Override
+  public void init() {
+    startTime = Timer.getFPGATimestamp();
+    finished = false;
+    lastPhase = -1;
+    shotCount = 0;
+    xPressed = false;
+    input.releaseAll();
+    SimulatedBattery.disableBatterySim(); // prevent MapleSim from overwriting our voltage ramp
+    RoboRioSim.setVInVoltage(12.5);
+    DriverStationSim.setAllianceStationId(AllianceStationID.Red1);
+    DriverStationSim.notifyNewData();
+  }
+
+  @Override
+  public void execute(double timestampSec) {
+    double t = timestampSec - startTime;
+    int phase = getPhase(t);
+
+    if (phase != lastPhase) {
+      SafeLog.put("Sim/RapidFire/Phase", phase);
+      SafeLog.put("Sim/RapidFire/PhaseName", phaseName(phase));
+      lastPhase = phase;
+      onPhaseEnter(phase);
+    }
+
+    onPhaseUpdate(phase, t);
+
+    SafeLog.put("Sim/RapidFire/ElapsedSec", t);
+    SafeLog.put("Sim/RapidFireShots", shotCount);
+    SafeLog.put("Sim/RapidFireRate", t > 0 ? shotCount / t : 0);
+    SafeLog.put("Sim/RapidFireProgress", Math.min(100, (t / 13.0) * 100));
+
+    if (t >= 13.0) {
+      input.releaseAll();
+      DriverStationSim.setEnabled(false);
+      DriverStationSim.notifyNewData();
+      finished = true;
+    }
+  }
+
+  @Override
+  public boolean isFinished() {
+    return finished;
+  }
+
+  private int getPhase(double t) {
+    if (t < 2) return 0; // Enable + pre-spin
+    if (t < 12) return 1; // Rapid fire cycles
+    return 2; // Release + disable
+  }
+
+  private String phaseName(int phase) {
+    switch (phase) {
+      case 0:
+        return "PreSpin";
+      case 1:
+        return "RapidFire";
+      case 2:
+        return "Disable";
+      default:
+        return "Unknown";
+    }
+  }
+
+  private void onPhaseEnter(int phase) {
+    switch (phase) {
+      case 0: // Enable teleop + pre-spin shooter
+        DriverStationSim.setAutonomous(false);
+        DriverStationSim.setEnabled(true);
+        DriverStationSim.setMatchTime(135.0);
+        DriverStationSim.notifyNewData();
+        input.holdA(true);
+        break;
+
+      case 2: // Disable
+        input.releaseAll();
+        DriverStationSim.setEnabled(false);
+        DriverStationSim.notifyNewData();
+        break;
+    }
+  }
+
+  private void onPhaseUpdate(int phase, double t) {
+    if (phase != 1) return;
+
+    // Rapid fire: 1.5s cycles (1.0s spin, 0.3s fire, 0.2s reset)
+    double cyclePos = (t - 2.0) % CYCLE_PERIOD;
+
+    if (cyclePos < SPIN_TIME) {
+      // Spin-up: hold A, release X
+      input.holdA(true);
+      if (xPressed) {
+        input.releaseX();
+        xPressed = false;
+      }
+    } else if (cyclePos < SPIN_TIME + FIRE_TIME) {
+      // Fire: tap X (SpeedUpThenIndex)
+      if (!xPressed) {
+        input.tapX();
+        xPressed = true;
+        shotCount++;
+      }
+    } else {
+      // Reset: release X for next cycle
+      if (xPressed) {
+        input.releaseX();
+        xPressed = false;
+      }
+    }
+  }
+}

--- a/src/main/java/frc/robot/sim/RapidModeTransitionScenario.java
+++ b/src/main/java/frc/robot/sim/RapidModeTransitionScenario.java
@@ -1,0 +1,193 @@
+package frc.robot.sim;
+
+import edu.wpi.first.hal.AllianceStationID;
+import edu.wpi.first.wpilibj.Timer;
+import edu.wpi.first.wpilibj.simulation.DriverStationSim;
+import edu.wpi.first.wpilibj.simulation.RoboRioSim;
+import frc.robot.telemetry.SafeLog;
+import swervelib.simulation.ironmaple.simulation.motorsims.SimulatedBattery;
+
+/**
+ * Rapid mode transition stress test: exercises MatchTelemetry, CommandsTelemetry, and
+ * mode-dependent logic under quick enable/disable cycling.
+ *
+ * <p>Tests: mode transition handling, per-phase statistics (MatchStatsTelemetry), command
+ * scheduling stability, PostMatchSummary under non-standard conditions.
+ *
+ * <p>30s total. Simulates field disconnect/reconnect, rapid auto↔teleop switching, and the kind of
+ * choppy FMS behavior teams see in practice.
+ *
+ * <p>Launch: ./gradlew simulateJava -DsimScenario=ModeTransition
+ */
+public class RapidModeTransitionScenario implements SimScenario {
+  private double startTime;
+  private boolean finished = false;
+  private int lastPhase = -1;
+  private int transitionCount = 0;
+
+  @Override
+  public String getName() {
+    return "ModeTransition";
+  }
+
+  @Override
+  public void init() {
+    startTime = Timer.getFPGATimestamp();
+    finished = false;
+    lastPhase = -1;
+    transitionCount = 0;
+    SimulatedBattery.disableBatterySim(); // prevent MapleSim from overwriting our voltage ramp
+    RoboRioSim.setVInVoltage(12.5);
+    DriverStationSim.setAllianceStationId(AllianceStationID.Red1);
+    DriverStationSim.notifyNewData();
+  }
+
+  @Override
+  public void execute(double timestampSec) {
+    double t = timestampSec - startTime;
+    int phase = getPhase(t);
+
+    if (phase != lastPhase) {
+      SafeLog.put("Sim/ModeTransit/Phase", phase);
+      SafeLog.put("Sim/ModeTransit/PhaseName", phaseName(phase));
+      lastPhase = phase;
+    }
+
+    onPhaseUpdate(phase, t);
+
+    SafeLog.put("Sim/ModeTransit/ElapsedSec", t);
+    SafeLog.put("Sim/ModeTransit/Transitions", transitionCount);
+
+    if (t >= 30.0) {
+      DriverStationSim.setEnabled(false);
+      DriverStationSim.notifyNewData();
+      finished = true;
+    }
+  }
+
+  @Override
+  public boolean isFinished() {
+    return finished;
+  }
+
+  private int getPhase(double t) {
+    if (t < 2) return 0; // Initial disabled
+    if (t < 5) return 1; // Quick auto enable
+    if (t < 6) return 2; // Disable (field glitch)
+    if (t < 9) return 3; // Teleop enable
+    if (t < 10) return 4; // Disable (field glitch)
+    if (t < 13) return 5; // Back to teleop
+    if (t < 14) return 6; // Disable
+    if (t < 20) return 7; // Sustained teleop (normal operation)
+    if (t < 21) return 8; // Disable
+    if (t < 24) return 9; // Auto re-enable (weird FMS)
+    if (t < 25) return 10; // Disable
+    if (t < 28) return 11; // Final teleop
+    return 12; // Final disable
+  }
+
+  private String phaseName(int phase) {
+    switch (phase) {
+      case 0:
+        return "InitialDisabled";
+      case 1:
+        return "AutoEnable";
+      case 2:
+        return "FieldGlitch1";
+      case 3:
+        return "TeleopEnable";
+      case 4:
+        return "FieldGlitch2";
+      case 5:
+        return "TeleopResume";
+      case 6:
+        return "BriefDisable";
+      case 7:
+        return "SustainedTeleop";
+      case 8:
+        return "MidMatchDisable";
+      case 9:
+        return "AutoReEnable";
+      case 10:
+        return "FinalDisable1";
+      case 11:
+        return "FinalTeleop";
+      case 12:
+        return "MatchEnd";
+      default:
+        return "Unknown";
+    }
+  }
+
+  private void onPhaseUpdate(int phase, double t) {
+    switch (phase) {
+      case 0: // Disabled
+        setMode(false, false, 0);
+        break;
+
+      case 1: // Auto
+        setMode(true, true, 15.0 - (t - 2.0));
+        break;
+
+      case 2: // Disabled (glitch)
+        setMode(false, false, 0);
+        break;
+
+      case 3: // Teleop
+        setMode(true, false, 135.0 - (t - 6.0));
+        break;
+
+      case 4: // Disabled (glitch)
+        setMode(false, false, 0);
+        break;
+
+      case 5: // Teleop resume
+        setMode(true, false, 130.0 - (t - 10.0));
+        break;
+
+      case 6: // Brief disable
+        setMode(false, false, 0);
+        break;
+
+      case 7: // Sustained teleop,6s of normal operation
+        setMode(true, false, 120.0 - (t - 14.0));
+        break;
+
+      case 8: // Mid-match disable
+        setMode(false, false, 0);
+        break;
+
+      case 9: // Auto re-enable (unusual)
+        setMode(true, true, 10.0 - (t - 21.0));
+        break;
+
+      case 10: // Final disable
+        setMode(false, false, 0);
+        break;
+
+      case 11: // Final teleop
+        setMode(true, false, 30.0 - (t - 25.0));
+        break;
+
+      case 12: // Match end
+        setMode(false, false, 0);
+        break;
+    }
+  }
+
+  private void setMode(boolean enabled, boolean auto, double matchTime) {
+    boolean wasEnabled = DriverStationSim.getEnabled();
+    boolean wasAuto = DriverStationSim.getAutonomous();
+
+    if (wasEnabled != enabled || wasAuto != auto) {
+      transitionCount++;
+    }
+
+    DriverStationSim.setEnabled(enabled);
+    DriverStationSim.setAutonomous(auto);
+    if (matchTime > 0) {
+      DriverStationSim.setMatchTime(matchTime);
+    }
+    DriverStationSim.notifyNewData();
+  }
+}

--- a/src/main/java/frc/robot/sim/SignalCoverageScenario.java
+++ b/src/main/java/frc/robot/sim/SignalCoverageScenario.java
@@ -1,0 +1,264 @@
+package frc.robot.sim;
+
+import edu.wpi.first.hal.AllianceStationID;
+import edu.wpi.first.wpilibj.Timer;
+import edu.wpi.first.wpilibj.simulation.DriverStationSim;
+import edu.wpi.first.wpilibj.simulation.RoboRioSim;
+import frc.robot.telemetry.SafeLog;
+import swervelib.simulation.ironmaple.simulation.motorsims.SimulatedBattery;
+
+/**
+ * Lean gap-filler scenario covering signals that CompetitionMatch, SubsystemSuite, Brownout, and
+ * AMDAShowcase do not exercise.
+ *
+ * <p>Focus areas (no overlap with other scenarios):
+ *
+ * <ul>
+ *   <li>Systematic voltage sweep through all 4 thresholds (WARNING 11.5V, predicted shutdown
+ *       10.5V, CRITICAL 10.0V, deep brownout 7.0V) with recovery
+ *   <li>All mode transitions in one run: disabled -> auto -> disabled -> teleop -> disabled -> test
+ *       -> disabled
+ *   <li>Motor stall/recovery cycles: all motors at speed, then sudden target zero, then resume
+ *       (exercises stall detection in ShooterTelemetry, IndexerTelemetry, IntakeTelemetry, etc.)
+ * </ul>
+ *
+ * <p>30s total, 8 phases. Launch: ./gradlew simulateJava -DsimScenario=SignalCoverage
+ */
+public class SignalCoverageScenario implements SimScenario {
+  private double startTime;
+  private boolean finished = false;
+  private final SimInputPlayback input = new SimInputPlayback();
+  private int lastPhase = -1;
+
+  private static final double MODE_CYCLE_END = 8.0;
+  private static final double MOTOR_SPINUP_END = 13.0;
+  private static final double MOTOR_STALL_END = 16.0;
+  private static final double MOTOR_RECOVERY_END = 19.0;
+  private static final double VOLTAGE_SWEEP_END = 26.0;
+  private static final double VOLTAGE_RECOVER_END = 29.0;
+  private static final double SCENARIO_END = 30.0;
+
+  @Override
+  public String getName() {
+    return "SignalCoverage";
+  }
+
+  @Override
+  public void init() {
+    startTime = Timer.getFPGATimestamp();
+    finished = false;
+    lastPhase = -1;
+    input.releaseAll();
+    SimulatedBattery.disableBatterySim();
+    RoboRioSim.setVInVoltage(12.8);
+    DriverStationSim.setAllianceStationId(AllianceStationID.Red1);
+    DriverStationSim.notifyNewData();
+  }
+
+  @Override
+  public void execute(double timestampSec) {
+    double t = timestampSec - startTime;
+    int phase = getPhase(t);
+
+    if (phase != lastPhase) {
+      SafeLog.put("Sim/SigCov/Phase", phase);
+      SafeLog.put("Sim/SigCov/PhaseName", phaseName(phase));
+      lastPhase = phase;
+      onPhaseEnter(phase);
+    }
+
+    onPhaseUpdate(phase, t);
+
+    SafeLog.put("Sim/SigCov/ElapsedSec", t);
+    SafeLog.put("Sim/SigCov/Progress", Math.min(100, (t / SCENARIO_END) * 100));
+
+    if (t >= SCENARIO_END) {
+      input.releaseAll();
+      DriverStationSim.setEnabled(false);
+      DriverStationSim.notifyNewData();
+      RoboRioSim.setVInVoltage(12.8);
+      finished = true;
+    }
+  }
+
+  @Override
+  public boolean isFinished() {
+    return finished;
+  }
+
+  private int getPhase(double t) {
+    if (t < MODE_CYCLE_END) return 0;
+    if (t < MOTOR_SPINUP_END) return 1;
+    if (t < MOTOR_STALL_END) return 2;
+    if (t < MOTOR_RECOVERY_END) return 3;
+    if (t < VOLTAGE_SWEEP_END) return 4;
+    if (t < VOLTAGE_RECOVER_END) return 5;
+    return 6;
+  }
+
+  private String phaseName(int phase) {
+    switch (phase) {
+      case 0:
+        return "ModeCycle";
+      case 1:
+        return "MotorSpinUp";
+      case 2:
+        return "MotorStall";
+      case 3:
+        return "MotorRecovery";
+      case 4:
+        return "VoltageSweep";
+      case 5:
+        return "VoltageRecover";
+      case 6:
+        return "PostDisable";
+      default:
+        return "Unknown";
+    }
+  }
+
+  private void onPhaseEnter(int phase) {
+    switch (phase) {
+      case 0: // Mode cycling handled in onPhaseUpdate
+        DriverStationSim.setEnabled(false);
+        DriverStationSim.setAutonomous(false);
+        DriverStationSim.notifyNewData();
+        break;
+
+      case 1: // Spin up all motors in teleop
+        DriverStationSim.setAutonomous(false);
+        DriverStationSim.setEnabled(true);
+        DriverStationSim.setMatchTime(120.0);
+        DriverStationSim.notifyNewData();
+        // Driver: drive + shooter(A) + indexer+agitator(Y) + intake(B)
+        input.driveForward(0.6);
+        input.holdA(true);
+        input.holdY(true);
+        input.holdB(true);
+        // Copilot: intake(A) + agitate(B)
+        input.copilotHoldA(true);
+        input.copilotHoldB(true);
+        SafeLog.put("Sim/SigCov/MotorsLoaded", true);
+        break;
+
+      case 2: // Stall: release all motor commands suddenly
+        input.holdA(false);
+        input.holdY(false);
+        input.holdB(false);
+        input.copilotHoldA(false);
+        input.copilotHoldB(false);
+        input.driveForward(0);
+        SafeLog.put("Sim/SigCov/MotorsLoaded", false);
+        SafeLog.put("Sim/SigCov/StallPhase", true);
+        break;
+
+      case 3: // Recovery: spin motors back up
+        input.driveForward(0.5);
+        input.holdA(true);
+        input.holdY(true);
+        input.holdB(true);
+        SafeLog.put("Sim/SigCov/StallPhase", false);
+        SafeLog.put("Sim/SigCov/MotorsLoaded", true);
+        break;
+
+      case 4: // Voltage sweep (motors still running under load)
+        break;
+
+      case 5: // Voltage recovery
+        break;
+
+      case 6: // Post-disable
+        input.releaseAll();
+        DriverStationSim.setEnabled(false);
+        DriverStationSim.notifyNewData();
+        break;
+    }
+  }
+
+  private void onPhaseUpdate(int phase, double t) {
+    switch (phase) {
+      case 0: // Mode cycle: disabled -> auto -> disabled -> teleop -> disabled -> test -> disabled
+        modeCycle(t);
+        break;
+
+      case 4: // Voltage sweep: 12.8V -> 11.5 -> 10.5 -> 10.0 -> 7.0V over 7s
+        double sweepT = t - MOTOR_RECOVERY_END;
+        double sweepFrac = sweepT / (VOLTAGE_SWEEP_END - MOTOR_RECOVERY_END);
+        double voltage;
+        if (sweepFrac < 0.2) {
+          // 12.8 -> 11.5 (WARNING threshold)
+          voltage = 12.8 - (1.3 * (sweepFrac / 0.2));
+        } else if (sweepFrac < 0.4) {
+          // 11.5 -> 10.5 (predicted shutdown)
+          voltage = 11.5 - (1.0 * ((sweepFrac - 0.2) / 0.2));
+        } else if (sweepFrac < 0.6) {
+          // 10.5 -> 10.0 (CRITICAL threshold)
+          voltage = 10.5 - (0.5 * ((sweepFrac - 0.4) / 0.2));
+        } else if (sweepFrac < 0.8) {
+          // 10.0 -> 7.0 (deep brownout)
+          voltage = 10.0 - (3.0 * ((sweepFrac - 0.6) / 0.2));
+        } else {
+          // Hold at 7.0
+          voltage = 7.0;
+        }
+        RoboRioSim.setVInVoltage(voltage);
+        SafeLog.put("Sim/SigCov/Voltage", voltage);
+        break;
+
+      case 5: // Recovery: 7.0 -> 12.8V over 3s
+        double recT = t - VOLTAGE_SWEEP_END;
+        double recFrac = Math.min(1.0, recT / (VOLTAGE_RECOVER_END - VOLTAGE_SWEEP_END));
+        double recVoltage = 7.0 + (5.8 * recFrac);
+        RoboRioSim.setVInVoltage(recVoltage);
+        SafeLog.put("Sim/SigCov/Voltage", recVoltage);
+        break;
+    }
+  }
+
+  /**
+   * Rapid mode cycling: disabled -> auto(1.5s) -> disabled(0.5s) -> teleop(2s) -> disabled(0.5s)
+   * -> test(2s) -> disabled(1s). Exercises EventMarker.modeChange(),
+   * PostMatchSummary.startTracking(), and all mode-dependent telemetry paths.
+   */
+  private void modeCycle(double t) {
+    if (t < 0.5) {
+      // Initial disabled
+      DriverStationSim.setEnabled(false);
+      DriverStationSim.setAutonomous(false);
+    } else if (t < 2.0) {
+      // Auto
+      DriverStationSim.setAutonomous(true);
+      DriverStationSim.setEnabled(true);
+      DriverStationSim.setMatchTime(15.0);
+      input.driveForward(0.3);
+    } else if (t < 2.5) {
+      // Disabled gap
+      input.releaseAll();
+      DriverStationSim.setEnabled(false);
+      DriverStationSim.setAutonomous(false);
+    } else if (t < 4.5) {
+      // Teleop
+      DriverStationSim.setAutonomous(false);
+      DriverStationSim.setEnabled(true);
+      DriverStationSim.setMatchTime(135.0);
+      input.driveForward(0.4);
+    } else if (t < 5.0) {
+      // Disabled gap
+      input.releaseAll();
+      DriverStationSim.setEnabled(false);
+      DriverStationSim.setAutonomous(false);
+    } else if (t < 7.0) {
+      // Test mode
+      DriverStationSim.setAutonomous(false);
+      DriverStationSim.setTest(true);
+      DriverStationSim.setEnabled(true);
+      input.driveForward(0.2);
+    } else {
+      // Final disabled
+      input.releaseAll();
+      DriverStationSim.setTest(false);
+      DriverStationSim.setEnabled(false);
+    }
+    DriverStationSim.notifyNewData();
+  }
+}

--- a/src/main/java/frc/robot/sim/SimDeviceManager.java
+++ b/src/main/java/frc/robot/sim/SimDeviceManager.java
@@ -1,0 +1,250 @@
+package frc.robot.sim;
+
+import com.revrobotics.spark.SparkSim;
+import edu.wpi.first.math.system.plant.DCMotor;
+import edu.wpi.first.wpilibj.Timer;
+import edu.wpi.first.wpilibj.simulation.RoboRioSim;
+import frc.robot.Constants;
+import frc.robot.Constants.ShooterConstants;
+import frc.robot.subsystems.Agitator;
+import frc.robot.subsystems.Hanger;
+import frc.robot.subsystems.Indexer;
+import frc.robot.subsystems.Intake;
+import frc.robot.subsystems.IntakeActuator;
+import frc.robot.subsystems.Shooter;
+import frc.robot.telemetry.SafeLog;
+
+/**
+ * SparkSim wiring for motor subsystems. Call update() each simulationPeriodic().
+ *
+ * <p>Velocity motors: reads target from subsystem (Shooter.getTargetRPM()) or uses duty-cycle
+ * model. First-order dynamics (100ms spin-up, 300ms coast-down) model motor response realistically
+ * without depending on the PID gains which are tuned for real hardware, not the sim physics model.
+ *
+ * <p>Position motors: output-proportional position integration.
+ */
+public class SimDeviceManager {
+  private static final double NEO_FREE_SPEED_RPM = 5676.0;
+  private static final double DT = 0.020;
+  private static final double SPINUP_TAU = 0.100; // 100ms spin-up
+  private static final double COASTDOWN_TAU = 0.300; // 300ms coast-down
+
+  private SparkSim shooterSim;
+  private SparkSim indexerSim;
+  private SparkSim intakeSim;
+  private SparkSim agitatorSim;
+  private SparkSim intakeActuatorSim;
+  private SparkSim hangerSim;
+  private boolean initialized = false;
+
+  // Per-motor RPM state for first-order dynamics
+  private double shooterRPM = 0;
+  private double indexerRPM = 0;
+  private double intakeRPM = 0;
+  private double agitatorRPM = 0;
+
+  // Position motor state with sticky targets (same command-conflict fix as shooter)
+  private double intakeActuatorPos = 0;
+  private double hangerPos = 0;
+  private static final double POSITION_TAU = 0.300; // 300ms approach
+  private double lastActuatorTarget = 0;
+  private int actuatorHoldCycles = 0;
+  private double lastHangerTarget = 0;
+  private int hangerHoldCycles = 0;
+
+  // Sticky target: holds last nonzero target for a brief grace period,
+  // avoiding brief 0s from command scheduler transitions
+  private double lastShooterTarget = 0;
+  private int targetHoldCycles = 0;
+  private static final int TARGET_HOLD_COUNT = 10; // 200ms grace
+
+  // Shot simulation: periodic RPM drops when indexing at speed
+  private static final double SHOT_RPM_DROP = 350.0;
+  private static final double SHOT_SIM_INTERVAL = 0.500; // one shot per 500ms
+  private double lastShotSimTime = 0;
+
+  public void init() {
+    try {
+      Shooter shooter = Shooter.getInstance();
+      Indexer indexer = Indexer.getInstance();
+      Intake intake = Intake.getInstance();
+      Agitator agitator = Agitator.getInstance();
+      IntakeActuator intakeActuator = IntakeActuator.getInstance();
+      Hanger hanger = Hanger.getInstance();
+      if (shooter == null || indexer == null || intake == null
+          || agitator == null || intakeActuator == null || hanger == null) {
+        SafeLog.put("Sim/DeviceManager/InitError", "NullSubsystem");
+        initialized = false;
+        return;
+      }
+      shooterSim = new SparkSim(shooter.getMotor(), DCMotor.getNEO(1));
+      indexerSim = new SparkSim(indexer.getMotor(), DCMotor.getNEO(1));
+      intakeSim = new SparkSim(intake.getMotor(), DCMotor.getNEO(1));
+      agitatorSim = new SparkSim(agitator.getMotor(), DCMotor.getNEO(1));
+      intakeActuatorSim = new SparkSim(intakeActuator.getMotor(), DCMotor.getNEO(1));
+      hangerSim = new SparkSim(hanger.getMotor(), DCMotor.getNEO(1));
+      initialized = true;
+    } catch (RuntimeException e) {
+      SafeLog.put("Sim/DeviceManager/InitError", e.getClass().getSimpleName());
+      initialized = false;
+    }
+  }
+
+  /** Call from Robot.simulationPeriodic() */
+  public void update() {
+    if (!initialized) return;
+    try {
+      // Shooter: sticky target rides through brief command transitions
+      Shooter shooterInst = Shooter.getInstance();
+      if (shooterInst == null) return;
+      double rawTarget = shooterInst.getTargetRPM();
+      if (rawTarget > 0) {
+        lastShooterTarget = rawTarget;
+        targetHoldCycles = TARGET_HOLD_COUNT;
+      } else if (targetHoldCycles > 0) {
+        targetHoldCycles--;
+      } else {
+        lastShooterTarget = 0;
+      }
+      double shooterTarget = lastShooterTarget;
+      shooterRPM = updateMotorToTarget(shooterSim, shooterRPM, shooterTarget);
+
+      // Indexer: target from subsystem when PID is active (output > threshold)
+      double indexerTarget =
+          (Math.abs(indexerSim.getAppliedOutput()) > 0.01)
+              ? Constants.MotorConstants.DESIRED_INDEXER_RPM
+              : 0;
+      indexerRPM = updateMotorToTarget(indexerSim, indexerRPM, indexerTarget);
+
+      // Intake: duty cycle motor,target = output * free speed
+      double intakeOutput = intakeSim.getAppliedOutput();
+      double intakeTarget = intakeOutput * NEO_FREE_SPEED_RPM;
+      intakeRPM = updateMotorToTarget(intakeSim, intakeRPM, intakeTarget);
+
+      // Agitator: duty cycle motor, same model as intake
+      double agitatorOutput = agitatorSim.getAppliedOutput();
+      double agitatorTarget = agitatorOutput * NEO_FREE_SPEED_RPM;
+      agitatorRPM = updateMotorToTarget(agitatorSim, agitatorRPM, agitatorTarget);
+
+      // When indexer is active and shooter is at speed, periodically drop
+      // shooter RPM to trigger shot detection in ShooterTelemetry
+      boolean indexerActive = indexerRPM > 100;
+      boolean shooterAtSpeed =
+          shooterRPM > (ShooterConstants.TARGET_RPM - ShooterConstants.SPEED_TOLERANCE_RPM);
+      double now = Timer.getFPGATimestamp();
+
+      if (indexerActive && shooterAtSpeed && (now - lastShotSimTime) > SHOT_SIM_INTERVAL) {
+        shooterRPM -= SHOT_RPM_DROP;
+        shooterSim.getRelativeEncoderSim().setVelocity(shooterRPM);
+        lastShotSimTime = now;
+        SafeLog.put("Sim/Debug/ShotSimulated", true);
+      } else {
+        SafeLog.put("Sim/Debug/ShotSimulated", false);
+      }
+
+      // Refresh hold whenever we see a nonzero target >= current sticky.
+      // This keeps hold alive during 50/0 oscillation (refreshed every other cycle).
+      // Hold only expires after 10 consecutive zero-target cycles (real release).
+      IntakeActuator actuatorInst = IntakeActuator.getInstance();
+      if (actuatorInst == null) return;
+      double rawActuatorTarget = actuatorInst.getTargetPosition();
+      if (rawActuatorTarget != 0 && Math.abs(rawActuatorTarget) >= Math.abs(lastActuatorTarget)) {
+        lastActuatorTarget = rawActuatorTarget;
+        actuatorHoldCycles = TARGET_HOLD_COUNT;
+      } else if (actuatorHoldCycles > 0) {
+        actuatorHoldCycles--;
+      } else {
+        lastActuatorTarget = rawActuatorTarget;
+      }
+      intakeActuatorPos =
+          updatePositionToTarget(intakeActuatorSim, intakeActuatorPos, lastActuatorTarget);
+
+      Hanger hangerInst = Hanger.getInstance();
+      if (hangerInst == null) return;
+      double rawHangerTarget = hangerInst.getTargetPosition();
+      if (rawHangerTarget != 0 && Math.abs(rawHangerTarget) >= Math.abs(lastHangerTarget)) {
+        lastHangerTarget = rawHangerTarget;
+        hangerHoldCycles = TARGET_HOLD_COUNT;
+      } else if (hangerHoldCycles > 0) {
+        hangerHoldCycles--;
+      } else {
+        lastHangerTarget = rawHangerTarget;
+      }
+      hangerPos = updatePositionToTarget(hangerSim, hangerPos, lastHangerTarget);
+
+      SafeLog.put("Sim/Debug/ShooterOutput", shooterSim.getAppliedOutput());
+      SafeLog.put("Sim/Debug/ShooterRPM", shooterRPM);
+      SafeLog.put("Sim/Debug/ShooterTarget", shooterTarget);
+      SafeLog.put("Sim/Debug/IndexerOutput", indexerSim.getAppliedOutput());
+      SafeLog.put("Sim/Debug/IndexerRPM", indexerRPM);
+      SafeLog.put("Sim/Debug/IntakeOutput", intakeSim.getAppliedOutput());
+      SafeLog.put("Sim/Debug/IntakeRPM", intakeRPM);
+      SafeLog.put("Sim/Debug/AgitatorOutput", agitatorSim.getAppliedOutput());
+      SafeLog.put("Sim/Debug/AgitatorRPM", agitatorRPM);
+      SafeLog.put("Sim/Debug/IntakeActuatorPos", intakeActuatorPos);
+      SafeLog.put("Sim/Debug/IntakeActuatorTarget", lastActuatorTarget);
+      SafeLog.put("Sim/Debug/HangerPos", hangerPos);
+      SafeLog.put("Sim/Debug/HangerTarget", lastHangerTarget);
+    } catch (RuntimeException e) {
+      SafeLog.put("Sim/DeviceManager/UpdateError", e.getClass().getSimpleName());
+    }
+  }
+
+  /**
+   * Model motor approaching targetRPM with first-order dynamics. Spin-up is fast (100ms tau),
+   * coast-down is slower (300ms tau).
+   */
+  private double updateMotorToTarget(SparkSim sim, double currentRPM, double targetRPM) {
+    double vbus = Math.max(1.0, RoboRioSim.getVInVoltage());
+
+    double tau = (Math.abs(targetRPM) > Math.abs(currentRPM)) ? SPINUP_TAU : COASTDOWN_TAU;
+    double alpha = 1.0 - Math.exp(-DT / tau);
+    currentRPM += (targetRPM - currentRPM) * alpha;
+
+    // Small values snap to zero
+    if (Math.abs(currentRPM) < 0.5) currentRPM = 0;
+
+    // iterate() first (updates PID state), then setVelocity() to override
+    // firmware averaging filter that would otherwise cap velocity at ~80%
+    sim.iterate(currentRPM, vbus, DT);
+    sim.getRelativeEncoderSim().setVelocity(currentRPM);
+
+    return currentRPM;
+  }
+
+  /** Position motors: read target from subsystem, first-order approach. */
+  private double updatePositionToTarget(SparkSim sim, double currentPos, double targetPos) {
+    double alpha = 1.0 - Math.exp(-DT / POSITION_TAU);
+    currentPos += (targetPos - currentPos) * alpha;
+    sim.getRelativeEncoderSim().setPosition(currentPos);
+    return currentPos;
+  }
+
+  public SparkSim getShooterSim() {
+    return shooterSim;
+  }
+
+  public SparkSim getIndexerSim() {
+    return indexerSim;
+  }
+
+  public SparkSim getIntakeSim() {
+    return intakeSim;
+  }
+
+  public SparkSim getAgitatorSim() {
+    return agitatorSim;
+  }
+
+  public SparkSim getIntakeActuatorSim() {
+    return intakeActuatorSim;
+  }
+
+  public SparkSim getHangerSim() {
+    return hangerSim;
+  }
+
+  public boolean isInitialized() {
+    return initialized;
+  }
+}

--- a/src/main/java/frc/robot/sim/SimDriveOverride.java
+++ b/src/main/java/frc/robot/sim/SimDriveOverride.java
@@ -1,0 +1,45 @@
+package frc.robot.sim;
+
+/**
+ * Static volatile fields for sim drive input,bypasses HAL joystick port 0 which halsim_gui
+ * continuously zeros. RobotContainer reads these via method references as SwerveInputStream
+ * suppliers in sim mode.
+ */
+public final class SimDriveOverride {
+
+  private static volatile double y = 0;
+  private static volatile double x = 0;
+  private static volatile double omega = 0;
+
+  private SimDriveOverride() {}
+
+  public static double getY() {
+    return y;
+  }
+
+  public static double getX() {
+    return x;
+  }
+
+  public static double getOmega() {
+    return omega;
+  }
+
+  public static void setY(double value) {
+    y = value;
+  }
+
+  public static void setX(double value) {
+    x = value;
+  }
+
+  public static void setOmega(double value) {
+    omega = value;
+  }
+
+  public static void reset() {
+    y = 0;
+    x = 0;
+    omega = 0;
+  }
+}

--- a/src/main/java/frc/robot/sim/SimInputPlayback.java
+++ b/src/main/java/frc/robot/sim/SimInputPlayback.java
@@ -1,0 +1,164 @@
+package frc.robot.sim;
+
+import edu.wpi.first.wpilibj.simulation.DriverStationSim;
+import edu.wpi.first.wpilibj.simulation.XboxControllerSim;
+
+/**
+ * Deterministic Xbox controller input playback for simulation. Wraps XboxControllerSim(0) to match
+ * RobotContainer's driverXbox port.
+ *
+ * <p>Drive axes go through SimDriveOverride (bypasses HAL race with SimGUI). Buttons still go
+ * through XboxControllerSim (triggers need HAL path).
+ *
+ * <p>Button mapping (from RobotContainer.configureBindings): A (whileTrue) ->
+ * MoveShooter(DESIRED_SHOOTER_RPM) Y (whileTrue) -> MoveIndexer(DESIRED_INDEXER_RPM) X (onTrue) ->
+ * SpeedUpThenIndex LeftStick -> Swerve drive (field-oriented angular velocity) Start -> Zero gyro
+ * LBumper -> Wheel lock
+ */
+public class SimInputPlayback {
+  private final XboxControllerSim xbox;
+  private final XboxControllerSim copilot;
+
+  public SimInputPlayback() {
+    xbox = new XboxControllerSim(0);
+    copilot = new XboxControllerSim(1);
+  }
+
+  public void driveForward(double magnitude) {
+    SimDriveOverride.setY(magnitude);
+  }
+
+  public void strafe(double magnitude) {
+    SimDriveOverride.setX(magnitude);
+  }
+
+  public void rotate(double magnitude) {
+    SimDriveOverride.setOmega(magnitude);
+  }
+
+  /** Hold A to spin shooter (MoveShooter command) */
+  public void holdA(boolean pressed) {
+    xbox.setAButton(pressed);
+    notifyDS();
+  }
+
+  /** Hold Y to run indexer (MoveIndexer command) */
+  public void holdY(boolean pressed) {
+    xbox.setYButton(pressed);
+    notifyDS();
+  }
+
+  /** Tap X for SpeedUpThenIndex (onTrue trigger) */
+  public void tapX() {
+    xbox.setXButton(true);
+    notifyDS();
+  }
+
+  public void releaseX() {
+    xbox.setXButton(false);
+    notifyDS();
+  }
+
+  /** Press Start to zero gyro */
+  public void pressStart() {
+    xbox.setStartButton(true);
+    notifyDS();
+  }
+
+  public void releaseStart() {
+    xbox.setStartButton(false);
+    notifyDS();
+  }
+
+  /** Hold left bumper for wheel lock */
+  public void holdLeftBumper(boolean pressed) {
+    xbox.setLeftBumperButton(pressed);
+    notifyDS();
+  }
+
+  /** Hold B for RunIntake (deploy intake actuator + run intake motor) */
+  public void holdB(boolean pressed) {
+    xbox.setBButton(pressed);
+    notifyDS();
+  }
+
+  /** Hold right bumper for DeployHanger / release for ClimbHanger */
+  public void holdRightBumper(boolean pressed) {
+    xbox.setRightBumperButton(pressed);
+    notifyDS();
+  }
+
+  public void setLeftTrigger(double value) {
+    xbox.setLeftTriggerAxis(value);
+    notifyDS();
+  }
+
+  public void setRightTrigger(double value) {
+    xbox.setRightTriggerAxis(value);
+    notifyDS();
+  }
+
+  // === Copilot (port 1) methods ===
+
+  /** Copilot A: DeployIntake + HoldAndIntake (whileTrue) */
+  public void copilotHoldA(boolean pressed) {
+    copilot.setAButton(pressed);
+    notifyDS();
+  }
+
+  /** Copilot B: AgitateAndIndex (whileTrue) */
+  public void copilotHoldB(boolean pressed) {
+    copilot.setBButton(pressed);
+    notifyDS();
+  }
+
+  /** Copilot X: MoveIntake (whileTrue) */
+  public void copilotHoldX(boolean pressed) {
+    copilot.setXButton(pressed);
+    notifyDS();
+  }
+
+  /** Copilot Right Trigger: SpeedUpThenIndex (whileTrue) */
+  public void copilotSetRightTrigger(double value) {
+    copilot.setRightTriggerAxis(value);
+    notifyDS();
+  }
+
+  /** Copilot Right Bumper: PivotIntake down (whileTrue) */
+  public void copilotHoldRightBumper(boolean pressed) {
+    copilot.setRightBumperButton(pressed);
+    notifyDS();
+  }
+
+  /** Copilot Left Bumper: PivotIntake up (whileTrue) */
+  public void copilotHoldLeftBumper(boolean pressed) {
+    copilot.setLeftBumperButton(pressed);
+    notifyDS();
+  }
+
+  public void releaseAll() {
+    SimDriveOverride.reset();
+    xbox.setAButton(false);
+    xbox.setYButton(false);
+    xbox.setXButton(false);
+    xbox.setBButton(false);
+    xbox.setStartButton(false);
+    xbox.setBackButton(false);
+    xbox.setLeftBumperButton(false);
+    xbox.setRightBumperButton(false);
+    xbox.setLeftTriggerAxis(0);
+    xbox.setRightTriggerAxis(0);
+    copilot.setAButton(false);
+    copilot.setBButton(false);
+    copilot.setXButton(false);
+    copilot.setLeftBumperButton(false);
+    copilot.setRightBumperButton(false);
+    copilot.setLeftTriggerAxis(0);
+    copilot.setRightTriggerAxis(0);
+    notifyDS();
+  }
+
+  private void notifyDS() {
+    DriverStationSim.notifyNewData();
+  }
+}

--- a/src/main/java/frc/robot/sim/SimScenario.java
+++ b/src/main/java/frc/robot/sim/SimScenario.java
@@ -1,0 +1,16 @@
+package frc.robot.sim;
+
+/** Simulation scenario interface for SimGUI testing. */
+public interface SimScenario {
+  /** Called once when scenario starts */
+  void init();
+
+  /** Called every robot cycle (~20ms). timestampSec is FPGA time. */
+  void execute(double timestampSec);
+
+  /** Returns true when scenario is complete */
+  boolean isFinished();
+
+  /** Scenario name for dashboard selection */
+  String getName();
+}

--- a/src/main/java/frc/robot/sim/SimScenarioRunner.java
+++ b/src/main/java/frc/robot/sim/SimScenarioRunner.java
@@ -1,0 +1,85 @@
+package frc.robot.sim;
+
+import edu.wpi.first.wpilibj.Timer;
+import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
+import frc.robot.telemetry.SafeLog;
+import java.util.HashMap;
+import java.util.Map;
+
+public class SimScenarioRunner {
+  private final Map<String, SimScenario> scenarios = new HashMap<>();
+  private SimScenario activeScenario = null;
+  private String lastRequestedScenario = "";
+  private final boolean cliLaunched;
+  private int exitDelayCycles = -1; // countdown after CLI scenario finishes
+
+  public SimScenarioRunner() {
+    register(new CompetitionMatchScenario());
+    register(new SubsystemSuiteScenario());
+    register(new RapidFireScenario());
+    register(new BrownoutScenario());
+    register(new FaultInjectionScenario());
+    register(new RapidModeTransitionScenario());
+    register(new FullVideoShowcaseScenario());
+    register(new AMDAShowcaseScenario());
+    register(new SignalCoverageScenario());
+    register(new HubShiftPracticeScenario());
+
+    // CLI support: -DsimScenario=SignalCoverage
+    String cliScenario = System.getProperty("simScenario", "");
+    cliLaunched = !cliScenario.isEmpty();
+    if (cliLaunched) {
+      SmartDashboard.putString("Sim/RunScenario", cliScenario);
+    } else {
+      SmartDashboard.putString("Sim/RunScenario", "");
+    }
+  }
+
+  private void register(SimScenario scenario) {
+    scenarios.put(scenario.getName(), scenario);
+  }
+
+  /** Call from Robot.simulationPeriodic() */
+  public void update() {
+    try {
+      String requested = SmartDashboard.getString("Sim/RunScenario", "");
+
+      if (!requested.equals(lastRequestedScenario)) {
+        lastRequestedScenario = requested;
+        activeScenario = scenarios.get(requested);
+        if (activeScenario != null) {
+          activeScenario.init();
+        }
+      }
+
+      // Auto-exit: after CLI scenario completes, wait 5s for log flush then exit
+      if (cliLaunched && exitDelayCycles >= 0) {
+        exitDelayCycles--;
+        if (exitDelayCycles == 0) {
+          System.exit(0);
+        }
+        return;
+      }
+
+      if (activeScenario != null) {
+        if (activeScenario.isFinished()) {
+          SafeLog.put("Sim/ScenarioActive", false);
+          SafeLog.put("Sim/ScenarioName", "COMPLETED: " + activeScenario.getName());
+          activeScenario = null;
+          if (cliLaunched) {
+            exitDelayCycles = 250; // ~5s at 50Hz for log flush
+          }
+        } else {
+          activeScenario.execute(Timer.getFPGATimestamp());
+          SafeLog.put("Sim/ScenarioActive", true);
+          SafeLog.put("Sim/ScenarioName", activeScenario.getName());
+        }
+      } else {
+        SafeLog.put("Sim/ScenarioActive", false);
+        SafeLog.put("Sim/ScenarioName", "");
+      }
+    } catch (RuntimeException e) {
+      SafeLog.put("Sim/ScenarioRunner/Error", e.getClass().getSimpleName());
+    }
+  }
+}

--- a/src/main/java/frc/robot/sim/SubsystemSuiteScenario.java
+++ b/src/main/java/frc/robot/sim/SubsystemSuiteScenario.java
@@ -1,0 +1,354 @@
+package frc.robot.sim;
+
+import edu.wpi.first.hal.AllianceStationID;
+import edu.wpi.first.wpilibj.Timer;
+import edu.wpi.first.wpilibj.simulation.DriverStationSim;
+import edu.wpi.first.wpilibj.simulation.RoboRioSim;
+import frc.robot.telemetry.SafeLog;
+import swervelib.simulation.ironmaple.simulation.motorsims.SimulatedBattery;
+
+/**
+ * Field-aware scenario: starts in center zone (between hubs), navigates around obstacles, drives to
+ * fuel, picks up, drives to scoring position, shoots.
+ *
+ * <p>Field layout (2026 REBUILT): - Center zone: x=5.19 to x=11.34 (between hub ramps) - Red Hub:
+ * (11.94, 4.03) with ramp collider y=1.28 to y=6.79 - Fuel patch: (7.36-9.18, 1.72-6.25), center
+ * ~(8.27, 4.0) - Robot starts at (9, 5, 180°),open area near fuel
+ *
+ * <p>100s total, 14 phases (12 original + copilot exercise + copilot shoot).
+ *
+ * <p>Launch: ./gradlew simulateJava -DsimScenario=SubsystemSuite
+ */
+public class SubsystemSuiteScenario implements SimScenario {
+  private double startTime;
+  private boolean finished = false;
+  private final SimInputPlayback input = new SimInputPlayback();
+  private int lastPhase = -1;
+  private boolean xPressed = false;
+
+  @Override
+  public String getName() {
+    return "SubsystemSuite";
+  }
+
+  @Override
+  public void init() {
+    startTime = Timer.getFPGATimestamp();
+    finished = false;
+    lastPhase = -1;
+    xPressed = false;
+    input.releaseAll();
+    SimulatedBattery.disableBatterySim(); // prevent MapleSim from overwriting our voltage ramp
+    RoboRioSim.setVInVoltage(12.5);
+    DriverStationSim.setAllianceStationId(AllianceStationID.Red1);
+    DriverStationSim.notifyNewData();
+  }
+
+  @Override
+  public void execute(double timestampSec) {
+    double t = timestampSec - startTime;
+    int phase = getPhase(t);
+
+    if (phase != lastPhase) {
+      SafeLog.put("Sim/Suite/Phase", phase);
+      SafeLog.put("Sim/Suite/PhaseName", phaseName(phase));
+      lastPhase = phase;
+      onPhaseEnter(phase);
+    }
+
+    onPhaseUpdate(phase, t);
+
+    SafeLog.put("Sim/Suite/ElapsedSec", t);
+    SafeLog.put("Sim/Suite/Progress", Math.min(100, (t / 100.0) * 100));
+
+    if (t >= 100.0) {
+      input.releaseAll();
+      DriverStationSim.setEnabled(false);
+      DriverStationSim.notifyNewData();
+      finished = true;
+    }
+  }
+
+  @Override
+  public boolean isFinished() {
+    return finished;
+  }
+
+  private int getPhase(double t) {
+    if (t < 2) return 0; // Disabled baseline
+    if (t < 10) return 1; // Drive to fuel area
+    if (t < 18) return 2; // Shooter spin-up
+    if (t < 25) return 3; // Indexer run
+    if (t < 33) return 4; // Intake deploy + run
+    if (t < 40) return 5; // Drive to scoring position + shoot
+    if (t < 50) return 6; // SpeedUpThenIndex rapid fire
+    if (t < 58) return 7; // Drive circle + shoot
+    if (t < 66) return 8; // Hanger deploy/climb
+    if (t < 76) return 9; // All subsystems combined
+    if (t < 82) return 10; // Copilot: DeployIntake + AgitateAndIndex
+    if (t < 88) return 11; // Copilot: SpeedUpThenIndex via right trigger
+    if (t < 94) return 12; // Drive back to fuel + intake
+    return 13; // Cooldown + disable
+  }
+
+  private String phaseName(int phase) {
+    switch (phase) {
+      case 0:
+        return "DisabledBaseline";
+      case 1:
+        return "DriveToFuel";
+      case 2:
+        return "ShooterSpinUp";
+      case 3:
+        return "IndexerRun";
+      case 4:
+        return "IntakeDeploy";
+      case 5:
+        return "DriveToHubAndShoot";
+      case 6:
+        return "RapidFire";
+      case 7:
+        return "DriveCircleShoot";
+      case 8:
+        return "HangerCycle";
+      case 9:
+        return "AllSubsystems";
+      case 10:
+        return "CopilotIntakeAgitate";
+      case 11:
+        return "CopilotShoot";
+      case 12:
+        return "DriveBackIntake";
+      case 13:
+        return "Cooldown";
+      default:
+        return "Unknown";
+    }
+  }
+
+  private void onPhaseEnter(int phase) {
+    // Release drive inputs between phases
+    input.driveForward(0);
+    input.strafe(0);
+    input.rotate(0);
+
+    // Release all action buttons,each phase explicitly enables what it needs
+    stopShooting();
+    input.holdA(false);
+    input.holdB(false);
+    input.holdY(false);
+    input.holdRightBumper(false);
+
+    switch (phase) {
+      case 0: // Disabled baseline,release everything
+        input.releaseAll();
+        DriverStationSim.setEnabled(false);
+        DriverStationSim.setAutonomous(false);
+        DriverStationSim.notifyNewData();
+        break;
+
+      case 1: // Enable teleop
+        DriverStationSim.setAutonomous(false);
+        DriverStationSim.setEnabled(true);
+        DriverStationSim.setMatchTime(135.0);
+        DriverStationSim.notifyNewData();
+        break;
+
+      case 13: // Cooldown, release everything
+        input.releaseAll();
+        break;
+    }
+  }
+
+  private void onPhaseUpdate(int phase, double t) {
+    switch (phase) {
+      case 1:
+        { // Drive to fuel: robot at (9,5,180°), drive toward fuel at (8.5,3.5)
+          double driveT = t - 2.0;
+          if (driveT < 3.0) {
+            input.driveForward(0.5);
+            input.strafe(-0.3);
+          } else if (driveT < 5.0) {
+            input.strafe(-0.4);
+            input.driveForward(0.2);
+          } else {
+            input.driveForward(-0.3);
+            input.rotate(0.5);
+          }
+          break;
+        }
+
+      case 2: // Shooter spin-up: A only (MoveShooter, no X conflict)
+        input.holdA(true);
+        break;
+
+      case 3: // Indexer: Y only (no shooter)
+        input.holdY(true);
+        break;
+
+      case 4:
+        { // Intake deploy: B for deploy+intake, then release to retract
+          double intakeT = t - 25.0;
+          if (intakeT < 5.0) {
+            input.holdB(true);
+          } else {
+            input.holdB(false);
+          }
+          break;
+        }
+
+      case 5:
+        { // Drive toward Red Hub scoring position + shoot
+          double dt = t - 33.0;
+          if (dt < 3.0) {
+            input.driveForward(-0.6);
+            input.strafe(0.2);
+            // Use X for shooting (SpeedUpThenIndex handles shooter+indexer)
+            // NO A,avoids command conflict
+            startShooting();
+          } else {
+            // Keep X held,SpeedUpThenIndex running
+            startShooting();
+          }
+          break;
+        }
+
+      case 6:
+        { // SpeedUpThenIndex rapid fire: X only, no A
+          double fireT = t - 40.0;
+          double cycle = fireT % 3.0;
+          if (cycle < 1.0) {
+            // Brief pause between shots,release X
+            stopShooting();
+          } else {
+            // SpeedUpThenIndex handles spin-up + indexing
+            startShooting();
+          }
+          break;
+        }
+
+      case 7:
+        { // Drive in circle near hub while shooting
+          double circT = t - 50.0;
+          input.driveForward(0.3 * Math.sin(circT * 0.8));
+          input.strafe(0.3 * Math.cos(circT * 0.8));
+          input.rotate(0.2);
+          // Shoot every 2.5s,X only, no A
+          if (circT % 2.5 > 0.8) {
+            startShooting();
+          } else {
+            stopShooting();
+          }
+          break;
+        }
+
+      case 8:
+        { // Hanger deploy and climb (no shooter)
+          double hangerT = t - 58.0;
+          if (hangerT < 4.0) {
+            input.holdRightBumper(true);
+          } else {
+            input.holdRightBumper(false);
+          }
+          break;
+        }
+
+      case 9:
+        { // All subsystems: drive + shoot + intake + hanger
+          double allT = t - 66.0;
+          input.driveForward(0.4 * Math.sin(allT * 0.6));
+          input.strafe(0.3 * Math.cos(allT * 0.4));
+          // Cycle intake every 3s (B button, no subsystem conflict with X)
+          input.holdB(allT % 3.0 < 1.5);
+          // Cycle hanger every 4s
+          input.holdRightBumper(allT % 4.0 < 2.0);
+          // Shoot every 3s,X only (handles shooter+indexer together)
+          // No A or Y,they'd conflict with SpeedUpThenIndex
+          if (allT % 3.0 > 1.0) {
+            startShooting();
+          } else {
+            stopShooting();
+          }
+          break;
+        }
+
+      case 10:
+        { // Copilot: DeployIntake(A) + AgitateAndIndex(B) + PivotIntake(bumpers)
+          double copT = t - 76.0;
+          if (copT < 2.5) {
+            // Deploy intake via copilot A (DeployIntake + HoldAndIntake)
+            input.copilotHoldA(true);
+          } else if (copT < 4.5) {
+            input.copilotHoldA(false);
+            // AgitateAndIndex via copilot B
+            input.copilotHoldB(true);
+          } else {
+            input.copilotHoldB(false);
+            // PivotIntake down then up via copilot bumpers
+            input.copilotHoldRightBumper(copT < 5.5);
+            input.copilotHoldLeftBumper(copT >= 5.5);
+          }
+          break;
+        }
+
+      case 11:
+        { // Copilot: SpeedUpThenIndex via right trigger
+          double copT = t - 82.0;
+          if (copT < 4.0) {
+            // Hold right trigger for SpeedUpThenIndex
+            input.copilotSetRightTrigger(1.0);
+          } else {
+            input.copilotSetRightTrigger(0);
+          }
+          break;
+        }
+
+      case 12:
+        { // Drive back to fuel + intake
+          double driveT = t - 88.0;
+          if (driveT < 4.0) {
+            input.driveForward(0.5);
+            input.holdB(true);
+          } else {
+            input.strafe(0.4 * Math.sin(driveT * 1.0));
+            input.holdB(true);
+          }
+          break;
+        }
+
+      case 13:
+        { // Cooldown, slow drive, fade out
+          double coolT = t - 94.0;
+          double fade = Math.max(0, 1.0 - coolT / 5.0);
+          input.driveForward(0.2 * fade);
+          input.rotate(0.1 * fade);
+          if (coolT > 5.0) {
+            DriverStationSim.setEnabled(false);
+            DriverStationSim.notifyNewData();
+          }
+          break;
+        }
+    }
+  }
+
+  /**
+   * Start shooting: X only (SpeedUpThenIndex handles both shooter+indexer). NEVER combine with A
+   * (MoveShooter),they fight over the Shooter subsystem.
+   */
+  private void startShooting() {
+    input.holdA(false); // release A to avoid conflict
+    input.holdY(false); // release Y,SpeedUpThenIndex owns indexer too
+    if (!xPressed) {
+      input.tapX();
+      xPressed = true;
+    }
+  }
+
+  /** Stop shooting: release X, SpeedUpThenIndex ends. */
+  private void stopShooting() {
+    if (xPressed) {
+      input.releaseX();
+      xPressed = false;
+    }
+  }
+}


### PR DESCRIPTION
## Summary

This is my simulation framework with 10 scenarios for testing the telemetry and feedback systems without a real robot. Run with `./gradlew simulateJava` and select a scenario from the `Sim/RunScenario` dropdown in SmartDashboard, or launch directly with
`./gradlew simulateJava -DsimScenario=SubsystemSuite`.

### Sim infrastructure

- **SimScenario** (interface): Common interface with `init()`, `execute(timestamp)`,  `isFinished()`, and `getName()`.
- **SimScenarioRunner**: Registry that reads `Sim/RunScenario` from SmartDashboard and runs the matching scenario. Supports CLI launch via `-DsimScenario=` property. Auto-exits after scenario completes (with 5s delay for log flush).
- **SimDeviceManager**: Wires SparkSim encoders to simulated motor velocities so telemetry classes see realistic readings during sim. Null-checks all subsystem singletons so it doesn't crash if a subsystem isn't initialized.
- **SimDriveOverride**: Lets sim scenarios inject drive commands (X, Y, omega) that get added to joystick input, so scenario playback and manual control work together.
- **SimInputPlayback**: Records and plays back joystick + button sequences for repeatable scenario runs.

### Scenarios

1. **CompetitionMatch**: Full 15s auto + 135s teleop + endgame with mode transitions
2. **SubsystemSuite**: Cycles through each subsystem (shooter, indexer, intake, agitator, hanger) at different speeds to verify telemetry readings
3. **RapidFire**: Shoots balls rapidly to stress-test scoring telemetry and cycle tracking
4. **Brownout**: Simulates battery voltage drops to test brownout detection and alerts
5. **FaultInjection**: Simulates motor disconnects and CAN bus failures
6. **RapidModeTransition**: Rapid enable/disable/auto/teleop switching to test mode change handling
7. **FullVideoShowcase**: Scripted demo that exercises every telemetry signal for video recording
8. **AMDAShowcase**: Demonstrates all 4 feedback channels (haptic, LED, dashboard, vision confidence) working together
9. **SignalCoverage**: Touches every logged signal at least once to verify nothing crashes
10. **HubShiftPractice**: Runs a 140s teleop countdown with REBUILT hub shift schedule so the driver can practice feeling the haptic shift warnings

### Robot.java / RobotContainer.java changes

- `Robot.java`: Added `simulationInit()` and `simulationPeriodic()` bodies that create and update SimDeviceManager and SimScenarioRunner.
- `RobotContainer.java`: Added SimDriveOverride integration into the drive input  stream (only active in sim). Added sim-only button bindings for driveToPose testing.