### PR TITLE
Fix isRedAlliance() always returning false for red alliance

### DIFF
--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -387,16 +387,11 @@ public class RobotContainer {
   }
 
   private boolean isRedAlliance() {
-    Optional<Alliance> ally = DriverStation.getAlliance();
-if (ally.isPresent()) {
-    if (ally.get() == Alliance.Red) {
-        return false;
+    var alliance = DriverStation.getAlliance();
+    if (alliance.isPresent()) {
+      return alliance.get() == DriverStation.Alliance.Red;
     }
-    if (ally.get() == Alliance.Blue) {
-        return false;
-    }
-}
-return false;
+    return false;
   }
 
   private Translation2d getHubCenter() {


### PR DESCRIPTION
isRedAlliance() returns false for both red and blue alliance (changed in dea6799). Robot always aims at the blue hub regardless of actual alliance.