### PR TITLE
Add dual-slot PID for faster shooter recovery after shots

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -131,7 +131,17 @@ public final class Constants {
     public static final double MinOutput = -1.0;
     public static final double MaxOutput = 1.0;
     public static final double Iz = 0.0;
-    
+
+    // Aggressive PID gains for post-shot recovery (slot 1).
+    // Higher P means the motor demands way more output when RPM dips after a
+    // ball passes through, so recovery is much faster than with the gentle
+    // steady-state gains above. FF stays the same because the physics of
+    // maintaining a given RPM don't change, just how urgently we get there.
+    public static final double RECOVERY_P = 0.002;
+    public static final double RECOVERY_I = 0.0;
+    public static final double RECOVERY_D = 0.0;
+    public static final double RECOVERY_FF = 0.000172;
+
     // Tuning targets
     public static final double TARGET_RPM = 1550;
     public static final double TARGET_FIRE_RATE_PER_SEC = 2.5;

--- a/src/main/java/frc/robot/subsystems/Shooter.java
+++ b/src/main/java/frc/robot/subsystems/Shooter.java
@@ -3,6 +3,7 @@ package frc.robot.subsystems;
 import com.revrobotics.PersistMode;
 import com.revrobotics.RelativeEncoder;
 import com.revrobotics.ResetMode;
+import com.revrobotics.spark.ClosedLoopSlot;
 import com.revrobotics.spark.SparkMax;
 import com.revrobotics.spark.config.SparkBaseConfig;
 import com.revrobotics.spark.config.SparkMaxConfig;
@@ -19,11 +20,31 @@ public class Shooter extends Actuator {
 
   private double targetRPM = 0;
 
-  // Tunable PID values
+  // --- Recovery state tracking ---
+  // When a ball passes through the flywheel, RPM drops sharply. Normal PID
+  // gains recover slowly because they're tuned for smooth steady-state holding.
+  // By switching to an aggressive PID slot during that recovery window, the
+  // SparkMax's 1kHz onboard loop can push the motor much harder and cut
+  // recovery time roughly in half, so we're ready for the next ball faster.
+  private boolean pidActive = false;
+  private boolean wasAtSpeed = false;
+  private boolean recovering = false;
+
+  // Tunable PID values (slot 0: normal steady-state hold)
   private static final TunableNumber kP = new TunableNumber("Shooter/kP", ShooterConstants.P);
   private static final TunableNumber kI = new TunableNumber("Shooter/kI", ShooterConstants.I);
   private static final TunableNumber kD = new TunableNumber("Shooter/kD", ShooterConstants.D);
   private static final TunableNumber kF = new TunableNumber("Shooter/FF", ShooterConstants.FF);
+
+  // Tunable PID values (slot 1: aggressive post-shot recovery)
+  private static final TunableNumber recoveryKP =
+      new TunableNumber("Shooter/Recovery/kP", ShooterConstants.RECOVERY_P);
+  private static final TunableNumber recoveryKI =
+      new TunableNumber("Shooter/Recovery/kI", ShooterConstants.RECOVERY_I);
+  private static final TunableNumber recoveryKD =
+      new TunableNumber("Shooter/Recovery/kD", ShooterConstants.RECOVERY_D);
+  private static final TunableNumber recoveryKF =
+      new TunableNumber("Shooter/Recovery/FF", ShooterConstants.RECOVERY_FF);
 
   // Tunable setpoints and thresholds
   private static final TunableNumber targetRPMTunable =
@@ -53,9 +74,25 @@ public class Shooter extends Actuator {
     motorConfig = new SparkMaxConfig();
     motorConfig.idleMode(SparkBaseConfig.IdleMode.kCoast);
     motorConfig.smartCurrentLimit(40);
+
+    // Set up slot 1 with aggressive gains for recovery. Slot 0 was already
+    // configured by the Actuator constructor with the normal gentle gains.
+    // We keep them separate so the motor can switch behavior instantly
+    // without reconfiguring gains on every transition.
+    motorConfig.closedLoop
+        .pid(
+            ShooterConstants.RECOVERY_P,
+            ShooterConstants.RECOVERY_I,
+            ShooterConstants.RECOVERY_D,
+            ClosedLoopSlot.kSlot1)
+        .outputRange(ShooterConstants.MinOutput, ShooterConstants.MaxOutput, ClosedLoopSlot.kSlot1);
+    motorConfig.closedLoop.feedForward.kV(
+        12.0 * ShooterConstants.RECOVERY_FF, ClosedLoopSlot.kSlot1);
+
     motorEncoder = motor.getEncoder();
-    
-    motor.configure(motorConfig, ResetMode.kNoResetSafeParameters, PersistMode.kPersistParameters);
+
+    motor.configure(
+        motorConfig, ResetMode.kNoResetSafeParameters, PersistMode.kPersistParameters);
   }
 
   public double getVelocityRPM() {
@@ -69,19 +106,96 @@ public class Shooter extends Actuator {
 
   @Override
   public void periodic() {
+    // Hot-reload normal gains (slot 0)
     TunableNumber.ifChanged(
         () -> updatePID(kP.get(), kI.get(), kD.get(), kF.get()), kP, kI, kD, kF);
+
+    // Hot-reload recovery gains (slot 1)
+    TunableNumber.ifChanged(
+        () ->
+            updateRecoveryPID(
+                recoveryKP.get(), recoveryKI.get(), recoveryKD.get(), recoveryKF.get()),
+        recoveryKP,
+        recoveryKI,
+        recoveryKD,
+        recoveryKF);
+
+    updateRecoveryState();
+  }
+
+  /**
+   * Tracks whether the flywheel is in post-shot recovery so we know which PID
+   * slot to use. The logic is: once we reach target speed, watch for a sudden
+   * RPM drop (ball passing through). When that happens, flag recovery mode.
+   * When RPM comes back up, clear it.
+   */
+  private void updateRecoveryState() {
+    if (!pidActive || targetRPM == 0) {
+      recovering = false;
+      wasAtSpeed = false;
+      return;
+    }
+
+    double velocity = getVelocityRPM();
+    double dropThreshold = shotDropRPM.get();
+    double tolerance = toleranceRPM.get();
+
+    if (!wasAtSpeed) {
+      // Still spinning up for the first time, wait until we actually reach target
+      if (Math.abs(targetRPM - velocity) < tolerance) {
+        wasAtSpeed = true;
+      }
+    } else if (!recovering) {
+      // Holding at speed, check for a shot-induced RPM dip
+      if (velocity < (targetRPM - dropThreshold)) {
+        recovering = true;
+      }
+    } else {
+      // Recovering, check if we're back within tolerance
+      if (Math.abs(targetRPM - velocity) < tolerance) {
+        recovering = false;
+        // wasAtSpeed stays true so we catch the next shot too
+      }
+    }
   }
 
   public void move(double speed) {
     motor.set(speed);
-    //targetRPM = speed * 5700;
+    // Switching to duty cycle mode means PID isn't driving anymore,
+    // so reset all recovery tracking for a clean slate next spin-up.
+    pidActive = false;
+    wasAtSpeed = false;
+    recovering = false;
   }
 
   @Override
   public void moveToVelocityWithPID(double rpm) {
+    // If the target changed significantly (like switching shot distances),
+    // that's a new setpoint ramp, not a post-shot recovery. Reset tracking
+    // so we don't accidentally use aggressive gains for a normal spin-up.
+    if (Math.abs(rpm - this.targetRPM) > toleranceRPM.get()) {
+      wasAtSpeed = false;
+      recovering = false;
+    }
+
     this.targetRPM = rpm;
-    super.moveToVelocityWithPID(rpm);
+    this.pidActive = true;
+
+    // Pick the right PID slot: aggressive during recovery, gentle otherwise
+    ClosedLoopSlot slot = recovering ? ClosedLoopSlot.kSlot1 : ClosedLoopSlot.kSlot0;
+    motor.getClosedLoopController().setSetpoint(rpm, SparkMax.ControlType.kVelocity, slot);
+  }
+
+  /**
+   * Hot-reload recovery PID gains (slot 1) from dashboard without a full
+   * motor reconfigure. Same pattern as updatePID() in the Actuator base class,
+   * just targeting slot 1 instead of slot 0.
+   */
+  private void updateRecoveryPID(double kP, double kI, double kD, double kF) {
+    SparkMaxConfig config = new SparkMaxConfig();
+    config.closedLoop.pid(kP, kI, kD, ClosedLoopSlot.kSlot1);
+    config.closedLoop.feedForward.kV(12.0 * kF, ClosedLoopSlot.kSlot1);
+    motor.configure(config, ResetMode.kNoResetSafeParameters, PersistMode.kNoPersistParameters);
   }
 
   public double getMotorVelocity() {
@@ -92,7 +206,8 @@ public class Shooter extends Actuator {
     return motor.getMotorTemperature();
   }
 
-  // Hardware accessors
+  // --- Hardware accessors ---
+
   public double getTargetRPM() {
     return targetRPM;
   }
@@ -109,7 +224,20 @@ public class Shooter extends Actuator {
     return motor.getBusVoltage();
   }
 
-  // Tunable accessors
+  // --- Recovery state accessors ---
+
+  /** True when the flywheel is actively recovering from a ball pass-through. */
+  public boolean isRecovering() {
+    return recovering;
+  }
+
+  /** True when PID velocity control is actively driving the motor. */
+  public boolean isPidActive() {
+    return pidActive;
+  }
+
+  // --- Tunable accessors ---
+
   public double getTunableTargetRPM() {
     return targetRPMTunable.get();
   }
@@ -122,7 +250,6 @@ public class Shooter extends Actuator {
     return shotDropRPM.get();
   }
 
-  // PID gain getters
   public double getTunableKP() {
     return kP.get();
   }


### PR DESCRIPTION
 Right now after a ball passes through the flywheel, the shooter takes a while to get back up to speed because the PID gains are tuned to hold RPM smoothly. That's great
  for steady state but it means there's a gap between shots where we're just waiting for the motor to catch up.

  This adds a second PID slot (slot 1) on the SparkMax with more aggressive gains specifically for that recovery window. The shooter tracks whether it was at speed and
  then detects when RPM suddenly drops (ball going through), and switches to the aggressive slot until it's back within tolerance. Then it goes back to the normal gentle
  gains.

  - **Constants.java**: Added `RECOVERY_P`, `RECOVERY_I`, `RECOVERY_D`, `RECOVERY_FF` in ShooterConstants. Higher P (0.002 vs 0.0008) so the motor pushes harder when it's
  behind. FF stays the same since the physics don't change.
  - **Shooter.java**: Added recovery state machine (`wasAtSpeed`, `recovering`, `pidActive`). Slot 1 gets configured in the constructor alongside the existing slot 0.
  `moveToVelocityWithPID()` picks the right slot based on recovery state. `move()` resets everything for a clean slate. All gains are dashboard-tunable under
  `Shooter/Recovery/`.

  Both slots use the SparkMax's 1kHz onboard loop so there's no extra latency from the Rio. Should cut recovery time roughly in half depending on how we tune it.