### PR TITLE
Add ball physics sim for programming w/o robot

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -11,7 +11,6 @@ import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.math.geometry.Translation2d;
 import edu.wpi.first.math.geometry.Translation3d;
 import edu.wpi.first.math.util.Units;
-
 import swervelib.math.Matter;
 
 /**
@@ -24,346 +23,346 @@ import swervelib.math.Matter;
  */
 public final class Constants {
 
-    /**
-     * Master tuning mode switch. - true: Values read from dashboard (practice/testing) - false:
-     * Values locked to defaults (competition)
-     *
-     * <p>IMPORTANT: Set to FALSE before competition deployment!
+  /**
+   * Master tuning mode switch. - true: Values read from dashboard (practice/testing) - false:
+   * Values locked to defaults (competition)
+   *
+   * <p>IMPORTANT: Set to FALSE before competition deployment!
+   */
+  public static final boolean TUNING_MODE = true;
+
+  public static final double ROBOT_MASS = (148 - 20.3) * 0.453592; // 32lbs * kg per pound
+  public static final double LOOP_TIME = 0.13; // s, 20ms + 110ms sprk max velocity lag
+  public static final double MAX_SPEED = Units.feetToMeters(14.5);
+  // Maximum speed of the robot in meters per second, used to limit acceleration.
+  public static final Matter CHASSIS =
+      new Matter(new Translation3d(0, 0, Units.inchesToMeters(8)), ROBOT_MASS);
+
+  public static final class DrivebaseConstants {
+
+    // Hold time on motor brakes when disabled
+    public static final double WHEEL_LOCK_TIME = 10; // seconds
+  }
+
+  public static final class FieldConstants {
+    public static final AprilTagFieldLayout FIELD_LAYOUT =
+        AprilTagFieldLayout.loadField(AprilTagFields.k2026RebuiltAndymark);
+
+    public static final double DistanceToHub = 0.4;
+  }
+
+  public static class OperatorConstants {
+
+    // Joystick Deadband
+    public static final double DEADBAND = 0.1;
+    public static final double LEFT_Y_DEADBAND = 0.1;
+    public static final double RIGHT_X_DEADBAND = 0.1;
+    public static final double TURN_CONSTANT = 6;
+  }
+
+  public static final class HubScoringConstants {
+
+    // Hub positions on field
+    public static final Translation2d BLUE_HUB_CENTER = new Translation2d(4.625594, 4.0);
+    public static final Translation2d RED_HUB_CENTER = new Translation2d(11.901424, 4.0);
+
+    // Scoring parameters
+    public static final double SCORING_DISTANCE = 2; // meters from hub center
+    public static final double MAX_ARC_SPEED = 2.0; // max speed while driving along arc (m/s)
+
+    // Valid scoring arc definition
+    public static final Rotation2d BLUE_SCORING_SIDE = Rotation2d.fromDegrees(180); // Faces +X
+    public static final Rotation2d RED_SCORING_SIDE = Rotation2d.fromDegrees(0); // Faces -X
+    public static final double SCORING_ARC_WIDTH_DEGREES =
+        90; // 180 = semicircle, 90 = quarter circle
+
+    // Tolerances
+    public static final double POSITION_TOLERANCE = 0.05; // meters
+    public static final double ANGLE_TOLERANCE = 2.0; // degrees
+  }
+
+  public static class PhotonvisionConstants {
+
+    /*
+    deploy order for Json files of swerve modules
+    frontleft,
+    frontright,
+    backleft,
+    backright
      */
-    public static final boolean TUNING_MODE = true;
+  }
 
-    public static final double ROBOT_MASS = (148 - 20.3) * 0.453592; // 32lbs * kg per pound
-    public static final double LOOP_TIME = 0.13; // s, 20ms + 110ms sprk max velocity lag
-    public static final double MAX_SPEED = Units.feetToMeters(14.5);
-    // Maximum speed of the robot in meters per second, used to limit acceleration.
-    public static final Matter CHASSIS =
-            new Matter(new Translation3d(0, 0, Units.inchesToMeters(8)), ROBOT_MASS);
+  public static final class CANDeviceIDs {
+    public static final int kIndexerID = 50;
+    public static final int kShooterID = 52;
+    public static final int kIntakePivotID = 56;
+    public static final int kIntakeRollerID = 55;
+    public static final int kHangerID = 60;
+    public static final int kAgitatorID = 54;
+  }
 
-    public static final class DrivebaseConstants {
+  public static final class MotorConstants {
+    public static final double DESIRED_SHOOTER_RPM = 3730;
+    public static final double DESIRED_INDEXER_RPM = 7833; // 8.4 * 3730/4
+    public static final double OUT_INTAKE_POS = 38.24;
+    public static final double IN_INTAKE_POS = 11.6;
+    public static final double DESIRED_INTAKE_RPM = 0;
+    public static final double UP_HANGER_POS = 0;
+    public static final double DOWN_HANGER_POS = 0;
+    public static final double DESIRED_AGITATOR_SPEED = .5;
+  }
 
-        // Hold time on motor brakes when disabled
-        public static final double WHEEL_LOCK_TIME = 10; // seconds
+  public static final class IntakeRollerConstants {
+    public static final double P = 1.0;
+    public static final double I = 0.0;
+    public static final double D = 0.0;
+    public static final double MinOutput = -1.0;
+    public static final double MaxOutput = 1.0;
+    public static final double FF = 0.0;
+    public static final double Iz = 0.0;
+  }
+
+  public static final class IntakePivotConstants {
+    public static final double P = 1.0;
+    public static final double I = 0.0;
+    public static final double D = 0.2;
+    public static final double MinOutput = -1.0;
+    public static final double MaxOutput = 1.0;
+    public static final double FF = 0.0;
+    public static final double Iz = 0.0;
+  }
+
+  public static final class ShooterConstants {
+    // Velocity PID tuning (from Kfir2026)
+    public static final double P = 0.00011;
+    public static final double I = 0.0;
+    public static final double D = 0.0;
+    public static final double FF = 0.000172;
+    public static final double MinOutput = -1.0;
+    public static final double MaxOutput = 1.0;
+    public static final double Iz = 0.0;
+
+    // Tuning targets
+    public static final double TARGET_RPM = 3730;
+    public static final double TARGET_FIRE_RATE_PER_SEC = 2.5;
+    public static final double TARGET_RECOVERY_MS = 150.0;
+
+    // Telemetry constants
+    public static final double SPEED_TOLERANCE_RPM = 50.0;
+    public static final double VELOCITY_CONVERSION = 1.0;
+    public static final double SHOT_DETECTION_DROP_RPM = 200.0;
+    public static final double SHOT_DETECTION_MIN_RPM = 1000.0;
+    public static final double TEMP_WARNING_CELSIUS = 65.0;
+  }
+
+  public static final class IndexerConstants {
+    // Velocity PID (from Alden)
+    public static final double P = 0.000;
+    public static final double I = 0.0;
+    public static final double D = 0.00;
+    public static final double MinOutput = -1.0;
+    public static final double MaxOutput = 1.0;
+    public static final double FF = 0.0004;
+    public static final double Iz = 0.0;
+
+    // Telemetry constants
+    public static final double TARGET_SPEED = 7833;
+    public static final double JAM_CURRENT_THRESHOLD_AMPS = 35.0;
+    public static final double JAM_TIME_THRESHOLD_SECONDS = 0.3;
+  }
+
+  public static final class AgitatorConstants {
+    public static final double P = 0.000;
+    public static final double I = 0.0;
+    public static final double D = 0.0;
+    public static final double MinOutput = -1.0;
+    public static final double MaxOutput = 1.0;
+    public static final double FF = 0.0002;
+    public static final double Iz = 0.0;
+
+    public static final double TARGET_RPM = 2000;
+    public static final double JAM_CURRENT_THRESHOLD_AMPS = 25.0;
+    public static final double JAM_TIME_THRESHOLD_SECONDS = 0.3;
+  }
+
+  public static final class HopperConstants {
+    public static final int LOW_BALL_THRESHOLD = 3;
+    public static final double DETECTION_CONFIDENCE_THRESHOLD = 0.8;
+  }
+
+  public static final class HangerConstants {
+    public static final double P = 1.0;
+    public static final double I = 0.0;
+    public static final double D = 0.0;
+    public static final double MinOutput = -1.0;
+    public static final double MaxOutput = 1.0;
+    public static final double FF = 0.0;
+    public static final double Iz = 0.0;
+    public static final double POSITION_TOLERANCE = 0.1;
+  }
+
+  public static final class BatteryThresholds {
+    public static final double CRITICAL_V = 10.0;
+    public static final double WARNING_V = 11.5;
+    public static final double PRE_MATCH_WARN_V = 12.3;
+    public static final double PRE_MATCH_FAIL_V = 12.0;
+  }
+
+  /** CAN bus disconnect debounce and scoring readiness stabilization */
+  public static final class DeviceHealthConstants {
+    // Motor must report disconnected for this long before we flag it (filters CAN glitches)
+    public static final double DISCONNECT_DEBOUNCE_SEC = 0.5;
+    // ReadyToShoot stays true through brief velocity dips during sustained fire
+    public static final double READY_TO_SHOOT_DEBOUNCE_SEC = 0.15;
+  }
+
+  /**
+   * Pre-deploy and pre-merge safety gates. Run via Gradle tasks:
+   *
+   * <ul>
+   *   <li>{@code ./gradlew checkDeploy} blocks deploy when TUNING_MODE is on
+   *   <li>{@code ./gradlew checkCompetition} stricter gate for match day
+   * </ul>
+   *
+   * Skip with {@code ./gradlew deploy -x checkDeploy} if you really need tuning on the robot.
+   */
+  public static final class DeploySafetyCheck {
+    /** Returns false if TUNING_MODE is on (unsafe for competition deploy). */
+    public static boolean isSafeForDeploy() {
+      return !TUNING_MODE;
     }
 
-    public static final class FieldConstants {
-        public static final AprilTagFieldLayout FIELD_LAYOUT =
-                AprilTagFieldLayout.loadField(AprilTagFields.k2026RebuiltAndymark);
-
-        public static final double DistanceToHub = 0.4;
+    // back left left 11.54, 11.54, 45 degrees 15 desgrees
+    /** Gradle entry point: exits 1 if deploy is unsafe. */
+    public static void main(String... args) {
+      if (!isSafeForDeploy()) {
+        System.err.println("DEPLOY BLOCKED: TUNING_MODE = true");
+        System.err.println("Set Constants.TUNING_MODE = false before deploying to robot.");
+        System.err.println("Override: ./gradlew deploy -x checkDeploy");
+        System.exit(1);
+      }
+      System.out.println("Deploy safety check passed.");
     }
+  }
 
-    public static class OperatorConstants {
+  public static final class LEDConstants {
+    public static final int PWM_PORT = 0;
+    public static final int STRIP_LENGTH = 19;
+    public static final double DIM_DISABLED = 0.15;
+  }
 
-        // Joystick Deadband
-        public static final double DEADBAND = 0.1;
-        public static final double LEFT_Y_DEADBAND = 0.1;
-        public static final double RIGHT_X_DEADBAND = 0.1;
-        public static final double TURN_CONSTANT = 6;
+  /**
+   * PDH channel map. Maps physical PDH channel (0-23) to a human-readable circuit name. Update this
+   * when wiring changes. Channels without a label are logged as "Ch{N}".
+   */
+  public static final class PDHChannelMap {
+    public static final int NUM_CHANNELS = 24;
+
+    // Channel labels: index = PDH channel number, value = circuit name
+    // Update these to match your actual wiring harness
+    private static final String[] LABELS = {
+      "FrontLeftDrive", // 0
+      "FrontLeftTurn", // 1
+      "FrontRightDrive", // 2
+      "FrontRightTurn", // 3
+      "BackLeftDrive", // 4
+      "BackLeftTurn", // 5
+      "BackRightDrive", // 6
+      "BackRightTurn", // 7
+      "Shooter", // 8
+      "Indexer", // 9
+      "Agitator", // 10
+      "Intake", // 11
+      "IntakeActuator", // 12
+      "Hanger", // 13
+      "Ch14", // 14 - unused/unknown
+      "Ch15", // 15 - unused/unknown
+      "Ch16", // 16 - unused/unknown
+      "Ch17", // 17 - unused/unknown
+      "Ch18", // 18 - unused/unknown
+      "Ch19", // 19 - unused/unknown
+      "Radio", // 20
+      "RoboRIO", // 21
+      "Ch22", // 22 - unused/unknown
+      "Ch23", // 23 - unused/unknown
+    };
+
+    /** Alert when any single channel exceeds this current (amps). */
+    public static final double CHANNEL_OVERCURRENT_AMPS = 40.0;
+
+    public static String getLabel(int channel) {
+      if (channel >= 0 && channel < LABELS.length) {
+        return LABELS[channel];
+      }
+      return "Ch" + channel;
     }
+  }
 
-    public static final class HubScoringConstants {
+  /** Jam protection: 3-layer debounce + auto-reverse + disable after max attempts */
+  public static final class JamProtectionConstants {
+    // Intake jam protection
+    public static final double INTAKE_JAM_CURRENT_AMPS = 25.0;
+    public static final double INTAKE_JAM_VELOCITY_RPM = 100.0;
+    public static final double INTAKE_STARTUP_IGNORE_SEC = 0.5;
+    public static final double INTAKE_JAM_CONFIRM_SEC = 0.3;
+    public static final double INTAKE_REVERSE_SEC = 0.4;
+    public static final double INTAKE_COOLDOWN_SEC = 0.15;
+    public static final double INTAKE_REVERSE_POWER = -0.4;
+    public static final int INTAKE_MAX_ATTEMPTS = 3;
 
-        // Hub positions on field
-        public static final Translation2d BLUE_HUB_CENTER = new Translation2d(4.625594, 4.0);
-        public static final Translation2d RED_HUB_CENTER = new Translation2d(11.901424, 4.0);
+    // Indexer jam protection (raised confirm + velocity to avoid false triggers during ball
+    // passage)
+    public static final double INDEXER_JAM_CURRENT_AMPS = 25.0;
+    public static final double INDEXER_JAM_VELOCITY_RPM = 200.0;
+    public static final double INDEXER_STARTUP_IGNORE_SEC = 0.5;
+    public static final double INDEXER_JAM_CONFIRM_SEC = 0.5;
+    public static final double INDEXER_REVERSE_SEC = 0.3;
+    public static final double INDEXER_COOLDOWN_SEC = 0.15;
+    public static final double INDEXER_REVERSE_POWER = -0.3;
+    public static final int INDEXER_MAX_ATTEMPTS = 3;
 
-        // Scoring parameters
-        public static final double SCORING_DISTANCE = 2; // meters from hub center
-        public static final double MAX_ARC_SPEED = 2.0; // max speed while driving along arc (m/s)
+    // Agitator jam protection (raised current threshold, needs real stall current measurement)
+    public static final double AGITATOR_JAM_CURRENT_AMPS = 20.0;
+    public static final double AGITATOR_JAM_VELOCITY_RPM = 100.0;
+    public static final double AGITATOR_STARTUP_IGNORE_SEC = 0.5;
+    public static final double AGITATOR_JAM_CONFIRM_SEC = 0.3;
+    public static final double AGITATOR_REVERSE_SEC = 0.4;
+    public static final double AGITATOR_COOLDOWN_SEC = 0.15;
+    public static final double AGITATOR_REVERSE_POWER = -0.3;
+    public static final int AGITATOR_MAX_ATTEMPTS = 3;
+  }
 
-        // Valid scoring arc definition
-        public static final Rotation2d BLUE_SCORING_SIDE = Rotation2d.fromDegrees(180); // Faces +X
-        public static final Rotation2d RED_SCORING_SIDE = Rotation2d.fromDegrees(0); // Faces -X
-        public static final double SCORING_ARC_WIDTH_DEGREES =
-                90; // 180 = semicircle, 90 = quarter circle
+  /** Stall = high current + low velocity for debounce time */
+  public static final class StallDetectionConstants {
+    // Shooter stall thresholds
+    public static final double SHOOTER_STALL_CURRENT_AMPS = 50.0;
+    public static final double SHOOTER_STALL_VELOCITY_RPM = 100.0;
+    public static final double SHOOTER_STALL_DEBOUNCE_MS = 250.0;
 
-        // Tolerances
-        public static final double POSITION_TOLERANCE = 0.05; // meters
-        public static final double ANGLE_TOLERANCE = 2.0; // degrees
-    }
+    // Indexer stall thresholds
+    public static final double INDEXER_STALL_CURRENT_AMPS = 15.0;
+    public static final double INDEXER_STALL_VELOCITY_RPM = 50.0;
+    public static final double INDEXER_STALL_DEBOUNCE_MS = 200.0;
 
-    public static class PhotonvisionConstants {
+    // Intake stall thresholds
+    public static final double INTAKE_STALL_CURRENT_AMPS = 20.0;
+    public static final double INTAKE_STALL_VELOCITY_RPM = 100.0;
+    public static final double INTAKE_STALL_DEBOUNCE_MS = 200.0;
+  }
 
-        /*
-        deploy order for Json files of swerve modules
-        frontleft,
-        frontright,
-        backleft,
-        backright
-         */
-    }
+  /** Projectile physics constants (measured from CAD) */
+  public static final class ProjectileSimConstants {
+    public static final double EXIT_HEIGHT_M = 0.4313; // 16.98in from floor
+    public static final double WHEEL_DIAMETER_M = 0.1016; // 4" flywheel
+    public static final double TARGET_HEIGHT_M = 1.83; // 72in hub entry
+    public static final double DT = 0.001; // integration step (s)
+    public static final double DRAG_COEFFICIENT = 0.47; // smooth sphere
+    public static final double BALL_MASS_KG = 0.27; // ~9.5oz fuel ball
+    public static final double BALL_RADIUS_M = 0.0889; // 3.5" radius
+  }
 
-    public static final class CANDeviceIDs {
-        public static final int kIndexerID = 50;
-        public static final int kShooterID = 52;
-        public static final int kIntakePivotID = 56;
-        public static final int kIntakeRollerID = 55;
-        public static final int kHangerID = 60;
-        public static final int kAgitatorID = 54;
-    }
-
-    public static final class MotorConstants {
-        public static final double DESIRED_SHOOTER_RPM = 3730;
-        public static final double DESIRED_INDEXER_RPM = 7833; // 8.4 * 3730/4
-        public static final double OUT_INTAKE_POS = 38.24;
-        public static final double IN_INTAKE_POS = 11.6;
-        public static final double DESIRED_INTAKE_RPM = 0;
-        public static final double UP_HANGER_POS = 0;
-        public static final double DOWN_HANGER_POS = 0;
-        public static final double DESIRED_AGITATOR_SPEED = .5;
-    }
-
-    public static final class IntakeRollerConstants {
-        public static final double P = 1.0;
-        public static final double I = 0.0;
-        public static final double D = 0.0;
-        public static final double MinOutput = -1.0;
-        public static final double MaxOutput = 1.0;
-        public static final double FF = 0.0;
-        public static final double Iz = 0.0;
-    }
-
-    public static final class IntakePivotConstants {
-        public static final double P = 1.0;
-        public static final double I = 0.0;
-        public static final double D = 0.2;
-        public static final double MinOutput = -1.0;
-        public static final double MaxOutput = 1.0;
-        public static final double FF = 0.0;
-        public static final double Iz = 0.0;
-    }
-
-    public static final class ShooterConstants {
-        // Velocity PID tuning (from Kfir2026)
-        public static final double P = 0.00011;
-        public static final double I = 0.0;
-        public static final double D = 0.0;
-        public static final double FF = 0.000172;
-        public static final double MinOutput = -1.0;
-        public static final double MaxOutput = 1.0;
-        public static final double Iz = 0.0;
-
-        // Tuning targets
-        public static final double TARGET_RPM = 3730;
-        public static final double TARGET_FIRE_RATE_PER_SEC = 2.5;
-        public static final double TARGET_RECOVERY_MS = 150.0;
-
-        // Telemetry constants
-        public static final double SPEED_TOLERANCE_RPM = 50.0;
-        public static final double VELOCITY_CONVERSION = 1.0;
-        public static final double SHOT_DETECTION_DROP_RPM = 200.0;
-        public static final double SHOT_DETECTION_MIN_RPM = 1000.0;
-        public static final double TEMP_WARNING_CELSIUS = 65.0;
-    }
-
-    public static final class IndexerConstants {
-        // Velocity PID (from Alden)
-        public static final double P = 0.000;
-        public static final double I = 0.0;
-        public static final double D = 0.00;
-        public static final double MinOutput = -1.0;
-        public static final double MaxOutput = 1.0;
-        public static final double FF = 0.0004;
-        public static final double Iz = 0.0;
-
-        // Telemetry constants
-        public static final double TARGET_SPEED = 7833;
-        public static final double JAM_CURRENT_THRESHOLD_AMPS = 35.0;
-        public static final double JAM_TIME_THRESHOLD_SECONDS = 0.3;
-    }
-
-    public static final class AgitatorConstants {
-        public static final double P = 0.000;
-        public static final double I = 0.0;
-        public static final double D = 0.0;
-        public static final double MinOutput = -1.0;
-        public static final double MaxOutput = 1.0;
-        public static final double FF = 0.0002;
-        public static final double Iz = 0.0;
-
-        public static final double TARGET_RPM = 2000;
-        public static final double JAM_CURRENT_THRESHOLD_AMPS = 25.0;
-        public static final double JAM_TIME_THRESHOLD_SECONDS = 0.3;
-    }
-
-    public static final class HopperConstants {
-        public static final int LOW_BALL_THRESHOLD = 3;
-        public static final double DETECTION_CONFIDENCE_THRESHOLD = 0.8;
-    }
-
-    public static final class HangerConstants {
-        public static final double P = 1.0;
-        public static final double I = 0.0;
-        public static final double D = 0.0;
-        public static final double MinOutput = -1.0;
-        public static final double MaxOutput = 1.0;
-        public static final double FF = 0.0;
-        public static final double Iz = 0.0;
-        public static final double POSITION_TOLERANCE = 0.1;
-    }
-
-    public static final class BatteryThresholds {
-        public static final double CRITICAL_V = 10.0;
-        public static final double WARNING_V = 11.5;
-        public static final double PRE_MATCH_WARN_V = 12.3;
-        public static final double PRE_MATCH_FAIL_V = 12.0;
-    }
-
-    /** CAN bus disconnect debounce and scoring readiness stabilization */
-    public static final class DeviceHealthConstants {
-        // Motor must report disconnected for this long before we flag it (filters CAN glitches)
-        public static final double DISCONNECT_DEBOUNCE_SEC = 0.5;
-        // ReadyToShoot stays true through brief velocity dips during sustained fire
-        public static final double READY_TO_SHOOT_DEBOUNCE_SEC = 0.15;
-    }
-
-    /**
-     * Pre-deploy and pre-merge safety gates. Run via Gradle tasks:
-     *
-     * <ul>
-     *   <li>{@code ./gradlew checkDeploy} blocks deploy when TUNING_MODE is on
-     *   <li>{@code ./gradlew checkCompetition} stricter gate for match day
-     * </ul>
-     *
-     * Skip with {@code ./gradlew deploy -x checkDeploy} if you really need tuning on the robot.
-     */
-    public static final class DeploySafetyCheck {
-        /** Returns false if TUNING_MODE is on (unsafe for competition deploy). */
-        public static boolean isSafeForDeploy() {
-            return !TUNING_MODE;
-        }
-
-        // back left left 11.54, 11.54, 45 degrees 15 desgrees
-        /** Gradle entry point: exits 1 if deploy is unsafe. */
-        public static void main(String... args) {
-            if (!isSafeForDeploy()) {
-                System.err.println("DEPLOY BLOCKED: TUNING_MODE = true");
-                System.err.println("Set Constants.TUNING_MODE = false before deploying to robot.");
-                System.err.println("Override: ./gradlew deploy -x checkDeploy");
-                System.exit(1);
-            }
-            System.out.println("Deploy safety check passed.");
-        }
-    }
-
-    public static final class LEDConstants {
-        public static final int PWM_PORT = 0;
-        public static final int STRIP_LENGTH = 19;
-        public static final double DIM_DISABLED = 0.15;
-    }
-
-    /**
-     * PDH channel map. Maps physical PDH channel (0-23) to a human-readable circuit name. Update
-     * this when wiring changes. Channels without a label are logged as "Ch{N}".
-     */
-    public static final class PDHChannelMap {
-        public static final int NUM_CHANNELS = 24;
-
-        // Channel labels: index = PDH channel number, value = circuit name
-        // Update these to match your actual wiring harness
-        private static final String[] LABELS = {
-            "FrontLeftDrive", // 0
-            "FrontLeftTurn", // 1
-            "FrontRightDrive", // 2
-            "FrontRightTurn", // 3
-            "BackLeftDrive", // 4
-            "BackLeftTurn", // 5
-            "BackRightDrive", // 6
-            "BackRightTurn", // 7
-            "Shooter", // 8
-            "Indexer", // 9
-            "Agitator", // 10
-            "Intake", // 11
-            "IntakeActuator", // 12
-            "Hanger", // 13
-            "Ch14", // 14 - unused/unknown
-            "Ch15", // 15 - unused/unknown
-            "Ch16", // 16 - unused/unknown
-            "Ch17", // 17 - unused/unknown
-            "Ch18", // 18 - unused/unknown
-            "Ch19", // 19 - unused/unknown
-            "Radio", // 20
-            "RoboRIO", // 21
-            "Ch22", // 22 - unused/unknown
-            "Ch23", // 23 - unused/unknown
-        };
-
-        /** Alert when any single channel exceeds this current (amps). */
-        public static final double CHANNEL_OVERCURRENT_AMPS = 40.0;
-
-        public static String getLabel(int channel) {
-            if (channel >= 0 && channel < LABELS.length) {
-                return LABELS[channel];
-            }
-            return "Ch" + channel;
-        }
-    }
-
-    /** Jam protection: 3-layer debounce + auto-reverse + disable after max attempts */
-    public static final class JamProtectionConstants {
-        // Intake jam protection
-        public static final double INTAKE_JAM_CURRENT_AMPS = 25.0;
-        public static final double INTAKE_JAM_VELOCITY_RPM = 100.0;
-        public static final double INTAKE_STARTUP_IGNORE_SEC = 0.5;
-        public static final double INTAKE_JAM_CONFIRM_SEC = 0.3;
-        public static final double INTAKE_REVERSE_SEC = 0.4;
-        public static final double INTAKE_COOLDOWN_SEC = 0.15;
-        public static final double INTAKE_REVERSE_POWER = -0.4;
-        public static final int INTAKE_MAX_ATTEMPTS = 3;
-
-        // Indexer jam protection (raised confirm + velocity to avoid false triggers during ball
-        // passage)
-        public static final double INDEXER_JAM_CURRENT_AMPS = 25.0;
-        public static final double INDEXER_JAM_VELOCITY_RPM = 200.0;
-        public static final double INDEXER_STARTUP_IGNORE_SEC = 0.5;
-        public static final double INDEXER_JAM_CONFIRM_SEC = 0.5;
-        public static final double INDEXER_REVERSE_SEC = 0.3;
-        public static final double INDEXER_COOLDOWN_SEC = 0.15;
-        public static final double INDEXER_REVERSE_POWER = -0.3;
-        public static final int INDEXER_MAX_ATTEMPTS = 3;
-
-        // Agitator jam protection (raised current threshold, needs real stall current measurement)
-        public static final double AGITATOR_JAM_CURRENT_AMPS = 20.0;
-        public static final double AGITATOR_JAM_VELOCITY_RPM = 100.0;
-        public static final double AGITATOR_STARTUP_IGNORE_SEC = 0.5;
-        public static final double AGITATOR_JAM_CONFIRM_SEC = 0.3;
-        public static final double AGITATOR_REVERSE_SEC = 0.4;
-        public static final double AGITATOR_COOLDOWN_SEC = 0.15;
-        public static final double AGITATOR_REVERSE_POWER = -0.3;
-        public static final int AGITATOR_MAX_ATTEMPTS = 3;
-    }
-
-    /** Stall = high current + low velocity for debounce time */
-    public static final class StallDetectionConstants {
-        // Shooter stall thresholds
-        public static final double SHOOTER_STALL_CURRENT_AMPS = 50.0;
-        public static final double SHOOTER_STALL_VELOCITY_RPM = 100.0;
-        public static final double SHOOTER_STALL_DEBOUNCE_MS = 250.0;
-
-        // Indexer stall thresholds
-        public static final double INDEXER_STALL_CURRENT_AMPS = 15.0;
-        public static final double INDEXER_STALL_VELOCITY_RPM = 50.0;
-        public static final double INDEXER_STALL_DEBOUNCE_MS = 200.0;
-
-        // Intake stall thresholds
-        public static final double INTAKE_STALL_CURRENT_AMPS = 20.0;
-        public static final double INTAKE_STALL_VELOCITY_RPM = 100.0;
-        public static final double INTAKE_STALL_DEBOUNCE_MS = 200.0;
-    }
-
-    /** Projectile physics constants (measured from CAD) */
-    public static final class ProjectileSimConstants {
-        public static final double EXIT_HEIGHT_M = 0.4313; // 16.98in from floor
-        public static final double WHEEL_DIAMETER_M = 0.1016; // 4" flywheel
-        public static final double TARGET_HEIGHT_M = 1.83; // 72in hub entry
-        public static final double DT = 0.001; // integration step (s)
-        public static final double DRAG_COEFFICIENT = 0.47; // smooth sphere
-        public static final double BALL_MASS_KG = 0.27; // ~9.5oz fuel ball
-        public static final double BALL_RADIUS_M = 0.0889; // 3.5" radius
-    }
-
-    /** Shot calculator constants (launcher geometry) */
-    public static final class ShotCalculatorConstants {
-        public static final double FIXED_LAUNCH_ANGLE_DEG = 68.0; // measured from OnShape CAD
-    }
+  /** Shot calculator constants (launcher geometry) */
+  public static final class ShotCalculatorConstants {
+    public static final double FIXED_LAUNCH_ANGLE_DEG = 68.0; // measured from OnShape CAD
+  }
 }

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -8,7 +8,6 @@ import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj.Timer;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.CommandScheduler;
-
 import frc.robot.sim.SimDeviceManager;
 import frc.robot.sim.SimFuelManager;
 import frc.robot.sim.SimScenarioRunner;
@@ -26,7 +25,6 @@ import frc.robot.util.LoggedTracer;
 import frc.robot.util.PostMatchSummary;
 import frc.robot.util.PreMatchDiagnostics;
 import frc.robot.util.PredictiveAlerts;
-
 import org.littletonrobotics.junction.LoggedRobot;
 import org.littletonrobotics.junction.Logger;
 import org.littletonrobotics.junction.networktables.NT4Publisher;
@@ -40,401 +38,395 @@ import org.littletonrobotics.junction.wpilog.WPILOGWriter;
  */
 public class Robot extends LoggedRobot {
 
-    private static Robot instance;
-    private Command m_autonomousCommand;
-    private RobotContainer m_robotContainer;
+  private static Robot instance;
+  private Command m_autonomousCommand;
+  private RobotContainer m_robotContainer;
 
-    private Timer disabledTimer;
-    private SimScenarioRunner simScenarioRunner;
-    private SimDeviceManager simDeviceManager;
-    private SimFuelManager simFuelManager;
+  private Timer disabledTimer;
+  private SimScenarioRunner simScenarioRunner;
+  private SimDeviceManager simDeviceManager;
+  private SimFuelManager simFuelManager;
 
-    // Diagnostics
-    private boolean hasRunDiagnostics = false;
+  // Diagnostics
+  private boolean hasRunDiagnostics = false;
 
-    // Logging status
-    private boolean loggingAvailable = false;
+  // Logging status
+  private boolean loggingAvailable = false;
 
-    public Robot() {
-        instance = this;
-    }
+  public Robot() {
+    instance = this;
+  }
 
-    public static Robot getInstance() {
-        return instance;
-    }
+  public static Robot getInstance() {
+    return instance;
+  }
 
-    private void installExceptionHandler() {
-        Thread.setDefaultUncaughtExceptionHandler(
-                (thread, exception) -> {
-                    try {
-                        DiagnosticContext.captureException(thread, exception);
-                    } catch (Throwable t) {
-                    }
+  private void installExceptionHandler() {
+    Thread.setDefaultUncaughtExceptionHandler(
+        (thread, exception) -> {
+          try {
+            DiagnosticContext.captureException(thread, exception);
+          } catch (Throwable t) {
+          }
 
-                    if (exception instanceof RuntimeException) {
-                        throw (RuntimeException) exception;
-                    } else if (exception instanceof Error) {
-                        throw (Error) exception;
-                    } else {
-                        throw new RuntimeException(exception);
-                    }
-                });
-    }
+          if (exception instanceof RuntimeException) {
+            throw (RuntimeException) exception;
+          } else if (exception instanceof Error) {
+            throw (Error) exception;
+          } else {
+            throw new RuntimeException(exception);
+          }
+        });
+  }
 
-    // Logging configuration
+  // Logging configuration
 
-    /** Configure AdvantageKit logging. Failures are swallowed so the robot keeps running. */
-    private void configureLogging() {
+  /** Configure AdvantageKit logging. Failures are swallowed so the robot keeps running. */
+  private void configureLogging() {
+    try {
+      Logger.recordMetadata("ProjectName", BuildConstants.MAVEN_NAME);
+      Logger.recordMetadata("BuildDate", BuildConstants.BUILD_DATE);
+      Logger.recordMetadata("GitSHA", BuildConstants.GIT_SHA);
+      Logger.recordMetadata("GitBranch", BuildConstants.GIT_BRANCH);
+      Logger.recordMetadata("GitDirty", BuildConstants.DIRTY == 1 ? "true" : "false");
+
+      if (isReal()) {
+        // USB logging, skip if USB not mounted
         try {
-            Logger.recordMetadata("ProjectName", BuildConstants.MAVEN_NAME);
-            Logger.recordMetadata("BuildDate", BuildConstants.BUILD_DATE);
-            Logger.recordMetadata("GitSHA", BuildConstants.GIT_SHA);
-            Logger.recordMetadata("GitBranch", BuildConstants.GIT_BRANCH);
-            Logger.recordMetadata("GitDirty", BuildConstants.DIRTY == 1 ? "true" : "false");
-
-            if (isReal()) {
-                // USB logging, skip if USB not mounted
-                try {
-                    Logger.addDataReceiver(new WPILOGWriter());
-                } catch (Throwable t) {
-                    DriverStation.reportWarning(
-                            "USB logging unavailable: " + t.getMessage(), false);
-                }
-
-                // NT logging - also optional
-                try {
-                    Logger.addDataReceiver(new NT4Publisher());
-                } catch (Throwable t) {
-                    DriverStation.reportWarning("NT logging unavailable: " + t.getMessage(), false);
-                }
-            } else {
-                // Simulation - less critical but still wrap
-                try {
-                    Logger.addDataReceiver(new WPILOGWriter("logs"));
-                    Logger.addDataReceiver(new NT4Publisher());
-                } catch (Throwable t) {
-                    // Simulation logging failed - continue anyway
-                }
-            }
-
-            Logger.start();
-            loggingAvailable = true;
+          Logger.addDataReceiver(new WPILOGWriter());
         } catch (Throwable t) {
-            // Entire logging system failed - robot still runs
-            DriverStation.reportError(
-                    "Logging system failed to initialize: " + t.getMessage(), false);
-            loggingAvailable = false;
+          DriverStation.reportWarning("USB logging unavailable: " + t.getMessage(), false);
         }
-    }
 
-    /** Crash-barrier wrapper: runs action, logs to Health/CrashBarrier/{name} on failure. */
-    private void safeCall(String name, Runnable action) {
+        // NT logging - also optional
         try {
-            action.run();
+          Logger.addDataReceiver(new NT4Publisher());
         } catch (Throwable t) {
-            safeLog("Health/CrashBarrier/" + name, true);
-            safeLog("Health/CrashBarrier/LastError", t.getClass().getSimpleName());
+          DriverStation.reportWarning("NT logging unavailable: " + t.getMessage(), false);
         }
-    }
-
-    /** Check critical telemetry values for NaN/Infinity corruption. */
-    private void checkNaNInfinity() {
-        TelemetryManager tm = TelemetryManager.getInstance();
-        checkValue("Shooter/VelocityRPM", tm.getShooterVelocityRPM());
-        checkValue("Shooter/Temperature", tm.getShooterTemperature());
-        checkValue("Health/LoopTimeMs", tm.getLoopTimeMs());
-    }
-
-    private void checkValue(String name, double value) {
-        if (Double.isNaN(value) || Double.isInfinite(value)) {
-            safeLog("Health/NaN/" + name, true);
-        }
-    }
-
-    /** Safe logging helper that cannot throw */
-    private void safeLog(String key, boolean value) {
+      } else {
+        // Simulation - less critical but still wrap
         try {
-            Logger.recordOutput(key, value);
+          Logger.addDataReceiver(new WPILOGWriter("logs"));
+          Logger.addDataReceiver(new NT4Publisher());
         } catch (Throwable t) {
-            // Ignore - logging failure shouldn't crash robot
+          // Simulation logging failed - continue anyway
         }
+      }
+
+      Logger.start();
+      loggingAvailable = true;
+    } catch (Throwable t) {
+      // Entire logging system failed - robot still runs
+      DriverStation.reportError("Logging system failed to initialize: " + t.getMessage(), false);
+      loggingAvailable = false;
+    }
+  }
+
+  /** Crash-barrier wrapper: runs action, logs to Health/CrashBarrier/{name} on failure. */
+  private void safeCall(String name, Runnable action) {
+    try {
+      action.run();
+    } catch (Throwable t) {
+      safeLog("Health/CrashBarrier/" + name, true);
+      safeLog("Health/CrashBarrier/LastError", t.getClass().getSimpleName());
+    }
+  }
+
+  /** Check critical telemetry values for NaN/Infinity corruption. */
+  private void checkNaNInfinity() {
+    TelemetryManager tm = TelemetryManager.getInstance();
+    checkValue("Shooter/VelocityRPM", tm.getShooterVelocityRPM());
+    checkValue("Shooter/Temperature", tm.getShooterTemperature());
+    checkValue("Health/LoopTimeMs", tm.getLoopTimeMs());
+  }
+
+  private void checkValue(String name, double value) {
+    if (Double.isNaN(value) || Double.isInfinite(value)) {
+      safeLog("Health/NaN/" + name, true);
+    }
+  }
+
+  /** Safe logging helper that cannot throw */
+  private void safeLog(String key, boolean value) {
+    try {
+      Logger.recordOutput(key, value);
+    } catch (Throwable t) {
+      // Ignore - logging failure shouldn't crash robot
+    }
+  }
+
+  /** Safe logging helper that cannot throw */
+  private void safeLog(String key, String value) {
+    try {
+      Logger.recordOutput(key, value);
+    } catch (Throwable t) {
+      // Ignore - logging failure shouldn't crash robot
+    }
+  }
+
+  @Override
+  public void robotInit() {
+    installExceptionHandler();
+    configureLogging();
+
+    m_robotContainer = RobotContainer.getInstance();
+
+    // Create a timer to disable motor brake a few seconds after disable. This will
+    // let the robot stop immediately when disabled, but then also let it be pushed more
+    disabledTimer = new Timer();
+
+    if (isSimulation()) {
+      DriverStation.silenceJoystickConnectionWarning(true);
     }
 
-    /** Safe logging helper that cannot throw */
-    private void safeLog(String key, String value) {
-        try {
-            Logger.recordOutput(key, value);
-        } catch (Throwable t) {
-            // Ignore - logging failure shouldn't crash robot
-        }
+    // Send test notification to Elastic Dashboard (protected)
+    try {
+      ElasticUtil.sendInfo("Robot", "Code initialized successfully");
+    } catch (Throwable t) {
+      // Dashboard notification failed - not critical
+    }
+  }
+
+  @Override
+  public void robotPeriodic() {
+    safeCall("Tracer", () -> LoggedTracer.reset());
+
+    safeCall("CommandScheduler", () -> CommandScheduler.getInstance().run());
+    safeCall("Tracer", () -> LoggedTracer.record("CommandsMs"));
+
+    safeCall("Telemetry", () -> TelemetryManager.getInstance().updateAll());
+    safeCall("NaNGuard", () -> checkNaNInfinity());
+    safeCall("Tracer", () -> LoggedTracer.record("TelemetryMs"));
+
+    safeCall(
+        "ChannelCoordinator",
+        () -> {
+          ChannelCoordinator.getInstance().update();
+          ChannelCoordinator.getInstance().log();
+        });
+
+    safeCall("DriverFeedback", () -> DriverFeedback.getInstance().update());
+    safeCall("LEDStatus", () -> LEDStatusDisplay.getInstance().update());
+
+    safeCall(
+        "Alerts",
+        () -> {
+          AlertManager.getInstance().checkAll();
+          AlertManager.getInstance().checkLoopTime(TelemetryManager.getInstance().getLoopTimeMs());
+          AlertManager.getInstance().logActiveAlerts();
+        });
+
+    safeCall(
+        "Predictive",
+        () -> {
+          PredictiveAlerts.getInstance().update();
+          PredictiveAlerts.getInstance().log();
+        });
+
+    safeCall(
+        "PostMatch",
+        () -> {
+          if (DriverStation.isEnabled()) {
+            PostMatchSummary.getInstance()
+                .updateTracking(TelemetryManager.getInstance().getLoopTimeMs());
+          }
+        });
+
+    safeCall("Tracer", () -> LoggedTracer.record("AlertsMs"));
+  }
+
+  @Override
+  public void disabledInit() {
+    try {
+      m_robotContainer.setMotorBrake(true);
+    } catch (Throwable t) {
+      safeLog("Health/CrashBarrier/DisabledInit", true);
+    }
+    disabledTimer.reset();
+    disabledTimer.start();
+
+    try {
+      EventMarker.modeChange("DISABLED");
+    } catch (Throwable t) {
+      // Event marker failure not critical
     }
 
-    @Override
-    public void robotInit() {
-        installExceptionHandler();
-        configureLogging();
-
-        m_robotContainer = RobotContainer.getInstance();
-
-        // Create a timer to disable motor brake a few seconds after disable. This will
-        // let the robot stop immediately when disabled, but then also let it be pushed more
-        disabledTimer = new Timer();
-
-        if (isSimulation()) {
-            DriverStation.silenceJoystickConnectionWarning(true);
-        }
-
-        // Send test notification to Elastic Dashboard (protected)
-        try {
-            ElasticUtil.sendInfo("Robot", "Code initialized successfully");
-        } catch (Throwable t) {
-            // Dashboard notification failed - not critical
-        }
+    try {
+      DriverFeedback.getInstance().stopAll();
+    } catch (Throwable t) {
+      // Not critical
     }
 
-    @Override
-    public void robotPeriodic() {
-        safeCall("Tracer", () -> LoggedTracer.reset());
-
-        safeCall("CommandScheduler", () -> CommandScheduler.getInstance().run());
-        safeCall("Tracer", () -> LoggedTracer.record("CommandsMs"));
-
-        safeCall("Telemetry", () -> TelemetryManager.getInstance().updateAll());
-        safeCall("NaNGuard", () -> checkNaNInfinity());
-        safeCall("Tracer", () -> LoggedTracer.record("TelemetryMs"));
-
-        safeCall(
-                "ChannelCoordinator",
-                () -> {
-                    ChannelCoordinator.getInstance().update();
-                    ChannelCoordinator.getInstance().log();
-                });
-
-        safeCall("DriverFeedback", () -> DriverFeedback.getInstance().update());
-        safeCall("LEDStatus", () -> LEDStatusDisplay.getInstance().update());
-
-        safeCall(
-                "Alerts",
-                () -> {
-                    AlertManager.getInstance().checkAll();
-                    AlertManager.getInstance()
-                            .checkLoopTime(TelemetryManager.getInstance().getLoopTimeMs());
-                    AlertManager.getInstance().logActiveAlerts();
-                });
-
-        safeCall(
-                "Predictive",
-                () -> {
-                    PredictiveAlerts.getInstance().update();
-                    PredictiveAlerts.getInstance().log();
-                });
-
-        safeCall(
-                "PostMatch",
-                () -> {
-                    if (DriverStation.isEnabled()) {
-                        PostMatchSummary.getInstance()
-                                .updateTracking(TelemetryManager.getInstance().getLoopTimeMs());
-                    }
-                });
-
-        safeCall("Tracer", () -> LoggedTracer.record("AlertsMs"));
+    // Generate post-match summary if we were tracking
+    try {
+      PostMatchSummary.getInstance().generateSummary();
+    } catch (Throwable t) {
+      safeLog("Health/CrashBarrier/PostMatchSummary", true);
     }
 
-    @Override
-    public void disabledInit() {
-        try {
-            m_robotContainer.setMotorBrake(true);
-        } catch (Throwable t) {
-            safeLog("Health/CrashBarrier/DisabledInit", true);
-        }
+    hasRunDiagnostics = false;
+  }
+
+  @Override
+  public void disabledPeriodic() {
+    try {
+      if (disabledTimer.hasElapsed(Constants.DrivebaseConstants.WHEEL_LOCK_TIME)) {
+        m_robotContainer.setMotorBrake(false);
+        disabledTimer.stop();
         disabledTimer.reset();
-        disabledTimer.start();
-
-        try {
-            EventMarker.modeChange("DISABLED");
-        } catch (Throwable t) {
-            // Event marker failure not critical
-        }
-
-        try {
-            DriverFeedback.getInstance().stopAll();
-        } catch (Throwable t) {
-            // Not critical
-        }
-
-        // Generate post-match summary if we were tracking
-        try {
-            PostMatchSummary.getInstance().generateSummary();
-        } catch (Throwable t) {
-            safeLog("Health/CrashBarrier/PostMatchSummary", true);
-        }
-
-        hasRunDiagnostics = false;
+      }
+    } catch (Throwable t) {
+      safeLog("Health/CrashBarrier/DisabledPeriodic", true);
     }
 
-    @Override
-    public void disabledPeriodic() {
-        try {
-            if (disabledTimer.hasElapsed(Constants.DrivebaseConstants.WHEEL_LOCK_TIME)) {
-                m_robotContainer.setMotorBrake(false);
-                disabledTimer.stop();
-                disabledTimer.reset();
-            }
-        } catch (Throwable t) {
-            safeLog("Health/CrashBarrier/DisabledPeriodic", true);
-        }
-
-        // Run safe diagnostics once after 0.5s delay (let readings stabilize)
-        if (!hasRunDiagnostics && disabledTimer.hasElapsed(0.5)) {
-            try {
-                PreMatchDiagnostics.getInstance().runSafeChecks();
-            } catch (Throwable t) {
-                safeLog("Health/CrashBarrier/Diagnostics", true);
-                DriverStation.reportWarning(
-                        "Pre-match diagnostics failed: " + t.getMessage(), false);
-            }
-            hasRunDiagnostics = true;
-        }
-
-        // Manual safe trigger from dashboard (sensor-only, works while disabled)
-        try {
-            if (PreMatchDiagnostics.getInstance().checkAndClearSafeTrigger()
-                    && !PreMatchDiagnostics.getInstance().isRunning()) {
-                PreMatchDiagnostics.getInstance().runSafeChecks();
-            }
-        } catch (Throwable t) {
-            safeLog("Health/CrashBarrier/DiagnosticsTrigger", true);
-        }
-
-        // Full trigger pressed while disabled - warn user
-        try {
-            if (PreMatchDiagnostics.getInstance().checkAndClearFullTrigger()) {
-                safeLog("Diagnostics/FullCheckBlocked", true);
-                // Notification sent by PreMatchDiagnostics.runFullChecks() when it rejects
-            }
-        } catch (Throwable t) {
-            // Ignore
-        }
+    // Run safe diagnostics once after 0.5s delay (let readings stabilize)
+    if (!hasRunDiagnostics && disabledTimer.hasElapsed(0.5)) {
+      try {
+        PreMatchDiagnostics.getInstance().runSafeChecks();
+      } catch (Throwable t) {
+        safeLog("Health/CrashBarrier/Diagnostics", true);
+        DriverStation.reportWarning("Pre-match diagnostics failed: " + t.getMessage(), false);
+      }
+      hasRunDiagnostics = true;
     }
 
-    @Override
-    public void autonomousInit() {
-        // Mode init is called by IterativeRobotBase.loopFunc() with NO try-catch.
-        // An unhandled exception here kills the robot program permanently.
-        m_robotContainer.setMotorBrake(true);
-        m_autonomousCommand = m_robotContainer.getAutonomousCommand();
-
-        try {
-            EventMarker.reset();
-            EventMarker.modeChange("AUTONOMOUS");
-            PostMatchSummary.getInstance().startTracking();
-        } catch (Throwable t) {
-            safeLog("Health/CrashBarrier/AutonomousInit", true);
-        }
-
-        if (m_autonomousCommand != null) {
-            CommandScheduler.getInstance().schedule(m_autonomousCommand);
-            try {
-                String autoName = m_autonomousCommand.getName();
-                EventMarker.autoStart(autoName);
-            } catch (Throwable t) {
-                safeLog("Health/CrashBarrier/AutonomousInit", true);
-            }
-        }
+    // Manual safe trigger from dashboard (sensor-only, works while disabled)
+    try {
+      if (PreMatchDiagnostics.getInstance().checkAndClearSafeTrigger()
+          && !PreMatchDiagnostics.getInstance().isRunning()) {
+        PreMatchDiagnostics.getInstance().runSafeChecks();
+      }
+    } catch (Throwable t) {
+      safeLog("Health/CrashBarrier/DiagnosticsTrigger", true);
     }
 
-    @Override
-    public void autonomousPeriodic() {}
+    // Full trigger pressed while disabled - warn user
+    try {
+      if (PreMatchDiagnostics.getInstance().checkAndClearFullTrigger()) {
+        safeLog("Diagnostics/FullCheckBlocked", true);
+        // Notification sent by PreMatchDiagnostics.runFullChecks() when it rejects
+      }
+    } catch (Throwable t) {
+      // Ignore
+    }
+  }
 
-    @Override
-    public void teleopInit() {
-        // cancelAll() is critical (stops auto commands). Telemetry helpers are not.
-        CommandScheduler.getInstance().cancelAll();
+  @Override
+  public void autonomousInit() {
+    // Mode init is called by IterativeRobotBase.loopFunc() with NO try-catch.
+    // An unhandled exception here kills the robot program permanently.
+    m_robotContainer.setMotorBrake(true);
+    m_autonomousCommand = m_robotContainer.getAutonomousCommand();
 
-        try {
-            EventMarker.modeChange("TELEOP");
-            PostMatchSummary.getInstance().startTracking();
-        } catch (Throwable t) {
-            safeLog("Health/CrashBarrier/TeleopInit", true);
-        }
+    try {
+      EventMarker.reset();
+      EventMarker.modeChange("AUTONOMOUS");
+      PostMatchSummary.getInstance().startTracking();
+    } catch (Throwable t) {
+      safeLog("Health/CrashBarrier/AutonomousInit", true);
     }
 
-    @Override
-    public void teleopPeriodic() {}
-
-    @Override
-    public void testInit() {
-        CommandScheduler.getInstance().cancelAll();
-        try {
-            EventMarker.modeChange("TEST");
-        } catch (Throwable t) {
-            safeLog("Health/CrashBarrier/TestInit", true);
-        }
+    if (m_autonomousCommand != null) {
+      CommandScheduler.getInstance().schedule(m_autonomousCommand);
+      try {
+        String autoName = m_autonomousCommand.getName();
+        EventMarker.autoStart(autoName);
+      } catch (Throwable t) {
+        safeLog("Health/CrashBarrier/AutonomousInit", true);
+      }
     }
+  }
 
-    @Override
-    public void testPeriodic() {
-        // Full diagnostic trigger (actuator tests) - only works in test mode
-        try {
-            if (PreMatchDiagnostics.getInstance().checkAndClearFullTrigger()
-                    && !PreMatchDiagnostics.getInstance().isRunning()) {
-                PreMatchDiagnostics.getInstance().runFullChecks();
-            }
-            // Safe checks can also run in test mode
-            if (PreMatchDiagnostics.getInstance().checkAndClearSafeTrigger()
-                    && !PreMatchDiagnostics.getInstance().isRunning()) {
-                PreMatchDiagnostics.getInstance().runSafeChecks();
-            }
-        } catch (Throwable t) {
-            safeLog("Health/CrashBarrier/DiagnosticsTest", true);
-        }
+  @Override
+  public void autonomousPeriodic() {}
+
+  @Override
+  public void teleopInit() {
+    // cancelAll() is critical (stops auto commands). Telemetry helpers are not.
+    CommandScheduler.getInstance().cancelAll();
+
+    try {
+      EventMarker.modeChange("TELEOP");
+      PostMatchSummary.getInstance().startTracking();
+    } catch (Throwable t) {
+      safeLog("Health/CrashBarrier/TeleopInit", true);
     }
+  }
 
-    @Override
-    public void simulationInit() {
-        simDeviceManager = new SimDeviceManager();
-        simDeviceManager.init();
-        simScenarioRunner = new SimScenarioRunner();
+  @Override
+  public void teleopPeriodic() {}
 
-        try {
-            simFuelManager = new SimFuelManager("Sim/FuelPositions");
-            simFuelManager.enable();
-            simFuelManager.placeFieldBalls();
-            SwerveSubsystem swerve = RobotContainer.getInstance().getSwerveSubsystem();
-            simFuelManager.configureRobot(
-                    0.66, 0.66, 0.25, swerve::getPose, swerve::getFieldVelocity);
-            // wire intake zone so balls get picked up when intake is running
-            try {
-                IntakeRoller intake = IntakeRoller.getInstance();
-                simFuelManager.addIntakeZone(0.10, 0.45, -0.20, 0.20, intake::isRunning);
-            } catch (Throwable t) {
-                // intake not available, shots fire freely without ball tracking
-            }
-        } catch (Throwable t) {
-            DriverStation.reportWarning("SimFuelManager init failed: " + t.getMessage(), false);
-        }
+  @Override
+  public void testInit() {
+    CommandScheduler.getInstance().cancelAll();
+    try {
+      EventMarker.modeChange("TEST");
+    } catch (Throwable t) {
+      safeLog("Health/CrashBarrier/TestInit", true);
     }
+  }
 
-    @Override
-    public void simulationPeriodic() {
-        if (simDeviceManager != null) {
-            simDeviceManager.update();
-        }
-        if (simFuelManager != null) {
-            try {
-                boolean shotFired =
-                        simDeviceManager != null && simDeviceManager.wasShotFiredThisCycle();
-                double shooterRPM = simDeviceManager != null ? simDeviceManager.getShooterRPM() : 0;
-                SwerveSubsystem swerve = RobotContainer.getInstance().getSwerveSubsystem();
-                simFuelManager.update(
-                        shotFired, swerve.getPose(), swerve.getHeading().getRadians(), shooterRPM);
-            } catch (Throwable t) {
-                // never let fuel sim crash the main sim loop
-            }
-        }
-        if (simScenarioRunner != null) {
-            simScenarioRunner.update();
-        }
+  @Override
+  public void testPeriodic() {
+    // Full diagnostic trigger (actuator tests) - only works in test mode
+    try {
+      if (PreMatchDiagnostics.getInstance().checkAndClearFullTrigger()
+          && !PreMatchDiagnostics.getInstance().isRunning()) {
+        PreMatchDiagnostics.getInstance().runFullChecks();
+      }
+      // Safe checks can also run in test mode
+      if (PreMatchDiagnostics.getInstance().checkAndClearSafeTrigger()
+          && !PreMatchDiagnostics.getInstance().isRunning()) {
+        PreMatchDiagnostics.getInstance().runSafeChecks();
+      }
+    } catch (Throwable t) {
+      safeLog("Health/CrashBarrier/DiagnosticsTest", true);
     }
+  }
+
+  @Override
+  public void simulationInit() {
+    simDeviceManager = new SimDeviceManager();
+    simDeviceManager.init();
+    simScenarioRunner = new SimScenarioRunner();
+
+    try {
+      simFuelManager = new SimFuelManager("Sim/FuelPositions");
+      simFuelManager.enable();
+      simFuelManager.placeFieldBalls();
+      SwerveSubsystem swerve = RobotContainer.getInstance().getSwerveSubsystem();
+      simFuelManager.configureRobot(0.66, 0.66, 0.25, swerve::getPose, swerve::getFieldVelocity);
+      // wire intake zone so balls get picked up when intake is running
+      try {
+        IntakeRoller intake = IntakeRoller.getInstance();
+        simFuelManager.addIntakeZone(0.10, 0.45, -0.20, 0.20, intake::isRunning);
+      } catch (Throwable t) {
+        // intake not available, shots fire freely without ball tracking
+      }
+    } catch (Throwable t) {
+      DriverStation.reportWarning("SimFuelManager init failed: " + t.getMessage(), false);
+    }
+  }
+
+  @Override
+  public void simulationPeriodic() {
+    if (simDeviceManager != null) {
+      simDeviceManager.update();
+    }
+    if (simFuelManager != null) {
+      try {
+        boolean shotFired = simDeviceManager != null && simDeviceManager.wasShotFiredThisCycle();
+        double shooterRPM = simDeviceManager != null ? simDeviceManager.getShooterRPM() : 0;
+        SwerveSubsystem swerve = RobotContainer.getInstance().getSwerveSubsystem();
+        simFuelManager.update(
+            shotFired, swerve.getPose(), swerve.getHeading().getRadians(), shooterRPM);
+      } catch (Throwable t) {
+        // never let fuel sim crash the main sim loop
+      }
+    }
+    if (simScenarioRunner != null) {
+      simScenarioRunner.update();
+    }
+  }
 }

--- a/src/main/java/frc/robot/sim/FuelPhysicsSim.java
+++ b/src/main/java/frc/robot/sim/FuelPhysicsSim.java
@@ -29,7 +29,6 @@ import edu.wpi.first.networktables.DoublePublisher;
 import edu.wpi.first.networktables.IntegerPublisher;
 import edu.wpi.first.networktables.NetworkTableInstance;
 import edu.wpi.first.networktables.StructArrayPublisher;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
@@ -37,9 +36,9 @@ import java.util.function.BooleanSupplier;
 import java.util.function.Supplier;
 
 /**
- * Full-field ball physics simulation for FRC 2026 REBUILT: drag, Magnus lift, friction,
- * ball-ball collisions, wall bounces, hub scoring, sleeping, CCD, and robot interaction. Single
- * file, only depends on WPILib (wpimath + ntcore). Drop it into your sim and watch balls fly.
+ * Full-field ball physics simulation for FRC 2026 REBUILT: drag, Magnus lift, friction, ball-ball
+ * collisions, wall bounces, hub scoring, sleeping, CCD, and robot interaction. Single file, only
+ * depends on WPILib (wpimath + ntcore). Drop it into your sim and watch balls fly.
  *
  * <p>Physics: symplectic Euler integration, 3D angular velocity for Magnus (omega x v cross
  * product), Coulomb friction with spin transfer, sequential impulse collision solver with warm
@@ -59,2418 +58,2357 @@ import java.util.function.Supplier;
  */
 public class FuelPhysicsSim {
 
-    // Physics constants
+  // Physics constants
 
-    private static final double GRAVITY = 9.81; // m/s^2
-    private static final double AIR_DENSITY = 1.225; // kg/m^3, standard atmosphere
-    private static final double BALL_MASS = 0.215; // kg, game manual 5.10.1 midpoint
-    private static final double BALL_DIAMETER = 0.1501; // m, game manual 5.10.1
-    private static final double BALL_RADIUS = BALL_DIAMETER / 2.0;
-    private static final double BALL_CROSS_AREA = Math.PI * BALL_RADIUS * BALL_RADIUS;
-    private static final double BALL_MOMENT_OF_INERTIA =
-            0.4 * BALL_MASS * BALL_RADIUS * BALL_RADIUS; // 2/5 * m * r^2, solid sphere
+  private static final double GRAVITY = 9.81; // m/s^2
+  private static final double AIR_DENSITY = 1.225; // kg/m^3, standard atmosphere
+  private static final double BALL_MASS = 0.215; // kg, game manual 5.10.1 midpoint
+  private static final double BALL_DIAMETER = 0.1501; // m, game manual 5.10.1
+  private static final double BALL_RADIUS = BALL_DIAMETER / 2.0;
+  private static final double BALL_CROSS_AREA = Math.PI * BALL_RADIUS * BALL_RADIUS;
+  private static final double BALL_MOMENT_OF_INERTIA =
+      0.4 * BALL_MASS * BALL_RADIUS * BALL_RADIUS; // 2/5 * m * r^2, solid sphere
 
-    // Aerodynamic coefficients
-    private static final double DEFAULT_CD = 0.47; // drag coefficient, smooth sphere
-    private static final double DEFAULT_CM = 0.2; // Magnus coefficient, conservative estimate
+  // Aerodynamic coefficients
+  private static final double DEFAULT_CD = 0.47; // drag coefficient, smooth sphere
+  private static final double DEFAULT_CM = 0.2; // Magnus coefficient, conservative estimate
 
-    // Precomputed force factors (divided by mass to get acceleration factors)
-    private static final double DRAG_ACCEL_FACTOR =
-            0.5 * AIR_DENSITY * DEFAULT_CD * BALL_CROSS_AREA / BALL_MASS;
-    // Extra BALL_RADIUS factor converts the omega x v cross product to acceleration
-    private static final double MAGNUS_ACCEL_FACTOR =
-            0.5 * AIR_DENSITY * DEFAULT_CM * BALL_CROSS_AREA * BALL_RADIUS / BALL_MASS;
+  // Precomputed force factors (divided by mass to get acceleration factors)
+  private static final double DRAG_ACCEL_FACTOR =
+      0.5 * AIR_DENSITY * DEFAULT_CD * BALL_CROSS_AREA / BALL_MASS;
+  // Extra BALL_RADIUS factor converts the omega x v cross product to acceleration
+  private static final double MAGNUS_ACCEL_FACTOR =
+      0.5 * AIR_DENSITY * DEFAULT_CM * BALL_CROSS_AREA * BALL_RADIUS / BALL_MASS;
 
-    // Coefficients of restitution (per-material, from field element build instructions)
-    private static final double COR_CARPET = 0.65; // foam on low-pile carpet
-    private static final double COR_WALL =
-            0.70; // foam on polycarbonate (alliance walls, guardrails)
-    private static final double COR_STEEL = 0.72; // foam on powder-coated steel (tower, rungs)
-    private static final double COR_HUB = 0.70; // foam on polycarbonate (hub body panels)
-    private static final double COR_HDPE = 0.60; // foam on textured HDPE (bump ramps, 15deg)
-    private static final double COR_NET = 0.15; // mesh fabric absorbs most of the energy
-    private static final double COR_BUMPER = 0.08; // polycarb-backed foam, nearly inelastic
-    private static final double COR_BALL_BALL = 0.45; // foam-on-foam, high deformation loss
+  // Coefficients of restitution (per-material, from field element build instructions)
+  private static final double COR_CARPET = 0.65; // foam on low-pile carpet
+  private static final double COR_WALL = 0.70; // foam on polycarbonate (alliance walls, guardrails)
+  private static final double COR_STEEL = 0.72; // foam on powder-coated steel (tower, rungs)
+  private static final double COR_HUB = 0.70; // foam on polycarbonate (hub body panels)
+  private static final double COR_HDPE = 0.60; // foam on textured HDPE (bump ramps, 15deg)
+  private static final double COR_NET = 0.15; // mesh fabric absorbs most of the energy
+  private static final double COR_BUMPER = 0.08; // polycarb-backed foam, nearly inelastic
+  private static final double COR_BALL_BALL = 0.45; // foam-on-foam, high deformation loss
 
-    // Friction coefficients
-    private static final double MU_GROUND_KINETIC = 0.3; // kinetic friction on carpet
-    private static final double MU_GROUND_ROLLING = 0.05; // rolling friction
-    private static final double MU_WALL = 0.4; // foam on polycarbonate/fabric
-    private static final double MU_BALL_BALL = 0.3; // foam on foam
+  // Friction coefficients
+  private static final double MU_GROUND_KINETIC = 0.3; // kinetic friction on carpet
+  private static final double MU_GROUND_ROLLING = 0.05; // rolling friction
+  private static final double MU_WALL = 0.4; // foam on polycarbonate/fabric
+  private static final double MU_BALL_BALL = 0.3; // foam on foam
 
-    // Velocity-dependent COR reference speed
-    private static final double COR_VREF = 3.0; // m/s
-    private static final double COR_EXPONENT = 0.15;
+  // Velocity-dependent COR reference speed
+  private static final double COR_VREF = 3.0; // m/s
+  private static final double COR_EXPONENT = 0.15;
 
-    // Reusable axis-aligned unit normals (avoids allocating these in hot loops)
-    private static final Translation3d AXIS_X_POS = new Translation3d(1, 0, 0);
-    private static final Translation3d AXIS_X_NEG = new Translation3d(-1, 0, 0);
-    private static final Translation3d AXIS_Y_POS = new Translation3d(0, 1, 0);
-    private static final Translation3d AXIS_Y_NEG = new Translation3d(0, -1, 0);
-    private static final Translation3d AXIS_Z_POS = new Translation3d(0, 0, 1);
-    private static final Translation3d AXIS_Z_NEG = new Translation3d(0, 0, -1);
+  // Reusable axis-aligned unit normals (avoids allocating these in hot loops)
+  private static final Translation3d AXIS_X_POS = new Translation3d(1, 0, 0);
+  private static final Translation3d AXIS_X_NEG = new Translation3d(-1, 0, 0);
+  private static final Translation3d AXIS_Y_POS = new Translation3d(0, 1, 0);
+  private static final Translation3d AXIS_Y_NEG = new Translation3d(0, -1, 0);
+  private static final Translation3d AXIS_Z_POS = new Translation3d(0, 0, 1);
+  private static final Translation3d AXIS_Z_NEG = new Translation3d(0, 0, -1);
 
-    // Period
-    private static final double PERIOD = 0.02; // 20ms
+  // Period
+  private static final double PERIOD = 0.02; // 20ms
 
-    // Field geometry
+  // Field geometry
 
-    private static final double FIELD_LENGTH = 16.541; // m
-    private static final double FIELD_WIDTH = 8.052; // m
+  private static final double FIELD_LENGTH = 16.541; // m
+  private static final double FIELD_WIDTH = 8.052; // m
 
-    // Alliance wall and guardrail heights
-    private static final double ALLIANCE_WALL_HEIGHT = 0.935; // 36.8 in
-    private static final double GUARDRAIL_HEIGHT = 0.508; // 20 in
+  // Alliance wall and guardrail heights
+  private static final double ALLIANCE_WALL_HEIGHT = 0.935; // 36.8 in
+  private static final double GUARDRAIL_HEIGHT = 0.508; // 20 in
 
-    // Bump geometry (tent-shaped, 15-degree ramps)
-    private static final double BUMP_HEIGHT = 0.165; // m, 6.513 in
+  // Bump geometry (tent-shaped, 15-degree ramps)
+  private static final double BUMP_HEIGHT = 0.165; // m, 6.513 in
 
-    // Hub positions (from game manual field layout)
-    private static final Translation2d BLUE_HUB_CENTER = new Translation2d(4.5974, 4.035);
-    private static final Translation2d RED_HUB_CENTER = new Translation2d(11.938, 4.035);
+  // Hub positions (from game manual field layout)
+  private static final Translation2d BLUE_HUB_CENTER = new Translation2d(4.5974, 4.035);
+  private static final Translation2d RED_HUB_CENTER = new Translation2d(11.938, 4.035);
 
-    // Hub dimensions
-    private static final double HUB_ENTRY_HEIGHT = 1.829; // m, 72 in
-    private static final double HUB_ENTRY_RADIUS = 0.5295; // m, 41.7 in / 2 across flats
-    private static final double HUB_SIDE = 1.194; // m, 47 in square base
-    // Hub base structure height for ball collision (not a solid wall to scoring height,
-    // just the base frame that deflects ground-level balls)
-    private static final double HUB_BASE_HEIGHT = 0.5; // m, ~20 in base frame
+  // Hub dimensions
+  private static final double HUB_ENTRY_HEIGHT = 1.829; // m, 72 in
+  private static final double HUB_ENTRY_RADIUS = 0.5295; // m, 41.7 in / 2 across flats
+  private static final double HUB_SIDE = 1.194; // m, 47 in square base
+  // Hub base structure height for ball collision (not a solid wall to scoring height,
+  // just the base frame that deflects ground-level balls)
+  private static final double HUB_BASE_HEIGHT = 0.5; // m, ~20 in base frame
 
-    // Net dimensions
-    private static final double NET_HEIGHT_MIN = 1.5; // m
-    private static final double NET_HEIGHT_MAX = 3.057; // m
-    private static final double NET_WIDTH = 1.484; // m
-    private static final double NET_OFFSET = HUB_SIDE / 2.0 + 0.261;
+  // Net dimensions
+  private static final double NET_HEIGHT_MIN = 1.5; // m
+  private static final double NET_HEIGHT_MAX = 3.057; // m
+  private static final double NET_WIDTH = 1.484; // m
+  private static final double NET_OFFSET = HUB_SIDE / 2.0 + 0.261;
 
-    // Trench geometry
-    private static final double TRENCH_WIDTH = 1.265; // m
-    private static final double TRENCH_BLOCK_WIDTH = 0.305; // m, 12 in
-    private static final double TRENCH_HEIGHT = 0.565; // m, 22.25 in underpass
-    private static final double TRENCH_PILLAR_HEIGHT = 1.346; // m, 53 in
+  // Trench geometry
+  private static final double TRENCH_WIDTH = 1.265; // m
+  private static final double TRENCH_BLOCK_WIDTH = 0.305; // m, 12 in
+  private static final double TRENCH_HEIGHT = 0.565; // m, 22.25 in underpass
+  private static final double TRENCH_PILLAR_HEIGHT = 1.346; // m, 53 in
 
-    // Tower geometry
-    private static final double TOWER_POLE_WIDTH = 0.051; // m, 2 in
-    private static final double TOWER_POLE_HEIGHT = 1.194; // m, 47 in
-    private static final double TOWER_UPRIGHT_THICK = 0.038; // m, 1.5 in
-    private static final double TOWER_UPRIGHT_DEPTH = 0.089; // m, 3.5 in
-    private static final double TOWER_UPRIGHT_HEIGHT = 1.831; // m, 72.1 in
-    private static final double TOWER_UPRIGHT_SPACING = 0.819; // m, 32.25 in center-to-center
+  // Tower geometry
+  private static final double TOWER_POLE_WIDTH = 0.051; // m, 2 in
+  private static final double TOWER_POLE_HEIGHT = 1.194; // m, 47 in
+  private static final double TOWER_UPRIGHT_THICK = 0.038; // m, 1.5 in
+  private static final double TOWER_UPRIGHT_DEPTH = 0.089; // m, 3.5 in
+  private static final double TOWER_UPRIGHT_HEIGHT = 1.831; // m, 72.1 in
+  private static final double TOWER_UPRIGHT_SPACING = 0.819; // m, 32.25 in center-to-center
 
-    // Tower rung geometry (Schedule 40 pipe)
-    private static final double RUNG_OUTER_DIAMETER = 0.042; // m, 1.66 in OD
-    private static final double RUNG_RADIUS = RUNG_OUTER_DIAMETER / 2.0;
-    private static final double RUNG_OVERHANG = 0.149; // m, 5.875 in past upright
-    private static final double RUNG_LOW_HEIGHT = 0.686; // m, 27 in
-    private static final double RUNG_MID_HEIGHT = 1.143; // m, 45 in
-    private static final double RUNG_HIGH_HEIGHT = 1.600; // m, 63 in
+  // Tower rung geometry (Schedule 40 pipe)
+  private static final double RUNG_OUTER_DIAMETER = 0.042; // m, 1.66 in OD
+  private static final double RUNG_RADIUS = RUNG_OUTER_DIAMETER / 2.0;
+  private static final double RUNG_OVERHANG = 0.149; // m, 5.875 in past upright
+  private static final double RUNG_LOW_HEIGHT = 0.686; // m, 27 in
+  private static final double RUNG_MID_HEIGHT = 1.143; // m, 45 in
+  private static final double RUNG_HIGH_HEIGHT = 1.600; // m, 63 in
 
-    // Tower bracing
-    private static final double BRACING_BOTTOM = 0.721; // m, 28.4 in
-    private static final double BRACING_TOP = 1.102; // m, 43.4 in
+  // Tower bracing
+  private static final double BRACING_BOTTOM = 0.721; // m, 28.4 in
+  private static final double BRACING_TOP = 1.102; // m, 43.4 in
 
-    // Outpost geometry
-    // Outpost/corral AABBs removed (not in YAGSL collision model, caused phantom floating)
+  // Outpost geometry
+  // Outpost/corral AABBs removed (not in YAGSL collision model, caused phantom floating)
 
-    // Corral geometry
+  // Corral geometry
 
-    // Hub ramp area
-    private static final double HUB_RAMP_WIDTH = 1.194; // m, 47 in
-    private static final double HUB_RAMP_LENGTH = 5.512; // m, 217 in
-    private static final double HUB_RAMP_HEIGHT = 0.165; // m, 6.5 in
+  // Hub ramp area
+  private static final double HUB_RAMP_WIDTH = 1.194; // m, 47 in
+  private static final double HUB_RAMP_LENGTH = 5.512; // m, 217 in
+  private static final double HUB_RAMP_HEIGHT = 0.165; // m, 6.5 in
 
-    // Divider pipe
+  // Divider pipe
 
-    // Spatial hash
-    private static final double CELL_SIZE = 0.25;
-    private static final int GRID_COLS = (int) Math.ceil(FIELD_LENGTH / CELL_SIZE);
-    private static final int GRID_ROWS = (int) Math.ceil(FIELD_WIDTH / CELL_SIZE);
+  // Spatial hash
+  private static final double CELL_SIZE = 0.25;
+  private static final int GRID_COLS = (int) Math.ceil(FIELD_LENGTH / CELL_SIZE);
+  private static final int GRID_ROWS = (int) Math.ceil(FIELD_WIDTH / CELL_SIZE);
 
-    // Max balls
-    private static final int MAX_BALLS = 2000;
+  // Max balls
+  private static final int MAX_BALLS = 2000;
 
-    // Bump ramp segments (XZ line segments extruded along Y)
+  // Bump ramp segments (XZ line segments extruded along Y)
 
-    private static final BumpSegment[] BUMP_SEGMENTS = {
-        // Blue lower bump ramp up/down
-        new BumpSegment(3.96, 0, 4.524, BUMP_HEIGHT, 1.88, 3.73),
-        new BumpSegment(4.524, BUMP_HEIGHT, 5.088, 0, 1.88, 3.73),
-        // Blue upper bump ramp up/down
-        new BumpSegment(3.96, 0, 4.524, BUMP_HEIGHT, 4.32, 6.17),
-        new BumpSegment(4.524, BUMP_HEIGHT, 5.088, 0, 4.32, 6.17),
-        // Red lower bump ramp up/down
-        new BumpSegment(FIELD_LENGTH - 5.088, 0, FIELD_LENGTH - 4.524, BUMP_HEIGHT, 1.88, 3.73),
-        new BumpSegment(FIELD_LENGTH - 4.524, BUMP_HEIGHT, FIELD_LENGTH - 3.96, 0, 1.88, 3.73),
-        // Red upper bump ramp up/down
-        new BumpSegment(FIELD_LENGTH - 5.088, 0, FIELD_LENGTH - 4.524, BUMP_HEIGHT, 4.32, 6.17),
-        new BumpSegment(FIELD_LENGTH - 4.524, BUMP_HEIGHT, FIELD_LENGTH - 3.96, 0, 4.32, 6.17),
-    };
+  private static final BumpSegment[] BUMP_SEGMENTS = {
+    // Blue lower bump ramp up/down
+    new BumpSegment(3.96, 0, 4.524, BUMP_HEIGHT, 1.88, 3.73),
+    new BumpSegment(4.524, BUMP_HEIGHT, 5.088, 0, 1.88, 3.73),
+    // Blue upper bump ramp up/down
+    new BumpSegment(3.96, 0, 4.524, BUMP_HEIGHT, 4.32, 6.17),
+    new BumpSegment(4.524, BUMP_HEIGHT, 5.088, 0, 4.32, 6.17),
+    // Red lower bump ramp up/down
+    new BumpSegment(FIELD_LENGTH - 5.088, 0, FIELD_LENGTH - 4.524, BUMP_HEIGHT, 1.88, 3.73),
+    new BumpSegment(FIELD_LENGTH - 4.524, BUMP_HEIGHT, FIELD_LENGTH - 3.96, 0, 1.88, 3.73),
+    // Red upper bump ramp up/down
+    new BumpSegment(FIELD_LENGTH - 5.088, 0, FIELD_LENGTH - 4.524, BUMP_HEIGHT, 4.32, 6.17),
+    new BumpSegment(FIELD_LENGTH - 4.524, BUMP_HEIGHT, FIELD_LENGTH - 3.96, 0, 4.32, 6.17),
+  };
 
-    // AABB obstacles
+  // AABB obstacles
 
-    private static final AABB[] AABB_OBSTACLES;
+  private static final AABB[] AABB_OBSTACLES;
 
-    static {
-        List<AABB> aabbs = new ArrayList<>();
+  static {
+    List<AABB> aabbs = new ArrayList<>();
 
-        // Trench pillars (4): 12in wide x 53in tall, steel structure
-        aabbs.add(
-                new AABB(
-                        3.96,
-                        TRENCH_WIDTH,
-                        0,
-                        3.96 + TRENCH_BLOCK_WIDTH,
-                        TRENCH_WIDTH + TRENCH_BLOCK_WIDTH,
-                        TRENCH_PILLAR_HEIGHT,
-                        COR_STEEL));
-        aabbs.add(
-                new AABB(
-                        3.96,
-                        FIELD_WIDTH - 1.57 - TRENCH_BLOCK_WIDTH,
-                        0,
-                        3.96 + TRENCH_BLOCK_WIDTH,
-                        FIELD_WIDTH - 1.57,
-                        TRENCH_PILLAR_HEIGHT,
-                        COR_STEEL));
-        aabbs.add(
-                new AABB(
-                        FIELD_LENGTH - 3.96 - TRENCH_BLOCK_WIDTH,
-                        TRENCH_WIDTH,
-                        0,
-                        FIELD_LENGTH - 3.96,
-                        TRENCH_WIDTH + TRENCH_BLOCK_WIDTH,
-                        TRENCH_PILLAR_HEIGHT,
-                        COR_STEEL));
-        aabbs.add(
-                new AABB(
-                        FIELD_LENGTH - 3.96 - TRENCH_BLOCK_WIDTH,
-                        FIELD_WIDTH - 1.57 - TRENCH_BLOCK_WIDTH,
-                        0,
-                        FIELD_LENGTH - 3.96,
-                        FIELD_WIDTH - 1.57,
-                        TRENCH_PILLAR_HEIGHT,
-                        COR_STEEL));
+    // Trench pillars (4): 12in wide x 53in tall, steel structure
+    aabbs.add(
+        new AABB(
+            3.96,
+            TRENCH_WIDTH,
+            0,
+            3.96 + TRENCH_BLOCK_WIDTH,
+            TRENCH_WIDTH + TRENCH_BLOCK_WIDTH,
+            TRENCH_PILLAR_HEIGHT,
+            COR_STEEL));
+    aabbs.add(
+        new AABB(
+            3.96,
+            FIELD_WIDTH - 1.57 - TRENCH_BLOCK_WIDTH,
+            0,
+            3.96 + TRENCH_BLOCK_WIDTH,
+            FIELD_WIDTH - 1.57,
+            TRENCH_PILLAR_HEIGHT,
+            COR_STEEL));
+    aabbs.add(
+        new AABB(
+            FIELD_LENGTH - 3.96 - TRENCH_BLOCK_WIDTH,
+            TRENCH_WIDTH,
+            0,
+            FIELD_LENGTH - 3.96,
+            TRENCH_WIDTH + TRENCH_BLOCK_WIDTH,
+            TRENCH_PILLAR_HEIGHT,
+            COR_STEEL));
+    aabbs.add(
+        new AABB(
+            FIELD_LENGTH - 3.96 - TRENCH_BLOCK_WIDTH,
+            FIELD_WIDTH - 1.57 - TRENCH_BLOCK_WIDTH,
+            0,
+            FIELD_LENGTH - 3.96,
+            FIELD_WIDTH - 1.57,
+            TRENCH_PILLAR_HEIGHT,
+            COR_STEEL));
 
-        // Trench ceilings (4): steel/aluminum above underpass height
-        double trenchXBlue1 = 3.96;
-        double trenchXBlue2 = 5.18;
-        double trenchXRed1 = FIELD_LENGTH - 5.18;
-        double trenchXRed2 = FIELD_LENGTH - 3.96;
-        aabbs.add(
-                new AABB(
-                        trenchXBlue1,
-                        1.57,
-                        TRENCH_HEIGHT,
-                        trenchXBlue2,
-                        3.73,
-                        TRENCH_PILLAR_HEIGHT,
-                        COR_STEEL));
-        aabbs.add(
-                new AABB(
-                        trenchXBlue1,
-                        FIELD_WIDTH - 3.73,
-                        TRENCH_HEIGHT,
-                        trenchXBlue2,
-                        FIELD_WIDTH - 1.57,
-                        TRENCH_PILLAR_HEIGHT,
-                        COR_STEEL));
-        aabbs.add(
-                new AABB(
-                        trenchXRed1,
-                        1.57,
-                        TRENCH_HEIGHT,
-                        trenchXRed2,
-                        3.73,
-                        TRENCH_PILLAR_HEIGHT,
-                        COR_STEEL));
-        aabbs.add(
-                new AABB(
-                        trenchXRed1,
-                        FIELD_WIDTH - 3.73,
-                        TRENCH_HEIGHT,
-                        trenchXRed2,
-                        FIELD_WIDTH - 1.57,
-                        TRENCH_PILLAR_HEIGHT,
-                        COR_STEEL));
+    // Trench ceilings (4): steel/aluminum above underpass height
+    double trenchXBlue1 = 3.96;
+    double trenchXBlue2 = 5.18;
+    double trenchXRed1 = FIELD_LENGTH - 5.18;
+    double trenchXRed2 = FIELD_LENGTH - 3.96;
+    aabbs.add(
+        new AABB(
+            trenchXBlue1,
+            1.57,
+            TRENCH_HEIGHT,
+            trenchXBlue2,
+            3.73,
+            TRENCH_PILLAR_HEIGHT,
+            COR_STEEL));
+    aabbs.add(
+        new AABB(
+            trenchXBlue1,
+            FIELD_WIDTH - 3.73,
+            TRENCH_HEIGHT,
+            trenchXBlue2,
+            FIELD_WIDTH - 1.57,
+            TRENCH_PILLAR_HEIGHT,
+            COR_STEEL));
+    aabbs.add(
+        new AABB(
+            trenchXRed1, 1.57, TRENCH_HEIGHT, trenchXRed2, 3.73, TRENCH_PILLAR_HEIGHT, COR_STEEL));
+    aabbs.add(
+        new AABB(
+            trenchXRed1,
+            FIELD_WIDTH - 3.73,
+            TRENCH_HEIGHT,
+            trenchXRed2,
+            FIELD_WIDTH - 1.57,
+            TRENCH_PILLAR_HEIGHT,
+            COR_STEEL));
 
-        // Tower poles (2): 2in wide x 47in tall
-        double blueTowerX = 1.067;
-        double redTowerX = 15.494;
-        double blueTowerY = 4.039;
-        double redTowerY = 4.318;
-        aabbs.add(
-                new AABB(
-                        blueTowerX - TOWER_POLE_WIDTH / 2,
-                        blueTowerY - TOWER_POLE_WIDTH / 2,
-                        0,
-                        blueTowerX + TOWER_POLE_WIDTH / 2,
-                        blueTowerY + TOWER_POLE_WIDTH / 2,
-                        TOWER_POLE_HEIGHT,
-                        COR_STEEL));
-        aabbs.add(
-                new AABB(
-                        redTowerX - TOWER_POLE_WIDTH / 2,
-                        redTowerY - TOWER_POLE_WIDTH / 2,
-                        0,
-                        redTowerX + TOWER_POLE_WIDTH / 2,
-                        redTowerY + TOWER_POLE_WIDTH / 2,
-                        TOWER_POLE_HEIGHT,
-                        COR_STEEL));
+    // Tower poles (2): 2in wide x 47in tall
+    double blueTowerX = 1.067;
+    double redTowerX = 15.494;
+    double blueTowerY = 4.039;
+    double redTowerY = 4.318;
+    aabbs.add(
+        new AABB(
+            blueTowerX - TOWER_POLE_WIDTH / 2,
+            blueTowerY - TOWER_POLE_WIDTH / 2,
+            0,
+            blueTowerX + TOWER_POLE_WIDTH / 2,
+            blueTowerY + TOWER_POLE_WIDTH / 2,
+            TOWER_POLE_HEIGHT,
+            COR_STEEL));
+    aabbs.add(
+        new AABB(
+            redTowerX - TOWER_POLE_WIDTH / 2,
+            redTowerY - TOWER_POLE_WIDTH / 2,
+            0,
+            redTowerX + TOWER_POLE_WIDTH / 2,
+            redTowerY + TOWER_POLE_WIDTH / 2,
+            TOWER_POLE_HEIGHT,
+            COR_STEEL));
 
-        // Tower uprights (4): 1.5in x 3.5in x 72.1in, two per tower
-        double halfSpacing = TOWER_UPRIGHT_SPACING / 2.0;
-        aabbs.add(
-                new AABB(
-                        0,
-                        blueTowerY - halfSpacing - TOWER_UPRIGHT_THICK / 2,
-                        0,
-                        TOWER_UPRIGHT_DEPTH,
-                        blueTowerY - halfSpacing + TOWER_UPRIGHT_THICK / 2,
-                        TOWER_UPRIGHT_HEIGHT,
-                        COR_STEEL));
-        aabbs.add(
-                new AABB(
-                        0,
-                        blueTowerY + halfSpacing - TOWER_UPRIGHT_THICK / 2,
-                        0,
-                        TOWER_UPRIGHT_DEPTH,
-                        blueTowerY + halfSpacing + TOWER_UPRIGHT_THICK / 2,
-                        TOWER_UPRIGHT_HEIGHT,
-                        COR_STEEL));
-        aabbs.add(
-                new AABB(
-                        FIELD_LENGTH - TOWER_UPRIGHT_DEPTH,
-                        redTowerY - halfSpacing - TOWER_UPRIGHT_THICK / 2,
-                        0,
-                        FIELD_LENGTH,
-                        redTowerY - halfSpacing + TOWER_UPRIGHT_THICK / 2,
-                        TOWER_UPRIGHT_HEIGHT,
-                        COR_STEEL));
-        aabbs.add(
-                new AABB(
-                        FIELD_LENGTH - TOWER_UPRIGHT_DEPTH,
-                        redTowerY + halfSpacing - TOWER_UPRIGHT_THICK / 2,
-                        0,
-                        FIELD_LENGTH,
-                        redTowerY + halfSpacing + TOWER_UPRIGHT_THICK / 2,
-                        TOWER_UPRIGHT_HEIGHT,
-                        COR_STEEL));
+    // Tower uprights (4): 1.5in x 3.5in x 72.1in, two per tower
+    double halfSpacing = TOWER_UPRIGHT_SPACING / 2.0;
+    aabbs.add(
+        new AABB(
+            0,
+            blueTowerY - halfSpacing - TOWER_UPRIGHT_THICK / 2,
+            0,
+            TOWER_UPRIGHT_DEPTH,
+            blueTowerY - halfSpacing + TOWER_UPRIGHT_THICK / 2,
+            TOWER_UPRIGHT_HEIGHT,
+            COR_STEEL));
+    aabbs.add(
+        new AABB(
+            0,
+            blueTowerY + halfSpacing - TOWER_UPRIGHT_THICK / 2,
+            0,
+            TOWER_UPRIGHT_DEPTH,
+            blueTowerY + halfSpacing + TOWER_UPRIGHT_THICK / 2,
+            TOWER_UPRIGHT_HEIGHT,
+            COR_STEEL));
+    aabbs.add(
+        new AABB(
+            FIELD_LENGTH - TOWER_UPRIGHT_DEPTH,
+            redTowerY - halfSpacing - TOWER_UPRIGHT_THICK / 2,
+            0,
+            FIELD_LENGTH,
+            redTowerY - halfSpacing + TOWER_UPRIGHT_THICK / 2,
+            TOWER_UPRIGHT_HEIGHT,
+            COR_STEEL));
+    aabbs.add(
+        new AABB(
+            FIELD_LENGTH - TOWER_UPRIGHT_DEPTH,
+            redTowerY + halfSpacing - TOWER_UPRIGHT_THICK / 2,
+            0,
+            FIELD_LENGTH,
+            redTowerY + halfSpacing + TOWER_UPRIGHT_THICK / 2,
+            TOWER_UPRIGHT_HEIGHT,
+            COR_STEEL));
 
-        // Tower bracing (2): between uprights, 28.4-43.4in height
-        aabbs.add(
-                new AABB(
-                        0,
-                        blueTowerY - halfSpacing,
-                        BRACING_BOTTOM,
-                        TOWER_UPRIGHT_DEPTH,
-                        blueTowerY + halfSpacing,
-                        BRACING_TOP,
-                        COR_STEEL));
-        aabbs.add(
-                new AABB(
-                        FIELD_LENGTH - TOWER_UPRIGHT_DEPTH,
-                        redTowerY - halfSpacing,
-                        BRACING_BOTTOM,
-                        FIELD_LENGTH,
-                        redTowerY + halfSpacing,
-                        BRACING_TOP,
-                        COR_STEEL));
+    // Tower bracing (2): between uprights, 28.4-43.4in height
+    aabbs.add(
+        new AABB(
+            0,
+            blueTowerY - halfSpacing,
+            BRACING_BOTTOM,
+            TOWER_UPRIGHT_DEPTH,
+            blueTowerY + halfSpacing,
+            BRACING_TOP,
+            COR_STEEL));
+    aabbs.add(
+        new AABB(
+            FIELD_LENGTH - TOWER_UPRIGHT_DEPTH,
+            redTowerY - halfSpacing,
+            BRACING_BOTTOM,
+            FIELD_LENGTH,
+            redTowerY + halfSpacing,
+            BRACING_TOP,
+            COR_STEEL));
 
-        // Hub ramp colliders (2): 47in x 217in ground-level area around each hub
-        aabbs.add(
-                new AABB(
-                        BLUE_HUB_CENTER.getX() - HUB_RAMP_WIDTH / 2,
-                        BLUE_HUB_CENTER.getY() - HUB_RAMP_LENGTH / 2,
-                        0,
-                        BLUE_HUB_CENTER.getX() + HUB_RAMP_WIDTH / 2,
-                        BLUE_HUB_CENTER.getY() + HUB_RAMP_LENGTH / 2,
-                        HUB_RAMP_HEIGHT,
-                        COR_STEEL));
-        aabbs.add(
-                new AABB(
-                        RED_HUB_CENTER.getX() - HUB_RAMP_WIDTH / 2,
-                        RED_HUB_CENTER.getY() - HUB_RAMP_LENGTH / 2,
-                        0,
-                        RED_HUB_CENTER.getX() + HUB_RAMP_WIDTH / 2,
-                        RED_HUB_CENTER.getY() + HUB_RAMP_LENGTH / 2,
-                        HUB_RAMP_HEIGHT,
-                        COR_STEEL));
+    // Hub ramp colliders (2): 47in x 217in ground-level area around each hub
+    aabbs.add(
+        new AABB(
+            BLUE_HUB_CENTER.getX() - HUB_RAMP_WIDTH / 2,
+            BLUE_HUB_CENTER.getY() - HUB_RAMP_LENGTH / 2,
+            0,
+            BLUE_HUB_CENTER.getX() + HUB_RAMP_WIDTH / 2,
+            BLUE_HUB_CENTER.getY() + HUB_RAMP_LENGTH / 2,
+            HUB_RAMP_HEIGHT,
+            COR_STEEL));
+    aabbs.add(
+        new AABB(
+            RED_HUB_CENTER.getX() - HUB_RAMP_WIDTH / 2,
+            RED_HUB_CENTER.getY() - HUB_RAMP_LENGTH / 2,
+            0,
+            RED_HUB_CENTER.getX() + HUB_RAMP_WIDTH / 2,
+            RED_HUB_CENTER.getY() + HUB_RAMP_LENGTH / 2,
+            HUB_RAMP_HEIGHT,
+            COR_STEEL));
 
-        // Hub body panels deflect ground-level balls
-        aabbs.add(
-                new AABB(
-                        BLUE_HUB_CENTER.getX() - HUB_SIDE / 2,
-                        BLUE_HUB_CENTER.getY() - HUB_SIDE / 2,
-                        0,
-                        BLUE_HUB_CENTER.getX() + HUB_SIDE / 2,
-                        BLUE_HUB_CENTER.getY() + HUB_SIDE / 2,
-                        HUB_BASE_HEIGHT,
-                        COR_HUB));
-        aabbs.add(
-                new AABB(
-                        RED_HUB_CENTER.getX() - HUB_SIDE / 2,
-                        RED_HUB_CENTER.getY() - HUB_SIDE / 2,
-                        0,
-                        RED_HUB_CENTER.getX() + HUB_SIDE / 2,
-                        RED_HUB_CENTER.getY() + HUB_SIDE / 2,
-                        HUB_BASE_HEIGHT,
-                        COR_HUB));
+    // Hub body panels deflect ground-level balls
+    aabbs.add(
+        new AABB(
+            BLUE_HUB_CENTER.getX() - HUB_SIDE / 2,
+            BLUE_HUB_CENTER.getY() - HUB_SIDE / 2,
+            0,
+            BLUE_HUB_CENTER.getX() + HUB_SIDE / 2,
+            BLUE_HUB_CENTER.getY() + HUB_SIDE / 2,
+            HUB_BASE_HEIGHT,
+            COR_HUB));
+    aabbs.add(
+        new AABB(
+            RED_HUB_CENTER.getX() - HUB_SIDE / 2,
+            RED_HUB_CENTER.getY() - HUB_SIDE / 2,
+            0,
+            RED_HUB_CENTER.getX() + HUB_SIDE / 2,
+            RED_HUB_CENTER.getY() + HUB_SIDE / 2,
+            HUB_BASE_HEIGHT,
+            COR_HUB));
 
-        AABB_OBSTACLES = aabbs.toArray(new AABB[0]);
+    AABB_OBSTACLES = aabbs.toArray(new AABB[0]);
+  }
+
+  // Cylinder obstacles (tower rungs + divider pipes)
+
+  private static final CylinderObstacle[] CYLINDER_OBSTACLES;
+
+  static {
+    List<CylinderObstacle> cyls = new ArrayList<>();
+    double blueTowerY = 4.039;
+    double redTowerY = 4.318;
+    double halfSpacing = TOWER_UPRIGHT_SPACING / 2.0;
+
+    // Blue tower rungs (3)
+    for (double h : new double[] {RUNG_LOW_HEIGHT, RUNG_MID_HEIGHT, RUNG_HIGH_HEIGHT}) {
+      cyls.add(
+          new CylinderObstacle(
+              0,
+              blueTowerY - halfSpacing - RUNG_OVERHANG,
+              h,
+              0,
+              blueTowerY + halfSpacing + RUNG_OVERHANG,
+              h,
+              RUNG_RADIUS,
+              COR_STEEL));
     }
 
-    // Cylinder obstacles (tower rungs + divider pipes)
-
-    private static final CylinderObstacle[] CYLINDER_OBSTACLES;
-
-    static {
-        List<CylinderObstacle> cyls = new ArrayList<>();
-        double blueTowerY = 4.039;
-        double redTowerY = 4.318;
-        double halfSpacing = TOWER_UPRIGHT_SPACING / 2.0;
-
-        // Blue tower rungs (3)
-        for (double h : new double[] {RUNG_LOW_HEIGHT, RUNG_MID_HEIGHT, RUNG_HIGH_HEIGHT}) {
-            cyls.add(
-                    new CylinderObstacle(
-                            0,
-                            blueTowerY - halfSpacing - RUNG_OVERHANG,
-                            h,
-                            0,
-                            blueTowerY + halfSpacing + RUNG_OVERHANG,
-                            h,
-                            RUNG_RADIUS,
-                            COR_STEEL));
-        }
-
-        // Red tower rungs (3)
-        for (double h : new double[] {RUNG_LOW_HEIGHT, RUNG_MID_HEIGHT, RUNG_HIGH_HEIGHT}) {
-            cyls.add(
-                    new CylinderObstacle(
-                            FIELD_LENGTH,
-                            redTowerY - halfSpacing - RUNG_OVERHANG,
-                            h,
-                            FIELD_LENGTH,
-                            redTowerY + halfSpacing + RUNG_OVERHANG,
-                            h,
-                            RUNG_RADIUS,
-                            COR_STEEL));
-        }
-
-        CYLINDER_OBSTACLES = cyls.toArray(new CylinderObstacle[0]);
+    // Red tower rungs (3)
+    for (double h : new double[] {RUNG_LOW_HEIGHT, RUNG_MID_HEIGHT, RUNG_HIGH_HEIGHT}) {
+      cyls.add(
+          new CylinderObstacle(
+              FIELD_LENGTH,
+              redTowerY - halfSpacing - RUNG_OVERHANG,
+              h,
+              FIELD_LENGTH,
+              redTowerY + halfSpacing + RUNG_OVERHANG,
+              h,
+              RUNG_RADIUS,
+              COR_STEEL));
     }
 
-    /** Axis-aligned bounding box with restitution coefficient. */
-    private record AABB(
-            double minX,
-            double minY,
-            double minZ,
-            double maxX,
-            double maxY,
-            double maxZ,
-            double cor) {}
+    CYLINDER_OBSTACLES = cyls.toArray(new CylinderObstacle[0]);
+  }
 
-    /** Cylinder obstacle defined by two axis endpoints, a radius, and restitution. */
-    private record CylinderObstacle(
-            double ax,
-            double ay,
-            double az,
-            double bx,
-            double by,
-            double bz,
-            double radius,
-            double cor,
-            double abx,
-            double aby,
-            double abz,
-            double abLenSq) {
-        CylinderObstacle(
-                double ax,
-                double ay,
-                double az,
-                double bx,
-                double by,
-                double bz,
-                double radius,
-                double cor) {
-            this(
-                    ax,
-                    ay,
-                    az,
-                    bx,
-                    by,
-                    bz,
-                    radius,
-                    cor,
-                    bx - ax,
-                    by - ay,
-                    bz - az,
-                    (bx - ax) * (bx - ax) + (by - ay) * (by - ay) + (bz - az) * (bz - az));
-        }
+  /** Axis-aligned bounding box with restitution coefficient. */
+  private record AABB(
+      double minX, double minY, double minZ, double maxX, double maxY, double maxZ, double cor) {}
+
+  /** Cylinder obstacle defined by two axis endpoints, a radius, and restitution. */
+  private record CylinderObstacle(
+      double ax,
+      double ay,
+      double az,
+      double bx,
+      double by,
+      double bz,
+      double radius,
+      double cor,
+      double abx,
+      double aby,
+      double abz,
+      double abLenSq) {
+    CylinderObstacle(
+        double ax,
+        double ay,
+        double az,
+        double bx,
+        double by,
+        double bz,
+        double radius,
+        double cor) {
+      this(
+          ax,
+          ay,
+          az,
+          bx,
+          by,
+          bz,
+          radius,
+          cor,
+          bx - ax,
+          by - ay,
+          bz - az,
+          (bx - ax) * (bx - ax) + (by - ay) * (by - ay) + (bz - az) * (bz - az));
     }
+  }
 
-    /** XZ line segment extruded along a Y range, used for bump ramp geometry. */
-    private record BumpSegment(
-            double xStart,
-            double zStart,
-            double xEnd,
-            double zEnd,
-            double yStart,
-            double yEnd,
-            double lineX,
-            double lineZ,
-            double lineLen,
-            double nx,
-            double nz) {
-        BumpSegment(
-                double xStart,
-                double zStart,
-                double xEnd,
-                double zEnd,
-                double yStart,
-                double yEnd) {
-            this(
-                    xStart,
-                    zStart,
-                    xEnd,
-                    zEnd,
-                    yStart,
-                    yEnd,
-                    xEnd - xStart,
-                    zEnd - zStart,
-                    Math.hypot(xEnd - xStart, zEnd - zStart),
-                    // Normal perpendicular to line in XZ, flipped so nz >= 0 (points away from
-                    // ground)
-                    (xEnd - xStart) >= 0
-                            ? -(zEnd - zStart) / Math.hypot(xEnd - xStart, zEnd - zStart)
-                            : (zEnd - zStart) / Math.hypot(xEnd - xStart, zEnd - zStart),
-                    Math.abs(xEnd - xStart) / Math.hypot(xEnd - xStart, zEnd - zStart));
-        }
+  /** XZ line segment extruded along a Y range, used for bump ramp geometry. */
+  private record BumpSegment(
+      double xStart,
+      double zStart,
+      double xEnd,
+      double zEnd,
+      double yStart,
+      double yEnd,
+      double lineX,
+      double lineZ,
+      double lineLen,
+      double nx,
+      double nz) {
+    BumpSegment(
+        double xStart, double zStart, double xEnd, double zEnd, double yStart, double yEnd) {
+      this(
+          xStart,
+          zStart,
+          xEnd,
+          zEnd,
+          yStart,
+          yEnd,
+          xEnd - xStart,
+          zEnd - zStart,
+          Math.hypot(xEnd - xStart, zEnd - zStart),
+          // Normal perpendicular to line in XZ, flipped so nz >= 0 (points away from
+          // ground)
+          (xEnd - xStart) >= 0
+              ? -(zEnd - zStart) / Math.hypot(xEnd - xStart, zEnd - zStart)
+              : (zEnd - zStart) / Math.hypot(xEnd - xStart, zEnd - zStart),
+          Math.abs(xEnd - xStart) / Math.hypot(xEnd - xStart, zEnd - zStart));
     }
+  }
 
-    /** Physics feature toggles. Flip these on/off to debug or simplify the sim. */
-    public static class PhysicsConfig {
-        public boolean dragEnabled = true;
-        public boolean magnusEnabled = true;
-        public boolean frictionEnabled = true;
-        public boolean spinTransferEnabled = true;
-        public boolean sleepingEnabled = true;
-        public boolean ccdEnabled = true;
-        public boolean velocityDependentCOR = true;
-        public boolean spinDecayEnabled = true;
-        public int solverIterations = 4;
-        public int subticks = 5;
-        public double spinDecayTau = 3.0; // seconds
-        public double sleepVelocityThreshold = 0.01; // m/s
-        public int sleepFrameThreshold = 10; // consecutive frames
-        public double ccdSpeedThreshold = 10.0; // m/s
-        public double baumgarteBeta = 0.2;
-        public double baumgarteSlop = 0.005; // 5mm allowed penetration
-        public boolean deterministic = false;
-        public long deterministicSeed = 42L;
-        public boolean conservationMonitor = false;
+  /** Physics feature toggles. Flip these on/off to debug or simplify the sim. */
+  public static class PhysicsConfig {
+    public boolean dragEnabled = true;
+    public boolean magnusEnabled = true;
+    public boolean frictionEnabled = true;
+    public boolean spinTransferEnabled = true;
+    public boolean sleepingEnabled = true;
+    public boolean ccdEnabled = true;
+    public boolean velocityDependentCOR = true;
+    public boolean spinDecayEnabled = true;
+    public int solverIterations = 4;
+    public int subticks = 5;
+    public double spinDecayTau = 3.0; // seconds
+    public double sleepVelocityThreshold = 0.01; // m/s
+    public int sleepFrameThreshold = 10; // consecutive frames
+    public double ccdSpeedThreshold = 10.0; // m/s
+    public double baumgarteBeta = 0.2;
+    public double baumgarteSlop = 0.005; // 5mm allowed penetration
+    public boolean deterministic = false;
+    public long deterministicSeed = 42L;
+    public boolean conservationMonitor = false;
 
-        /** Default: everything on. */
-        public PhysicsConfig() {}
+    /** Default: everything on. */
+    public PhysicsConfig() {}
 
-        /** Deep copy. */
-        public PhysicsConfig copy() {
-            PhysicsConfig c = new PhysicsConfig();
-            c.dragEnabled = dragEnabled;
-            c.magnusEnabled = magnusEnabled;
-            c.frictionEnabled = frictionEnabled;
-            c.spinTransferEnabled = spinTransferEnabled;
-            c.sleepingEnabled = sleepingEnabled;
-            c.ccdEnabled = ccdEnabled;
-            c.velocityDependentCOR = velocityDependentCOR;
-            c.spinDecayEnabled = spinDecayEnabled;
-            c.solverIterations = solverIterations;
-            c.subticks = subticks;
-            c.spinDecayTau = spinDecayTau;
-            c.sleepVelocityThreshold = sleepVelocityThreshold;
-            c.sleepFrameThreshold = sleepFrameThreshold;
-            c.ccdSpeedThreshold = ccdSpeedThreshold;
-            c.baumgarteBeta = baumgarteBeta;
-            c.baumgarteSlop = baumgarteSlop;
-            c.deterministic = deterministic;
-            c.deterministicSeed = deterministicSeed;
-            c.conservationMonitor = conservationMonitor;
-            return c;
-        }
+    /** Deep copy. */
+    public PhysicsConfig copy() {
+      PhysicsConfig c = new PhysicsConfig();
+      c.dragEnabled = dragEnabled;
+      c.magnusEnabled = magnusEnabled;
+      c.frictionEnabled = frictionEnabled;
+      c.spinTransferEnabled = spinTransferEnabled;
+      c.sleepingEnabled = sleepingEnabled;
+      c.ccdEnabled = ccdEnabled;
+      c.velocityDependentCOR = velocityDependentCOR;
+      c.spinDecayEnabled = spinDecayEnabled;
+      c.solverIterations = solverIterations;
+      c.subticks = subticks;
+      c.spinDecayTau = spinDecayTau;
+      c.sleepVelocityThreshold = sleepVelocityThreshold;
+      c.sleepFrameThreshold = sleepFrameThreshold;
+      c.ccdSpeedThreshold = ccdSpeedThreshold;
+      c.baumgarteBeta = baumgarteBeta;
+      c.baumgarteSlop = baumgarteSlop;
+      c.deterministic = deterministic;
+      c.deterministicSeed = deterministicSeed;
+      c.conservationMonitor = conservationMonitor;
+      return c;
     }
+  }
 
-    /** One ball in the simulation. Tracks position, velocity, spin, and lifecycle flags. */
-    public static class SimBall {
-        // State
-        Translation3d pos; // field-frame position (m)
-        Translation3d vel; // field-frame velocity (m/s)
-        Translation3d omega; // angular velocity (rad/s), 3D spin axis
-
-        // Previous state (for CCD and scoring detection)
-        Translation3d prevPos;
-        Translation3d prevVel;
-
-        // Sleeping
-        boolean sleeping;
-        int sleepCounter;
-
-        // Stuck-on-obstacle detection
-        int elevatedSlowCounter;
-
-        // Lifecycle flags
-        boolean intaked;
-        boolean outOfBounds;
-
-        SimBall(Translation3d pos, Translation3d vel, Translation3d omega) {
-            this.pos = pos;
-            this.vel = vel;
-            this.omega = omega;
-            this.prevPos = pos;
-            this.prevVel = vel;
-            this.sleeping = false;
-            this.sleepCounter = 0;
-            this.elevatedSlowCounter = 0;
-            this.intaked = false;
-            this.outOfBounds = false;
-        }
-
-        SimBall(Translation3d pos, Translation3d vel) {
-            this(pos, vel, new Translation3d());
-        }
-
-        SimBall(Translation3d pos) {
-            this(pos, new Translation3d(), new Translation3d());
-        }
-
-        /** Get backspin in RPM (from the Y component of omega). */
-        public double getSpinRPM() {
-            return omega.getY() * 60.0 / (2.0 * Math.PI);
-        }
-    }
-
-    /** Contact point between two colliding objects. Used by the impulse solver. */
-    static class Contact {
-        int ballIndexA; // index into balls list
-        int ballIndexB; // index into balls list, or -1 for field geometry
-        Translation3d normal; // contact normal (A -> B or outward from field)
-        double penetration; // overlap depth (positive = overlapping)
-        Translation3d contactPoint; // world-space contact location
-        double normalImpulseAccum; // warm-start accumulated normal impulse
-        double tangentImpulseAccum; // warm-start accumulated tangent impulse
-        double restitution; // effective COR for this pair
-        double friction; // Coulomb mu for this pair
-        double restitutionVelocity; // target bounce-back speed, set once before solving
-
-        Contact() {
-            normal = new Translation3d();
-            contactPoint = new Translation3d();
-        }
-    }
-
-    /** A hub that can be scored in. Detects balls falling through the opening. */
-    public static class ScoringTarget {
-        final Translation2d center;
-        final Translation3d exit;
-        final int exitVelXSign; // +1 for blue (exits toward red), -1 for red
-        int score;
-
-        ScoringTarget(Translation2d center, Translation3d exit, int exitVelXSign) {
-            this.center = center;
-            this.exit = exit;
-            this.exitVelXSign = exitVelXSign;
-            this.score = 0;
-        }
-
-        boolean didScore(SimBall ball) {
-            double dist2d = ball.pos.toTranslation2d().getDistance(center);
-            if (dist2d > HUB_ENTRY_RADIUS) return false;
-            double currZ = ball.pos.getZ();
-            double prevZ = ball.prevPos.getZ();
-            // Only count balls falling through the opening (top-down entry)
-            return prevZ > HUB_ENTRY_HEIGHT && currZ <= HUB_ENTRY_HEIGHT;
-        }
-
-        Translation3d getDispersalVelocity(Random rng) {
-            double vx = exitVelXSign * (rng.nextDouble() + 0.1) * 1.5;
-            double vy = rng.nextDouble() * 2.0 - 1.0;
-            return new Translation3d(vx, vy, 0);
-        }
-
-        /** How many balls have scored in this hub. */
-        public int getScore() {
-            return score;
-        }
-
-        void resetScore() {
-            score = 0;
-        }
-    }
-
-    /** Intake zone defined in robot-relative coordinates. Picks up balls that enter the box. */
-    static class IntakeZone {
-        final double xMin, xMax, yMin, yMax;
-        final BooleanSupplier active;
-        final Runnable callback;
-
-        IntakeZone(
-                double xMin,
-                double xMax,
-                double yMin,
-                double yMax,
-                BooleanSupplier active,
-                Runnable callback) {
-            this.xMin = xMin;
-            this.xMax = xMax;
-            this.yMin = yMin;
-            this.yMax = yMax;
-            this.active = active;
-            this.callback = callback;
-        }
-
-        boolean shouldIntake(SimBall ball, Pose2d robotPose, double bumperHeight) {
-            if (!active.getAsBoolean() || ball.pos.getZ() > bumperHeight) return false;
-            Translation2d relPos =
-                    new Pose2d(ball.pos.toTranslation2d(), Rotation2d.kZero)
-                            .relativeTo(robotPose)
-                            .getTranslation();
-            boolean inside =
-                    relPos.getX() >= xMin
-                            && relPos.getX() <= xMax
-                            && relPos.getY() >= yMin
-                            && relPos.getY() <= yMax;
-            if (inside) {
-                callback.run();
-            }
-            return inside;
-        }
-    }
-
+  /** One ball in the simulation. Tracks position, velocity, spin, and lifecycle flags. */
+  public static class SimBall {
     // State
+    Translation3d pos; // field-frame position (m)
+    Translation3d vel; // field-frame velocity (m/s)
+    Translation3d omega; // angular velocity (rad/s), 3D spin axis
 
-    private final List<SimBall> balls = new ArrayList<>();
-    private final List<Contact> contacts = new ArrayList<>();
-    private final List<Contact> contactPool = new ArrayList<>(); // pre-allocated contact pool
-    private int contactPoolIndex = 0;
+    // Previous state (for CCD and scoring detection)
+    Translation3d prevPos;
+    Translation3d prevVel;
 
-    private PhysicsConfig config;
-    private Random rng;
+    // Sleeping
+    boolean sleeping;
+    int sleepCounter;
 
-    // Spatial hash grid for ball-ball broadphase
-    @SuppressWarnings("unchecked")
-    private final List<Integer>[][] grid = new ArrayList[GRID_COLS][GRID_ROWS];
+    // Stuck-on-obstacle detection
+    int elevatedSlowCounter;
 
-    // Hub targets
-    private final ScoringTarget blueHub;
-    private final ScoringTarget redHub;
+    // Lifecycle flags
+    boolean intaked;
+    boolean outOfBounds;
 
-    // Robot registration
-    private Supplier<Pose2d> robotPoseSupplier;
-    private Supplier<ChassisSpeeds> robotSpeedsSupplier;
-    private double robotWidth;
-    private double robotLength;
-    private double bumperHeight;
-
-    // Intakes
-    private final List<IntakeZone> intakes = new ArrayList<>();
-
-    // Counters
-    private int totalLaunched;
-    private int totalScored;
-    private int totalIntaked;
-    private double lastLaunchSpeed;
-
-    // Running state
-    private boolean running;
-
-    // NetworkTables publishing
-    private StructArrayPublisher<Translation3d> positionPublisher;
-    private StructArrayPublisher<Translation3d> inFlightPublisher;
-    private StructArrayPublisher<Translation3d> lastShotArcPublisher;
-    private IntegerPublisher blueScorePub;
-    private IntegerPublisher redScorePub;
-    private IntegerPublisher ballCountPub;
-    private IntegerPublisher activeBallsPub;
-    private IntegerPublisher sleepingBallsPub;
-    private IntegerPublisher contactCountPub;
-    private DoublePublisher physicsTimePub;
-    private DoublePublisher totalEnergyPub;
-
-    // Last shot arc for trajectory visualization (predicted path in Field3d)
-    private Translation3d[] lastShotArc = new Translation3d[0];
-    private long lastPhysicsNanos;
-
-    // Conservation monitor state
-    private double totalKE;
-    private double totalPE;
-    private Translation3d totalMomentum = new Translation3d();
-
-    // Constructor
-
-    /**
-     * New sim with default physics config. Publishes ball positions to the given NT path.
-     *
-     * @param tableKey where to publish in NetworkTables (e.g. "Sim/Fuel")
-     */
-    public FuelPhysicsSim(String tableKey) {
-        this(tableKey, new PhysicsConfig());
+    SimBall(Translation3d pos, Translation3d vel, Translation3d omega) {
+      this.pos = pos;
+      this.vel = vel;
+      this.omega = omega;
+      this.prevPos = pos;
+      this.prevVel = vel;
+      this.sleeping = false;
+      this.sleepCounter = 0;
+      this.elevatedSlowCounter = 0;
+      this.intaked = false;
+      this.outOfBounds = false;
     }
 
-    /**
-     * New sim with custom physics config.
-     *
-     * @param tableKey where to publish in NetworkTables
-     * @param config physics feature toggles and tuning
-     */
-    public FuelPhysicsSim(String tableKey, PhysicsConfig config) {
-        this.config = config;
-        this.rng = config.deterministic ? new Random(config.deterministicSeed) : new Random();
-
-        // Initialize spatial hash grid
-        for (int i = 0; i < GRID_COLS; i++) {
-            for (int j = 0; j < GRID_ROWS; j++) {
-                grid[i][j] = new ArrayList<>();
-            }
-        }
-
-        // Pre-allocate contact pool
-        for (int i = 0; i < 200; i++) {
-            contactPool.add(new Contact());
-        }
-
-        // Create hubs
-        blueHub =
-                new ScoringTarget(
-                        BLUE_HUB_CENTER, new Translation3d(5.3, FIELD_WIDTH / 2.0, 0.89), 1);
-        redHub =
-                new ScoringTarget(
-                        RED_HUB_CENTER,
-                        new Translation3d(FIELD_LENGTH - 5.3, FIELD_WIDTH / 2.0, 0.89),
-                        -1);
-
-        // NT publishers
-        var nt = NetworkTableInstance.getDefault();
-        positionPublisher =
-                nt.getStructArrayTopic(tableKey + "/Positions", Translation3d.struct).publish();
-        inFlightPublisher =
-                nt.getStructArrayTopic(tableKey + "/InFlight", Translation3d.struct).publish();
-        lastShotArcPublisher =
-                nt.getStructArrayTopic(tableKey + "/LastShotArc", Translation3d.struct).publish();
-        blueScorePub = nt.getIntegerTopic(tableKey + "/BlueScore").publish();
-        redScorePub = nt.getIntegerTopic(tableKey + "/RedScore").publish();
-        ballCountPub = nt.getIntegerTopic(tableKey + "/Stats/BallCount").publish();
-        activeBallsPub = nt.getIntegerTopic(tableKey + "/Stats/ActiveBalls").publish();
-        sleepingBallsPub = nt.getIntegerTopic(tableKey + "/Stats/SleepingBalls").publish();
-        contactCountPub = nt.getIntegerTopic(tableKey + "/Stats/ContactsPerTick").publish();
-        physicsTimePub = nt.getDoubleTopic(tableKey + "/Stats/PhysicsMs").publish();
-        totalEnergyPub = nt.getDoubleTopic(tableKey + "/Stats/TotalEnergy").publish();
-
-        running = false;
-        totalLaunched = 0;
-        totalScored = 0;
-        totalIntaked = 0;
-        lastLaunchSpeed = 0;
+    SimBall(Translation3d pos, Translation3d vel) {
+      this(pos, vel, new Translation3d());
     }
 
-    /** Default constructor, publishes to "Sim/FuelPositions". */
-    public FuelPhysicsSim() {
-        this("Sim/FuelPositions");
+    SimBall(Translation3d pos) {
+      this(pos, new Translation3d(), new Translation3d());
     }
 
-    /** Turn the sim on. You still need to call tick() every cycle. */
-    public void enable() {
-        running = true;
+    /** Get backspin in RPM (from the Y component of omega). */
+    public double getSpinRPM() {
+      return omega.getY() * 60.0 / (2.0 * Math.PI);
+    }
+  }
+
+  /** Contact point between two colliding objects. Used by the impulse solver. */
+  static class Contact {
+    int ballIndexA; // index into balls list
+    int ballIndexB; // index into balls list, or -1 for field geometry
+    Translation3d normal; // contact normal (A -> B or outward from field)
+    double penetration; // overlap depth (positive = overlapping)
+    Translation3d contactPoint; // world-space contact location
+    double normalImpulseAccum; // warm-start accumulated normal impulse
+    double tangentImpulseAccum; // warm-start accumulated tangent impulse
+    double restitution; // effective COR for this pair
+    double friction; // Coulomb mu for this pair
+    double restitutionVelocity; // target bounce-back speed, set once before solving
+
+    Contact() {
+      normal = new Translation3d();
+      contactPoint = new Translation3d();
+    }
+  }
+
+  /** A hub that can be scored in. Detects balls falling through the opening. */
+  public static class ScoringTarget {
+    final Translation2d center;
+    final Translation3d exit;
+    final int exitVelXSign; // +1 for blue (exits toward red), -1 for red
+    int score;
+
+    ScoringTarget(Translation2d center, Translation3d exit, int exitVelXSign) {
+      this.center = center;
+      this.exit = exit;
+      this.exitVelXSign = exitVelXSign;
+      this.score = 0;
     }
 
-    /** Pause the sim. Balls freeze in place. */
-    public void disable() {
-        running = false;
+    boolean didScore(SimBall ball) {
+      double dist2d = ball.pos.toTranslation2d().getDistance(center);
+      if (dist2d > HUB_ENTRY_RADIUS) return false;
+      double currZ = ball.pos.getZ();
+      double prevZ = ball.prevPos.getZ();
+      // Only count balls falling through the opening (top-down entry)
+      return prevZ > HUB_ENTRY_HEIGHT && currZ <= HUB_ENTRY_HEIGHT;
     }
 
-    /** Is the sim running? */
-    public boolean isRunning() {
-        return running;
+    Translation3d getDispersalVelocity(Random rng) {
+      double vx = exitVelXSign * (rng.nextDouble() + 0.1) * 1.5;
+      double vy = rng.nextDouble() * 2.0 - 1.0;
+      return new Translation3d(vx, vy, 0);
     }
 
-    /**
-     * Tell the sim about your robot so it can handle bumper collisions and intake pickup.
-     *
-     * @param width robot width along Y axis (m)
-     * @param length robot length along X axis (m)
-     * @param bumperHeight bumper height (m)
-     * @param poseSupplier field-relative pose supplier
-     * @param speedsSupplier field-relative chassis speeds supplier
-     */
-    public void configureRobot(
-            double width,
-            double length,
-            double bumperHeight,
-            Supplier<Pose2d> poseSupplier,
-            Supplier<ChassisSpeeds> speedsSupplier) {
-        this.robotWidth = width;
-        this.robotLength = length;
-        this.bumperHeight = bumperHeight;
-        this.robotPoseSupplier = poseSupplier;
-        this.robotSpeedsSupplier = speedsSupplier;
+    /** How many balls have scored in this hub. */
+    public int getScore() {
+      return score;
     }
 
-    /**
-     * Add an intake zone. Balls that enter this box (in robot-relative coords) get picked up.
-     *
-     * @param xMin front edge in robot frame
-     * @param xMax back edge in robot frame
-     * @param yMin left edge in robot frame
-     * @param yMax right edge in robot frame
-     * @param active returns true when the intake is actually running
-     * @param callback fires when a ball gets picked up
-     */
-    public void addIntakeZone(
-            double xMin,
-            double xMax,
-            double yMin,
-            double yMax,
-            BooleanSupplier active,
-            Runnable callback) {
-        intakes.add(new IntakeZone(xMin, xMax, yMin, yMax, active, callback));
+    void resetScore() {
+      score = 0;
+    }
+  }
+
+  /** Intake zone defined in robot-relative coordinates. Picks up balls that enter the box. */
+  static class IntakeZone {
+    final double xMin, xMax, yMin, yMax;
+    final BooleanSupplier active;
+    final Runnable callback;
+
+    IntakeZone(
+        double xMin,
+        double xMax,
+        double yMin,
+        double yMax,
+        BooleanSupplier active,
+        Runnable callback) {
+      this.xMin = xMin;
+      this.xMax = xMax;
+      this.yMin = yMin;
+      this.yMax = yMax;
+      this.active = active;
+      this.callback = callback;
     }
 
-    /** Add an intake zone without a callback. */
-    public void addIntakeZone(
-            double xMin, double xMax, double yMin, double yMax, BooleanSupplier active) {
-        addIntakeZone(xMin, xMax, yMin, yMax, active, () -> {});
+    boolean shouldIntake(SimBall ball, Pose2d robotPose, double bumperHeight) {
+      if (!active.getAsBoolean() || ball.pos.getZ() > bumperHeight) return false;
+      Translation2d relPos =
+          new Pose2d(ball.pos.toTranslation2d(), Rotation2d.kZero)
+              .relativeTo(robotPose)
+              .getTranslation();
+      boolean inside =
+          relPos.getX() >= xMin
+              && relPos.getX() <= xMax
+              && relPos.getY() >= yMin
+              && relPos.getY() <= yMax;
+      if (inside) {
+        callback.run();
+      }
+      return inside;
+    }
+  }
+
+  // State
+
+  private final List<SimBall> balls = new ArrayList<>();
+  private final List<Contact> contacts = new ArrayList<>();
+  private final List<Contact> contactPool = new ArrayList<>(); // pre-allocated contact pool
+  private int contactPoolIndex = 0;
+
+  private PhysicsConfig config;
+  private Random rng;
+
+  // Spatial hash grid for ball-ball broadphase
+  @SuppressWarnings("unchecked")
+  private final List<Integer>[][] grid = new ArrayList[GRID_COLS][GRID_ROWS];
+
+  // Hub targets
+  private final ScoringTarget blueHub;
+  private final ScoringTarget redHub;
+
+  // Robot registration
+  private Supplier<Pose2d> robotPoseSupplier;
+  private Supplier<ChassisSpeeds> robotSpeedsSupplier;
+  private double robotWidth;
+  private double robotLength;
+  private double bumperHeight;
+
+  // Intakes
+  private final List<IntakeZone> intakes = new ArrayList<>();
+
+  // Counters
+  private int totalLaunched;
+  private int totalScored;
+  private int totalIntaked;
+  private double lastLaunchSpeed;
+
+  // Running state
+  private boolean running;
+
+  // NetworkTables publishing
+  private StructArrayPublisher<Translation3d> positionPublisher;
+  private StructArrayPublisher<Translation3d> inFlightPublisher;
+  private StructArrayPublisher<Translation3d> lastShotArcPublisher;
+  private IntegerPublisher blueScorePub;
+  private IntegerPublisher redScorePub;
+  private IntegerPublisher ballCountPub;
+  private IntegerPublisher activeBallsPub;
+  private IntegerPublisher sleepingBallsPub;
+  private IntegerPublisher contactCountPub;
+  private DoublePublisher physicsTimePub;
+  private DoublePublisher totalEnergyPub;
+
+  // Last shot arc for trajectory visualization (predicted path in Field3d)
+  private Translation3d[] lastShotArc = new Translation3d[0];
+  private long lastPhysicsNanos;
+
+  // Conservation monitor state
+  private double totalKE;
+  private double totalPE;
+  private Translation3d totalMomentum = new Translation3d();
+
+  // Constructor
+
+  /**
+   * New sim with default physics config. Publishes ball positions to the given NT path.
+   *
+   * @param tableKey where to publish in NetworkTables (e.g. "Sim/Fuel")
+   */
+  public FuelPhysicsSim(String tableKey) {
+    this(tableKey, new PhysicsConfig());
+  }
+
+  /**
+   * New sim with custom physics config.
+   *
+   * @param tableKey where to publish in NetworkTables
+   * @param config physics feature toggles and tuning
+   */
+  public FuelPhysicsSim(String tableKey, PhysicsConfig config) {
+    this.config = config;
+    this.rng = config.deterministic ? new Random(config.deterministicSeed) : new Random();
+
+    // Initialize spatial hash grid
+    for (int i = 0; i < GRID_COLS; i++) {
+      for (int j = 0; j < GRID_ROWS; j++) {
+        grid[i][j] = new ArrayList<>();
+      }
     }
 
-    /**
-     * Shoot a ball into the sim.
-     *
-     * @param pos where the ball leaves the launcher (field frame, meters)
-     * @param vel launch velocity (field frame, m/s)
-     * @param spinRPM backspin in RPM (positive = backspin = Magnus lift)
-     */
-    public void launchBall(Translation3d pos, Translation3d vel, double spinRPM) {
-        // Convert RPM to 3D omega: backspin is rotation around -Y axis
-        double omegaY = -spinRPM * 2.0 * Math.PI / 60.0;
-        Translation3d omega = new Translation3d(0, omegaY, 0);
-        launchBall(pos, vel, omega);
+    // Pre-allocate contact pool
+    for (int i = 0; i < 200; i++) {
+      contactPool.add(new Contact());
     }
 
-    /**
-     * Shoot a ball with full 3D spin control.
-     *
-     * @param pos launch position (field frame, meters)
-     * @param vel launch velocity (field frame, m/s)
-     * @param omega 3D angular velocity (rad/s)
-     */
-    public void launchBall(Translation3d pos, Translation3d vel, Translation3d omega) {
-        if (balls.size() >= MAX_BALLS) return;
-        SimBall ball = new SimBall(pos, vel, omega);
-        balls.add(ball);
-        totalLaunched++;
-        lastLaunchSpeed = vel.getNorm();
+    // Create hubs
+    blueHub =
+        new ScoringTarget(BLUE_HUB_CENTER, new Translation3d(5.3, FIELD_WIDTH / 2.0, 0.89), 1);
+    redHub =
+        new ScoringTarget(
+            RED_HUB_CENTER, new Translation3d(FIELD_LENGTH - 5.3, FIELD_WIDTH / 2.0, 0.89), -1);
 
-        // Predict the trajectory arc for Field3d visualization (20 points, gravity + drag only)
-        lastShotArc = predictArc(pos, vel, 20, 0.05);
+    // NT publishers
+    var nt = NetworkTableInstance.getDefault();
+    positionPublisher =
+        nt.getStructArrayTopic(tableKey + "/Positions", Translation3d.struct).publish();
+    inFlightPublisher =
+        nt.getStructArrayTopic(tableKey + "/InFlight", Translation3d.struct).publish();
+    lastShotArcPublisher =
+        nt.getStructArrayTopic(tableKey + "/LastShotArc", Translation3d.struct).publish();
+    blueScorePub = nt.getIntegerTopic(tableKey + "/BlueScore").publish();
+    redScorePub = nt.getIntegerTopic(tableKey + "/RedScore").publish();
+    ballCountPub = nt.getIntegerTopic(tableKey + "/Stats/BallCount").publish();
+    activeBallsPub = nt.getIntegerTopic(tableKey + "/Stats/ActiveBalls").publish();
+    sleepingBallsPub = nt.getIntegerTopic(tableKey + "/Stats/SleepingBalls").publish();
+    contactCountPub = nt.getIntegerTopic(tableKey + "/Stats/ContactsPerTick").publish();
+    physicsTimePub = nt.getDoubleTopic(tableKey + "/Stats/PhysicsMs").publish();
+    totalEnergyPub = nt.getDoubleTopic(tableKey + "/Stats/TotalEnergy").publish();
 
-        // Wake nearby sleeping balls
-        if (config.sleepingEnabled) {
-            wakeNearbyBalls(pos, 1.0);
-        }
+    running = false;
+    totalLaunched = 0;
+    totalScored = 0;
+    totalIntaked = 0;
+    lastLaunchSpeed = 0;
+  }
+
+  /** Default constructor, publishes to "Sim/FuelPositions". */
+  public FuelPhysicsSim() {
+    this("Sim/FuelPositions");
+  }
+
+  /** Turn the sim on. You still need to call tick() every cycle. */
+  public void enable() {
+    running = true;
+  }
+
+  /** Pause the sim. Balls freeze in place. */
+  public void disable() {
+    running = false;
+  }
+
+  /** Is the sim running? */
+  public boolean isRunning() {
+    return running;
+  }
+
+  /**
+   * Tell the sim about your robot so it can handle bumper collisions and intake pickup.
+   *
+   * @param width robot width along Y axis (m)
+   * @param length robot length along X axis (m)
+   * @param bumperHeight bumper height (m)
+   * @param poseSupplier field-relative pose supplier
+   * @param speedsSupplier field-relative chassis speeds supplier
+   */
+  public void configureRobot(
+      double width,
+      double length,
+      double bumperHeight,
+      Supplier<Pose2d> poseSupplier,
+      Supplier<ChassisSpeeds> speedsSupplier) {
+    this.robotWidth = width;
+    this.robotLength = length;
+    this.bumperHeight = bumperHeight;
+    this.robotPoseSupplier = poseSupplier;
+    this.robotSpeedsSupplier = speedsSupplier;
+  }
+
+  /**
+   * Add an intake zone. Balls that enter this box (in robot-relative coords) get picked up.
+   *
+   * @param xMin front edge in robot frame
+   * @param xMax back edge in robot frame
+   * @param yMin left edge in robot frame
+   * @param yMax right edge in robot frame
+   * @param active returns true when the intake is actually running
+   * @param callback fires when a ball gets picked up
+   */
+  public void addIntakeZone(
+      double xMin,
+      double xMax,
+      double yMin,
+      double yMax,
+      BooleanSupplier active,
+      Runnable callback) {
+    intakes.add(new IntakeZone(xMin, xMax, yMin, yMax, active, callback));
+  }
+
+  /** Add an intake zone without a callback. */
+  public void addIntakeZone(
+      double xMin, double xMax, double yMin, double yMax, BooleanSupplier active) {
+    addIntakeZone(xMin, xMax, yMin, yMax, active, () -> {});
+  }
+
+  /**
+   * Shoot a ball into the sim.
+   *
+   * @param pos where the ball leaves the launcher (field frame, meters)
+   * @param vel launch velocity (field frame, m/s)
+   * @param spinRPM backspin in RPM (positive = backspin = Magnus lift)
+   */
+  public void launchBall(Translation3d pos, Translation3d vel, double spinRPM) {
+    // Convert RPM to 3D omega: backspin is rotation around -Y axis
+    double omegaY = -spinRPM * 2.0 * Math.PI / 60.0;
+    Translation3d omega = new Translation3d(0, omegaY, 0);
+    launchBall(pos, vel, omega);
+  }
+
+  /**
+   * Shoot a ball with full 3D spin control.
+   *
+   * @param pos launch position (field frame, meters)
+   * @param vel launch velocity (field frame, m/s)
+   * @param omega 3D angular velocity (rad/s)
+   */
+  public void launchBall(Translation3d pos, Translation3d vel, Translation3d omega) {
+    if (balls.size() >= MAX_BALLS) return;
+    SimBall ball = new SimBall(pos, vel, omega);
+    balls.add(ball);
+    totalLaunched++;
+    lastLaunchSpeed = vel.getNorm();
+
+    // Predict the trajectory arc for Field3d visualization (20 points, gravity + drag only)
+    lastShotArc = predictArc(pos, vel, 20, 0.05);
+
+    // Wake nearby sleeping balls
+    if (config.sleepingEnabled) {
+      wakeNearbyBalls(pos, 1.0);
+    }
+  }
+
+  /** Drop a ball at this position, sitting on the ground. */
+  public void spawnBall(Translation3d pos) {
+    if (balls.size() >= MAX_BALLS) return;
+    balls.add(new SimBall(pos));
+  }
+
+  /** Drop a ball with some initial velocity. */
+  public void spawnBall(Translation3d pos, Translation3d vel) {
+    if (balls.size() >= MAX_BALLS) return;
+    balls.add(new SimBall(pos, vel));
+  }
+
+  /** Remove every ball from the sim. */
+  public void clearBalls() {
+    balls.clear();
+  }
+
+  /** Spawn all game pieces in their starting positions (neutral zone + depots). */
+  public void placeFieldBalls() {
+    // Neutral zone fuel
+    double cx = FIELD_LENGTH / 2.0;
+    double cy = FIELD_WIDTH / 2.0;
+    int nzCols = 12; // 12 * 5.91in = 70.9in, fits inside the 72.0in depth
+    int nzRows = 30; // 30 * 5.91in = 177.3in, fits inside the 206.0in width
+    double halfDivider = 0.0254; // half of the 2.0in center divider
+
+    for (int col = 0; col < nzCols; col++) {
+      double x = cx + (col - (nzCols - 1) * 0.5) * BALL_DIAMETER;
+      for (int row = 0; row < nzRows; row++) {
+        double y = cy + (row - (nzRows - 1) * 0.5) * BALL_DIAMETER;
+        if (Math.abs(y - cy) < halfDivider) continue;
+        spawnBall(new Translation3d(x, y, BALL_RADIUS));
+      }
     }
 
-    /** Drop a ball at this position, sitting on the ground. */
-    public void spawnBall(Translation3d pos) {
-        if (balls.size() >= MAX_BALLS) return;
-        balls.add(new SimBall(pos));
+    // Depot fuel
+    int depotCols = 4; // 4 * 5.91in = 23.6in fits inside 27.0in depth
+    int depotRows = 6; // 6 * 5.91in = 35.5in fits inside 42.0in width
+
+    // Blue-side depot
+    fillBallGrid(FIELD_LENGTH - 0.37, 2.10, depotCols, depotRows);
+    // Red-side depot
+    fillBallGrid(0.37, FIELD_WIDTH - 2.10, depotCols, depotRows);
+  }
+
+  /** Helper: fill a grid of balls centered at (cx, cy). */
+  private void fillBallGrid(double cx, double cy, int cols, int rows) {
+    for (int c = 0; c < cols; c++) {
+      double x = cx + (c - (cols - 1) * 0.5) * BALL_DIAMETER;
+      for (int r = 0; r < rows; r++) {
+        double y = cy + (r - (rows - 1) * 0.5) * BALL_DIAMETER;
+        spawnBall(new Translation3d(x, y, BALL_RADIUS));
+      }
+    }
+  }
+
+  /**
+   * Step the sim forward one period (20ms) and publish ball positions to NT. Does nothing if the
+   * sim isn't enabled.
+   */
+  public void tick() {
+    if (!running) return;
+    long t0 = System.nanoTime();
+    advancePhysics(PERIOD);
+    lastPhysicsNanos = System.nanoTime() - t0;
+    publishPositions();
+  }
+
+  /**
+   * Advance physics by dt seconds. Splits into subticks for stability.
+   *
+   * @param dt time to advance (seconds)
+   */
+  public void advancePhysics(double dt) {
+    int ticks = Math.max(1, config.subticks);
+    double subDt = dt / ticks;
+
+    for (int tick = 0; tick < ticks; tick++) {
+      stepSubtick(subDt);
     }
 
-    /** Drop a ball with some initial velocity. */
-    public void spawnBall(Translation3d pos, Translation3d vel) {
-        if (balls.size() >= MAX_BALLS) return;
-        balls.add(new SimBall(pos, vel));
+    // Remove flagged balls
+    removeFlaggedBalls();
+  }
+
+  // Core physics pipeline
+
+  private void stepSubtick(double subDt) {
+    // Reset contact list
+    contactPoolIndex = 0;
+    contacts.clear();
+
+    for (int i = 0; i < balls.size(); i++) {
+      SimBall ball = balls.get(i);
+      if (ball.intaked || ball.outOfBounds) continue;
+      if (ball.sleeping && config.sleepingEnabled) continue;
+
+      // Save previous state
+      ball.prevPos = ball.pos;
+      ball.prevVel = ball.vel;
+
+      // Compute forces and get acceleration
+      Translation3d accel = computeAcceleration(ball);
+
+      // Symplectic Euler: update velocity first so we don't accumulate energy drift
+      ball.vel = ball.vel.plus(accel.times(subDt));
+      ball.pos = ball.pos.plus(ball.vel.times(subDt));
+
+      // Spin decay
+      if (config.spinDecayEnabled && ball.omega.getNorm() > 1e-6) {
+        double decayFactor = Math.exp(-subDt / config.spinDecayTau);
+        ball.omega = ball.omega.times(decayFactor);
+      }
     }
 
-    /** Remove every ball from the sim. */
-    public void clearBalls() {
-        balls.clear();
+    // CCD for fast balls
+    if (config.ccdEnabled) {
+      for (int i = 0; i < balls.size(); i++) {
+        SimBall ball = balls.get(i);
+        if (ball.intaked || ball.outOfBounds) continue;
+        if (ball.sleeping && config.sleepingEnabled) continue;
+        if (ball.vel.getNorm() > config.ccdSpeedThreshold) {
+          handleCCD(ball);
+        }
+      }
     }
 
-    /** Spawn all game pieces in their starting positions (neutral zone + depots). */
-    public void placeFieldBalls() {
-        // Neutral zone fuel
-        double cx = FIELD_LENGTH / 2.0;
-        double cy = FIELD_WIDTH / 2.0;
-        int nzCols = 12; // 12 * 5.91in = 70.9in, fits inside the 72.0in depth
-        int nzRows = 30; // 30 * 5.91in = 177.3in, fits inside the 206.0in width
-        double halfDivider = 0.0254; // half of the 2.0in center divider
-
-        for (int col = 0; col < nzCols; col++) {
-            double x = cx + (col - (nzCols - 1) * 0.5) * BALL_DIAMETER;
-            for (int row = 0; row < nzRows; row++) {
-                double y = cy + (row - (nzRows - 1) * 0.5) * BALL_DIAMETER;
-                if (Math.abs(y - cy) < halfDivider) continue;
-                spawnBall(new Translation3d(x, y, BALL_RADIUS));
-            }
-        }
-
-        // Depot fuel
-        int depotCols = 4; // 4 * 5.91in = 23.6in fits inside 27.0in depth
-        int depotRows = 6; // 6 * 5.91in = 35.5in fits inside 42.0in width
-
-        // Blue-side depot
-        fillBallGrid(FIELD_LENGTH - 0.37, 2.10, depotCols, depotRows);
-        // Red-side depot
-        fillBallGrid(0.37, FIELD_WIDTH - 2.10, depotCols, depotRows);
-    }
-
-    /** Helper: fill a grid of balls centered at (cx, cy). */
-    private void fillBallGrid(double cx, double cy, int cols, int rows) {
-        for (int c = 0; c < cols; c++) {
-            double x = cx + (c - (cols - 1) * 0.5) * BALL_DIAMETER;
-            for (int r = 0; r < rows; r++) {
-                double y = cy + (r - (rows - 1) * 0.5) * BALL_DIAMETER;
-                spawnBall(new Translation3d(x, y, BALL_RADIUS));
-            }
-        }
-    }
-
-    /**
-     * Step the sim forward one period (20ms) and publish ball positions to NT. Does nothing if the
-     * sim isn't enabled.
-     */
-    public void tick() {
-        if (!running) return;
-        long t0 = System.nanoTime();
-        advancePhysics(PERIOD);
-        lastPhysicsNanos = System.nanoTime() - t0;
-        publishPositions();
-    }
-
-    /**
-     * Advance physics by dt seconds. Splits into subticks for stability.
-     *
-     * @param dt time to advance (seconds)
-     */
-    public void advancePhysics(double dt) {
-        int ticks = Math.max(1, config.subticks);
-        double subDt = dt / ticks;
-
-        for (int tick = 0; tick < ticks; tick++) {
-            stepSubtick(subDt);
-        }
-
-        // Remove flagged balls
-        removeFlaggedBalls();
-    }
-
-    // Core physics pipeline
-
-    private void stepSubtick(double subDt) {
-        // Reset contact list
-        contactPoolIndex = 0;
-        contacts.clear();
-
-        for (int i = 0; i < balls.size(); i++) {
-            SimBall ball = balls.get(i);
-            if (ball.intaked || ball.outOfBounds) continue;
-            if (ball.sleeping && config.sleepingEnabled) continue;
-
-            // Save previous state
-            ball.prevPos = ball.pos;
-            ball.prevVel = ball.vel;
-
-            // Compute forces and get acceleration
-            Translation3d accel = computeAcceleration(ball);
-
-            // Symplectic Euler: update velocity first so we don't accumulate energy drift
-            ball.vel = ball.vel.plus(accel.times(subDt));
-            ball.pos = ball.pos.plus(ball.vel.times(subDt));
-
-            // Spin decay
-            if (config.spinDecayEnabled && ball.omega.getNorm() > 1e-6) {
-                double decayFactor = Math.exp(-subDt / config.spinDecayTau);
-                ball.omega = ball.omega.times(decayFactor);
-            }
-        }
-
-        // CCD for fast balls
-        if (config.ccdEnabled) {
-            for (int i = 0; i < balls.size(); i++) {
-                SimBall ball = balls.get(i);
-                if (ball.intaked || ball.outOfBounds) continue;
-                if (ball.sleeping && config.sleepingEnabled) continue;
-                if (ball.vel.getNorm() > config.ccdSpeedThreshold) {
-                    handleCCD(ball);
-                }
-            }
-        }
-
-        // Broadphase: build spatial hash
-        buildSpatialHash();
-
-        // Generate contacts: ball-ball via spatial hash, ball-field via narrowphase
-        generateBallBallContacts();
-        generateBallFieldContacts();
-
-        // Sequential impulse solver
-        solveContacts();
-
-        // Simple wall/ground handling (direct impulse, not through solver)
-        for (int i = 0; i < balls.size(); i++) {
-            SimBall ball = balls.get(i);
-            if (ball.intaked || ball.outOfBounds) continue;
-            if (ball.sleeping && config.sleepingEnabled) continue;
-            handleWallBounce(ball);
-            handleGroundContact(ball, subDt);
-            handleBumpCollisions(ball);
-        }
-
-        // Hub scoring
-        for (int i = 0; i < balls.size(); i++) {
-            SimBall ball = balls.get(i);
-            if (ball.intaked || ball.outOfBounds) continue;
-            handleHubScoring(ball);
-        }
-
-        // Net collisions
-        for (int i = 0; i < balls.size(); i++) {
-            SimBall ball = balls.get(i);
-            if (ball.intaked || ball.outOfBounds) continue;
-            if (ball.sleeping && config.sleepingEnabled) continue;
-            handleNetCollision(ball, blueHub);
-            handleNetCollision(ball, redHub);
-        }
-
-        // Robot interaction
-        if (robotPoseSupplier != null && robotSpeedsSupplier != null) {
-            Pose2d robotPose = robotPoseSupplier.get();
-            ChassisSpeeds speeds = robotSpeedsSupplier.get();
-            Translation2d robotVel =
-                    new Translation2d(speeds.vxMetersPerSecond, speeds.vyMetersPerSecond);
-
-            // Wake radius: robot half-diagonal plus margin so balls react before contact
-            double wakeRadius = Math.hypot(robotLength, robotWidth) / 2.0 + 0.3;
-            double wakeRadiusSq = wakeRadius * wakeRadius;
-
-            for (int i = 0; i < balls.size(); i++) {
-                SimBall ball = balls.get(i);
-                if (ball.intaked || ball.outOfBounds) continue;
-                // Wake sleeping balls near the robot so bumpers push them
-                if (ball.sleeping && config.sleepingEnabled) {
-                    double dx = ball.pos.getX() - robotPose.getX();
-                    double dy = ball.pos.getY() - robotPose.getY();
-                    if (dx * dx + dy * dy < wakeRadiusSq) {
-                        wakeBall(ball);
-                    } else {
-                        continue;
-                    }
-                }
-                // Intake first so balls are consumed before bumper pushes them away
-                handleIntakePickup(ball, robotPose);
-                if (ball.intaked) continue;
-                handleRobotCollision(ball, robotPose, robotVel);
-            }
-        }
-
-        // Sleep update
-        if (config.sleepingEnabled) {
-            for (int i = 0; i < balls.size(); i++) {
-                updateSleepState(balls.get(i));
-            }
-        }
-
-        // Out-of-bounds cleanup (includes NaN guard, upper Z limit, and stuck-on-obstacle removal)
-        for (int i = 0; i < balls.size(); i++) {
-            SimBall ball = balls.get(i);
-            if (!Double.isFinite(ball.pos.getX())
-                    || !Double.isFinite(ball.pos.getY())
-                    || !Double.isFinite(ball.pos.getZ())
-                    || !Double.isFinite(ball.vel.getX())
-                    || !Double.isFinite(ball.vel.getY())
-                    || !Double.isFinite(ball.vel.getZ())
-                    || !Double.isFinite(ball.omega.getX())
-                    || !Double.isFinite(ball.omega.getY())
-                    || !Double.isFinite(ball.omega.getZ())
-                    || ball.pos.getX() < -2.0
-                    || ball.pos.getX() > FIELD_LENGTH + 2.0
-                    || ball.pos.getY() < -2.0
-                    || ball.pos.getY() > FIELD_WIDTH + 2.0
-                    || ball.pos.getZ() < -1.0
-                    || ball.pos.getZ() > 15.0) {
-                ball.outOfBounds = true;
-            }
-            // Remove balls stuck on elevated obstacles
-            if (ball.pos.getZ() > BALL_RADIUS + 0.3 && ball.vel.getNorm() < 0.5) {
-                ball.elevatedSlowCounter++;
-                if (ball.elevatedSlowCounter > 250) {
-                    ball.outOfBounds = true;
-                }
-            } else {
-                ball.elevatedSlowCounter = 0;
-            }
-        }
-
-        // Conservation monitor
-        if (config.conservationMonitor) {
-            computeConservationQuantities();
-        }
-    }
-
-    /** Compute acceleration: gravity + drag + Magnus lift. Magnus only kicks in when airborne. */
-    private Translation3d computeAcceleration(SimBall ball) {
-        // Gravity always acts
-        double ax = 0, ay = 0, az = -GRAVITY;
-
-        double speed = ball.vel.getNorm();
-        boolean airborne = ball.pos.getZ() > BALL_RADIUS + 0.01;
-
-        // Drag acts whether on ground or airborne (air doesn't vanish at carpet level)
-        if (config.dragEnabled && speed > 1e-6) {
-            ax -= DRAG_ACCEL_FACTOR * speed * ball.vel.getX();
-            ay -= DRAG_ACCEL_FACTOR * speed * ball.vel.getY();
-            az -= DRAG_ACCEL_FACTOR * speed * ball.vel.getZ();
-        }
-
-        // Magnus only applies airborne (ground friction dominates spin behavior on carpet)
-        if (airborne && speed > 1e-6) {
-            if (config.magnusEnabled && ball.omega.getNorm() > 1e-3) {
-                Translation3d magnusDir = cross(ball.omega, ball.vel);
-                double magnusMag = magnusDir.getNorm();
-                if (magnusMag > 1e-6) {
-                    // a_magnus = MAGNUS_ACCEL_FACTOR * (omega x v)
-                    ax += MAGNUS_ACCEL_FACTOR * magnusDir.getX();
-                    ay += MAGNUS_ACCEL_FACTOR * magnusDir.getY();
-                    az += MAGNUS_ACCEL_FACTOR * magnusDir.getZ();
-                }
-            }
-        }
-
-        return new Translation3d(ax, ay, az);
-    }
-
-    /** Continuous collision detection: sweep fast balls so they don't tunnel through walls. */
-    private void handleCCD(SimBall ball) {
-        Translation3d delta = ball.pos.minus(ball.prevPos);
-        double dist = delta.getNorm();
-        if (dist < 1e-6) return;
-
-        Translation3d dir = delta.div(dist);
-
-        // Check against field boundaries
-        double tMin = 1.0;
-        Translation3d hitNormal = null;
-
-        // X walls
-        if (dir.getX() < -1e-6) {
-            double t = (BALL_RADIUS - ball.prevPos.getX()) / (delta.getX());
-            if (t > 0 && t < tMin) {
-                tMin = t;
-                hitNormal = AXIS_X_POS;
-            }
-        } else if (dir.getX() > 1e-6) {
-            double t = (FIELD_LENGTH - BALL_RADIUS - ball.prevPos.getX()) / (delta.getX());
-            if (t > 0 && t < tMin) {
-                tMin = t;
-                hitNormal = AXIS_X_NEG;
-            }
-        }
-
-        // Y walls
-        if (dir.getY() < -1e-6) {
-            double t = (BALL_RADIUS - ball.prevPos.getY()) / (delta.getY());
-            if (t > 0 && t < tMin) {
-                tMin = t;
-                hitNormal = AXIS_Y_POS;
-            }
-        } else if (dir.getY() > 1e-6) {
-            double t = (FIELD_WIDTH - BALL_RADIUS - ball.prevPos.getY()) / (delta.getY());
-            if (t > 0 && t < tMin) {
-                tMin = t;
-                hitNormal = AXIS_Y_NEG;
-            }
-        }
-
-        // Ground
-        if (dir.getZ() < -1e-6) {
-            double t = (BALL_RADIUS - ball.prevPos.getZ()) / (delta.getZ());
-            if (t > 0 && t < tMin) {
-                tMin = t;
-                hitNormal = AXIS_Z_POS;
-            }
-        }
-
-        // AABB obstacles (ray-box intersection)
-        for (AABB aabb : AABB_OBSTACLES) {
-            double tHit = sweepSphereAABB(ball.prevPos, delta, aabb);
-            if (tHit >= 0 && tHit < tMin) {
-                // Compute normal at hit point
-                Translation3d hitPos = ball.prevPos.plus(delta.times(tHit));
-                Translation3d n = computeAABBNormal(hitPos, aabb);
-                if (n != null) {
-                    tMin = tHit;
-                    hitNormal = n;
-                }
-            }
-        }
-
-        if (hitNormal != null && tMin < 1.0) {
-            // Move ball to contact point
-            ball.pos = ball.prevPos.plus(delta.times(tMin));
-
-            // Reflect velocity
-            double vDotN = ball.vel.dot(hitNormal);
-            if (vDotN < 0) {
-                double cor = config.velocityDependentCOR ? velocityCOR(COR_WALL, -vDotN) : COR_WALL;
-                ball.vel = ball.vel.minus(hitNormal.times((1.0 + cor) * vDotN));
-            }
-        }
-    }
-
-    /**
-     * Ray-AABB intersection with sphere expansion (Minkowski sum). Returns hit time in [0,1] or -1.
-     */
-    private double sweepSphereAABB(Translation3d origin, Translation3d delta, AABB aabb) {
-        // Expand AABB by ball radius (Minkowski sum with sphere)
-        double minX = aabb.minX() - BALL_RADIUS;
-        double minY = aabb.minY() - BALL_RADIUS;
-        double minZ = aabb.minZ() - BALL_RADIUS;
-        double maxX = aabb.maxX() + BALL_RADIUS;
-        double maxY = aabb.maxY() + BALL_RADIUS;
-        double maxZ = aabb.maxZ() + BALL_RADIUS;
-
-        double tEnter = 0;
-        double tExit = 1;
-
-        // X slab
-        if (Math.abs(delta.getX()) > 1e-9) {
-            double invD = 1.0 / delta.getX();
-            double t1 = (minX - origin.getX()) * invD;
-            double t2 = (maxX - origin.getX()) * invD;
-            if (t1 > t2) {
-                double tmp = t1;
-                t1 = t2;
-                t2 = tmp;
-            }
-            tEnter = Math.max(tEnter, t1);
-            tExit = Math.min(tExit, t2);
-        } else {
-            if (origin.getX() < minX || origin.getX() > maxX) return -1;
-        }
-
-        // Y slab
-        if (Math.abs(delta.getY()) > 1e-9) {
-            double invD = 1.0 / delta.getY();
-            double t1 = (minY - origin.getY()) * invD;
-            double t2 = (maxY - origin.getY()) * invD;
-            if (t1 > t2) {
-                double tmp = t1;
-                t1 = t2;
-                t2 = tmp;
-            }
-            tEnter = Math.max(tEnter, t1);
-            tExit = Math.min(tExit, t2);
-        } else {
-            if (origin.getY() < minY || origin.getY() > maxY) return -1;
-        }
-
-        // Z slab
-        if (Math.abs(delta.getZ()) > 1e-9) {
-            double invD = 1.0 / delta.getZ();
-            double t1 = (minZ - origin.getZ()) * invD;
-            double t2 = (maxZ - origin.getZ()) * invD;
-            if (t1 > t2) {
-                double tmp = t1;
-                t1 = t2;
-                t2 = tmp;
-            }
-            tEnter = Math.max(tEnter, t1);
-            tExit = Math.min(tExit, t2);
-        } else {
-            if (origin.getZ() < minZ || origin.getZ() > maxZ) return -1;
-        }
-
-        if (tEnter > tExit || tExit < 0) return -1;
-        return tEnter > 0 ? tEnter : -1; // Already inside if tEnter <= 0
-    }
-
-    // Broadphase (spatial hash)
-
-    private void buildSpatialHash() {
-        for (int i = 0; i < GRID_COLS; i++) {
-            for (int j = 0; j < GRID_ROWS; j++) {
-                grid[i][j].clear();
-            }
-        }
-        // Include sleeping balls so awake balls can detect them for wake-on-collision
-        for (int i = 0; i < balls.size(); i++) {
-            SimBall ball = balls.get(i);
-            if (ball.intaked || ball.outOfBounds) continue;
-            int col = (int) (ball.pos.getX() / CELL_SIZE);
-            int row = (int) (ball.pos.getY() / CELL_SIZE);
-            if (col >= 0 && col < GRID_COLS && row >= 0 && row < GRID_ROWS) {
-                grid[col][row].add(i);
-            }
-        }
-    }
-
-    // Narrowphase contact generation
-
-    private void generateBallBallContacts() {
-        for (int i = 0; i < balls.size(); i++) {
-            SimBall ballA = balls.get(i);
-            if (ballA.intaked || ballA.outOfBounds) continue;
-            if (ballA.sleeping && config.sleepingEnabled) continue;
-
-            int col = (int) (ballA.pos.getX() / CELL_SIZE);
-            int row = (int) (ballA.pos.getY() / CELL_SIZE);
-
-            for (int di = -1; di <= 1; di++) {
-                for (int dj = -1; dj <= 1; dj++) {
-                    int ci = col + di;
-                    int cj = row + dj;
-                    if (ci < 0 || ci >= GRID_COLS || cj < 0 || cj >= GRID_ROWS) continue;
-                    List<Integer> cell = grid[ci][cj];
-                    for (int k = 0; k < cell.size(); k++) {
-                        int j = cell.get(k);
-                        if (j == i) continue; // same ball
-                        if (j < i && !(config.sleepingEnabled && balls.get(j).sleeping)) continue;
-
-                        SimBall ballB = balls.get(j);
-                        double dx = ballA.pos.getX() - ballB.pos.getX();
-                        double dy = ballA.pos.getY() - ballB.pos.getY();
-                        double dz = ballA.pos.getZ() - ballB.pos.getZ();
-                        double distSq = dx * dx + dy * dy + dz * dz;
-                        double minDist = BALL_RADIUS * 2;
-
-                        if (distSq < minDist * minDist) {
-                            double dist = Math.sqrt(distSq);
-                            Contact c = allocateContact();
-                            if (dist < 1e-9) {
-                                c.normal = AXIS_X_POS;
-                                dist = 1e-9;
-                            } else {
-                                c.normal = ballA.pos.minus(ballB.pos).div(dist);
-                            }
-                            c.ballIndexA = i;
-                            c.ballIndexB = j;
-                            c.penetration = minDist - dist;
-                            c.contactPoint =
-                                    ballA.pos.plus(ballB.pos).div(2.0); // midpoint between centers
-                            c.restitution = COR_BALL_BALL;
-                            c.friction = config.frictionEnabled ? MU_BALL_BALL : 0;
-                            c.normalImpulseAccum = 0;
-                            c.tangentImpulseAccum = 0;
-                            contacts.add(c);
-
-                            // Wake sleeping ball on contact
-                            if (ballB.sleeping) {
-                                wakeBall(ballB);
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    private void generateBallFieldContacts() {
-        for (int i = 0; i < balls.size(); i++) {
-            SimBall ball = balls.get(i);
-            if (ball.intaked || ball.outOfBounds) continue;
-            if (ball.sleeping && config.sleepingEnabled) continue;
-
-            // AABB obstacles
-            for (AABB aabb : AABB_OBSTACLES) {
-                generateSphereAABBContact(i, ball, aabb);
-            }
-
-            // Cylinder obstacles
-            for (CylinderObstacle cyl : CYLINDER_OBSTACLES) {
-                generateSphereCylinderContact(i, ball, cyl);
-            }
-        }
-    }
-
-    private void generateSphereAABBContact(int ballIndex, SimBall ball, AABB aabb) {
-        // Find nearest point on AABB to sphere center
-        double cx = Math.max(aabb.minX(), Math.min(ball.pos.getX(), aabb.maxX()));
-        double cy = Math.max(aabb.minY(), Math.min(ball.pos.getY(), aabb.maxY()));
-        double cz = Math.max(aabb.minZ(), Math.min(ball.pos.getZ(), aabb.maxZ()));
-
-        double dx = ball.pos.getX() - cx;
-        double dy = ball.pos.getY() - cy;
-        double dz = ball.pos.getZ() - cz;
-        double distSq = dx * dx + dy * dy + dz * dz;
-
-        if (distSq < BALL_RADIUS * BALL_RADIUS && distSq >= 1e-9) {
-            double dist = Math.sqrt(distSq);
-            Contact c = allocateContact();
-            c.ballIndexA = ballIndex;
-            c.ballIndexB = -1;
-            c.normal = new Translation3d(dx / dist, dy / dist, dz / dist);
-            c.penetration = BALL_RADIUS - dist;
-            c.contactPoint = new Translation3d(cx, cy, cz);
-            c.restitution = aabb.cor();
-            c.friction = config.frictionEnabled ? MU_WALL : 0;
-            c.normalImpulseAccum = 0;
-            c.tangentImpulseAccum = 0;
-            contacts.add(c);
-        } else if (distSq < 1e-9) {
-            // Ball center is inside AABB.
-            Translation3d normal = computeEntryFaceNormal(ball.prevPos, ball.pos, aabb);
-            if (normal != null) {
-                double pen = computeAABBPenetration(ball.pos, aabb);
-                Contact c = allocateContact();
-                c.ballIndexA = ballIndex;
-                c.ballIndexB = -1;
-                c.normal = normal;
-                c.penetration = pen + BALL_RADIUS;
-                c.contactPoint = ball.pos;
-                c.restitution = aabb.cor();
-                c.friction = config.frictionEnabled ? MU_WALL : 0;
-                c.normalImpulseAccum = 0;
-                c.tangentImpulseAccum = 0;
-                contacts.add(c);
-            }
-        }
-    }
-
-    /** Which face of the AABB is the point closest to? Returns outward normal of that face. */
-    private Translation3d computeAABBNormal(Translation3d p, AABB aabb) {
-        double dxMin = p.getX() - aabb.minX();
-        double dxMax = aabb.maxX() - p.getX();
-        double dyMin = p.getY() - aabb.minY();
-        double dyMax = aabb.maxY() - p.getY();
-        double dzMin = p.getZ() - aabb.minZ();
-        double dzMax = aabb.maxZ() - p.getZ();
-
-        double min = dxMin;
-        Translation3d normal = AXIS_X_NEG;
-
-        if (dxMax < min) {
-            min = dxMax;
-            normal = AXIS_X_POS;
-        }
-        if (dyMin < min) {
-            min = dyMin;
-            normal = AXIS_Y_NEG;
-        }
-        if (dyMax < min) {
-            min = dyMax;
-            normal = AXIS_Y_POS;
-        }
-        if (dzMin < min) {
-            min = dzMin;
-            normal = AXIS_Z_NEG;
-        }
-        if (dzMax < min) {
-            min = dzMax;
-            normal = AXIS_Z_POS;
-        }
-        return normal;
-    }
-
-    /** How deep is a point inside an AABB? Returns min distance to any face. */
-    private double computeAABBPenetration(Translation3d p, AABB aabb) {
-        double dxMin = p.getX() - aabb.minX();
-        double dxMax = aabb.maxX() - p.getX();
-        double dyMin = p.getY() - aabb.minY();
-        double dyMax = aabb.maxY() - p.getY();
-        double dzMin = p.getZ() - aabb.minZ();
-        double dzMax = aabb.maxZ() - p.getZ();
-        return Math.min(
-                Math.min(Math.min(dxMin, dxMax), Math.min(dyMin, dyMax)), Math.min(dzMin, dzMax));
-    }
-
-    /**
-     * If a ball is inside an AABB, figure out which face it came in through by raycasting from
-     * prevPos to pos. Without this, balls pop onto the top of obstacles when they actually entered
-     * from the side. Falls back to nearest-face if the ray is degenerate (ball spawned inside).
-     */
-    private Translation3d computeEntryFaceNormal(Translation3d from, Translation3d to, AABB aabb) {
-        if (from == null) return computeAABBNormal(to, aabb);
-
-        double dx = to.getX() - from.getX();
-        double dy = to.getY() - from.getY();
-        double dz = to.getZ() - from.getZ();
-
-        // Slab intersection: the entry face is the axis with the latest entry time
-        double tMax = Double.NEGATIVE_INFINITY;
-        Translation3d bestNormal = null;
-
-        if (Math.abs(dx) > 1e-12) {
-            double invD = 1.0 / dx;
-            double t1 = (aabb.minX() - from.getX()) * invD;
-            double t2 = (aabb.maxX() - from.getX()) * invD;
-            double tEntry = Math.min(t1, t2);
-            if (tEntry > tMax) {
-                tMax = tEntry;
-                bestNormal = dx > 0 ? AXIS_X_NEG : AXIS_X_POS;
-            }
-        }
-        if (Math.abs(dy) > 1e-12) {
-            double invD = 1.0 / dy;
-            double t1 = (aabb.minY() - from.getY()) * invD;
-            double t2 = (aabb.maxY() - from.getY()) * invD;
-            double tEntry = Math.min(t1, t2);
-            if (tEntry > tMax) {
-                tMax = tEntry;
-                bestNormal = dy > 0 ? AXIS_Y_NEG : AXIS_Y_POS;
-            }
-        }
-        if (Math.abs(dz) > 1e-12) {
-            double invD = 1.0 / dz;
-            double t1 = (aabb.minZ() - from.getZ()) * invD;
-            double t2 = (aabb.maxZ() - from.getZ()) * invD;
-            double tEntry = Math.min(t1, t2);
-            if (tEntry > tMax) {
-                tMax = tEntry;
-                bestNormal = dz > 0 ? AXIS_Z_NEG : AXIS_Z_POS;
-            }
-        }
-
-        return bestNormal != null ? bestNormal : computeAABBNormal(to, aabb);
-    }
-
-    private void generateSphereCylinderContact(int ballIndex, SimBall ball, CylinderObstacle cyl) {
-        if (cyl.abLenSq() < 1e-12) return;
-
-        // Find nearest point on line segment to ball center
-
-        double apx = ball.pos.getX() - cyl.ax();
-        double apy = ball.pos.getY() - cyl.ay();
-        double apz = ball.pos.getZ() - cyl.az();
-        double t =
-                Math.max(
-                        0,
-                        Math.min(
-                                1,
-                                (apx * cyl.abx() + apy * cyl.aby() + apz * cyl.abz())
-                                        / cyl.abLenSq()));
-
-        double nearX = cyl.ax() + t * cyl.abx();
-        double nearY = cyl.ay() + t * cyl.aby();
-        double nearZ = cyl.az() + t * cyl.abz();
-
-        double dx = ball.pos.getX() - nearX;
-        double dy = ball.pos.getY() - nearY;
-        double dz = ball.pos.getZ() - nearZ;
-        double distSq = dx * dx + dy * dy + dz * dz;
-        double minDist = BALL_RADIUS + cyl.radius();
-
-        if (distSq < minDist * minDist && distSq > 0) {
-            double dist = Math.sqrt(distSq);
-            Contact c = allocateContact();
-            c.ballIndexA = ballIndex;
-            c.ballIndexB = -1;
-            c.normal = new Translation3d(dx / dist, dy / dist, dz / dist);
-            c.penetration = minDist - dist;
-            c.contactPoint = new Translation3d(nearX, nearY, nearZ);
-            c.restitution = cyl.cor();
-            c.friction = config.frictionEnabled ? MU_WALL : 0;
-            c.normalImpulseAccum = 0;
-            c.tangentImpulseAccum = 0;
-            contacts.add(c);
-        }
-    }
-
-    /**
-     * Sequential impulse solver: resolve bounces, friction, and spin transfer across all contacts.
-     */
-    private void solveContacts() {
-        if (contacts.isEmpty()) return;
-
-        // Compute restitution targets from initial approach velocities (before any solving)
-        for (int i = 0; i < contacts.size(); i++) {
-            Contact c = contacts.get(i);
-            SimBall ballA = balls.get(c.ballIndexA);
-            Translation3d relVel;
-            if (c.ballIndexB >= 0) {
-                relVel = ballA.vel.minus(balls.get(c.ballIndexB).vel);
-            } else {
-                relVel = ballA.vel;
-            }
-            double vn = relVel.dot(c.normal);
-            double e = c.restitution;
-            if (config.velocityDependentCOR) {
-                e = velocityCOR(e, Math.abs(vn));
-            }
-            // Only bounce for significant approach speeds.
-            c.restitutionVelocity = vn < -0.5 ? -e * vn : 0;
-        }
-
-        for (int iter = 0; iter < config.solverIterations; iter++) {
-            for (int i = 0; i < contacts.size(); i++) {
-                Contact c = contacts.get(i);
-                solveContact(c);
-            }
-        }
-
-        // Position correction
-        for (int i = 0; i < contacts.size(); i++) {
-            applyPositionCorrection(contacts.get(i));
-        }
-    }
-
-    private void solveContact(Contact c) {
-        SimBall ballA = balls.get(c.ballIndexA);
-        Translation3d relVel;
-        double invMassSum;
-
-        if (c.ballIndexB >= 0) {
-            // Ball-ball contact
-            SimBall ballB = balls.get(c.ballIndexB);
-            relVel = ballA.vel.minus(ballB.vel);
-            invMassSum = 2.0 / BALL_MASS; // both balls have same mass
-        } else {
-            // Ball-field contact
-            relVel = ballA.vel;
-            invMassSum = 1.0 / BALL_MASS;
-        }
-
-        double vRelNormal = relVel.dot(c.normal);
-        double jn = -(vRelNormal - c.restitutionVelocity) / invMassSum;
-        double oldAccum = c.normalImpulseAccum;
-        c.normalImpulseAccum = Math.max(0, oldAccum + jn);
-        jn = c.normalImpulseAccum - oldAccum;
-
-        // Apply normal impulse
-        Translation3d normalImpulse = c.normal.times(jn);
-        ballA.vel = ballA.vel.plus(normalImpulse.div(BALL_MASS));
-        if (c.ballIndexB >= 0) {
-            SimBall ballB = balls.get(c.ballIndexB);
-            ballB.vel = ballB.vel.minus(normalImpulse.div(BALL_MASS));
-        }
-
-        // Tangential impulse (friction)
-        if (c.friction > 0 && config.frictionEnabled) {
-            // Recompute relative velocity after normal impulse
-            if (c.ballIndexB >= 0) {
-                relVel = ballA.vel.minus(balls.get(c.ballIndexB).vel);
-            } else {
-                relVel = ballA.vel;
-            }
-
-            // Tangent velocity: remove normal component
-            double vn = relVel.dot(c.normal);
-            Translation3d vTangent = relVel.minus(c.normal.times(vn));
-            double vTangentMag = vTangent.getNorm();
-
-            if (vTangentMag > 1e-6) {
-                Translation3d tangentDir = vTangent.div(vTangentMag);
-
-                // Friction impulse magnitude
-                double jt = -vTangentMag / invMassSum;
-
-                // Coulomb clamp: |j_t| <= mu * j_n
-                double maxFriction = c.friction * c.normalImpulseAccum;
-                double oldTangentAccum = c.tangentImpulseAccum;
-                c.tangentImpulseAccum =
-                        Math.max(-maxFriction, Math.min(maxFriction, oldTangentAccum + jt));
-                jt = c.tangentImpulseAccum - oldTangentAccum;
-
-                // Apply tangent impulse
-                Translation3d frictionImpulse = tangentDir.times(jt);
-                ballA.vel = ballA.vel.plus(frictionImpulse.div(BALL_MASS));
-                if (c.ballIndexB >= 0) {
-                    SimBall ballB = balls.get(c.ballIndexB);
-                    ballB.vel = ballB.vel.minus(frictionImpulse.div(BALL_MASS));
-                }
-
-                // Spin transfer from friction torque
-                if (config.spinTransferEnabled && Math.abs(jt) > 1e-9) {
-                    Translation3d rContact = c.normal.times(-BALL_RADIUS); // from center to contact
-                    Translation3d torqueImpulse = cross(rContact, frictionImpulse);
-                    Translation3d deltaOmega = torqueImpulse.div(BALL_MOMENT_OF_INERTIA);
-                    ballA.omega = ballA.omega.plus(deltaOmega);
-
-                    if (c.ballIndexB >= 0) {
-                        SimBall ballB = balls.get(c.ballIndexB);
-                        Translation3d rContactB = c.normal.times(BALL_RADIUS);
-                        Translation3d torqueImpulseB =
-                                cross(rContactB, frictionImpulse.unaryMinus());
-                        Translation3d deltaOmegaB = torqueImpulseB.div(BALL_MOMENT_OF_INERTIA);
-                        ballB.omega = ballB.omega.plus(deltaOmegaB);
-                    }
-                }
-            }
-        }
-    }
-
-    /** Push overlapping objects apart so they don't sink into each other. */
-    private void applyPositionCorrection(Contact c) {
-        double slop = config.baumgarteSlop;
-        double beta = config.baumgarteBeta;
-        double correction = Math.max(c.penetration - slop, 0) * beta;
-
-        if (correction < 1e-6) return;
-
-        SimBall ballA = balls.get(c.ballIndexA);
-        if (c.ballIndexB >= 0) {
-            SimBall ballB = balls.get(c.ballIndexB);
-            Translation3d corrVec = c.normal.times(correction * 0.5);
-            ballA.pos = ballA.pos.plus(corrVec);
-            ballB.pos = ballB.pos.minus(corrVec);
-        } else {
-            ballA.pos = ballA.pos.plus(c.normal.times(correction));
-        }
-    }
-
-    // Wall and ground handling
-
-    private void handleWallBounce(SimBall ball) {
-        double z = ball.pos.getZ();
-
-        // X walls (alliance walls: diamond plate + polycarbonate, height-aware)
-        if (ball.pos.getX() < BALL_RADIUS) {
-            if (z < ALLIANCE_WALL_HEIGHT) {
-                ball.pos = new Translation3d(BALL_RADIUS, ball.pos.getY(), ball.pos.getZ());
-                if (ball.vel.getX() < 0) {
-                    applyWallSpinTransfer(ball, AXIS_X_POS);
-                    double cor = effectiveCOR(COR_WALL, Math.abs(ball.vel.getX()));
-                    ball.vel =
-                            new Translation3d(
-                                    -ball.vel.getX() * cor, ball.vel.getY(), ball.vel.getZ());
-                }
-            }
-        } else if (ball.pos.getX() > FIELD_LENGTH - BALL_RADIUS) {
-            if (z < ALLIANCE_WALL_HEIGHT) {
-                ball.pos =
-                        new Translation3d(
-                                FIELD_LENGTH - BALL_RADIUS, ball.pos.getY(), ball.pos.getZ());
-                if (ball.vel.getX() > 0) {
-                    applyWallSpinTransfer(ball, AXIS_X_NEG);
-                    double cor = effectiveCOR(COR_WALL, Math.abs(ball.vel.getX()));
-                    ball.vel =
-                            new Translation3d(
-                                    -ball.vel.getX() * cor, ball.vel.getY(), ball.vel.getZ());
-                }
-            }
-        }
-
-        // Y walls (guardrails: polycarbonate on aluminum extrusion, height-aware)
-        if (ball.pos.getY() < BALL_RADIUS) {
-            if (z < GUARDRAIL_HEIGHT) {
-                ball.pos = new Translation3d(ball.pos.getX(), BALL_RADIUS, ball.pos.getZ());
-                if (ball.vel.getY() < 0) {
-                    applyWallSpinTransfer(ball, AXIS_Y_POS);
-                    double cor = effectiveCOR(COR_WALL, Math.abs(ball.vel.getY()));
-                    ball.vel =
-                            new Translation3d(
-                                    ball.vel.getX(), -ball.vel.getY() * cor, ball.vel.getZ());
-                }
-            }
-        } else if (ball.pos.getY() > FIELD_WIDTH - BALL_RADIUS) {
-            if (z < GUARDRAIL_HEIGHT) {
-                ball.pos =
-                        new Translation3d(
-                                ball.pos.getX(), FIELD_WIDTH - BALL_RADIUS, ball.pos.getZ());
-                if (ball.vel.getY() > 0) {
-                    applyWallSpinTransfer(ball, AXIS_Y_NEG);
-                    double cor = effectiveCOR(COR_WALL, Math.abs(ball.vel.getY()));
-                    ball.vel =
-                            new Translation3d(
-                                    ball.vel.getX(), -ball.vel.getY() * cor, ball.vel.getZ());
-                }
-            }
-        }
-    }
-
-    private void handleGroundContact(SimBall ball, double subDt) {
-        if (ball.pos.getZ() < BALL_RADIUS) {
-            ball.pos = new Translation3d(ball.pos.getX(), ball.pos.getY(), BALL_RADIUS);
-
-            if (ball.vel.getZ() < 0) {
-                double cor = effectiveCOR(COR_CARPET, Math.abs(ball.vel.getZ()));
-
-                // If bounce would be very small, just zero out vertical velocity
-                if (Math.abs(ball.vel.getZ() * cor) < 0.05) {
-                    ball.vel = new Translation3d(ball.vel.getX(), ball.vel.getY(), 0);
-                } else {
-                    ball.vel =
-                            new Translation3d(
-                                    ball.vel.getX(), ball.vel.getY(), -ball.vel.getZ() * cor);
-                }
-            }
-
-            // Ground friction: uses surface velocity (vel + omega x r) so spin-on-contact works
-            if (config.frictionEnabled) {
-                double surfVelX = ball.vel.getX() - ball.omega.getY() * BALL_RADIUS;
-                double surfVelY = ball.vel.getY() + ball.omega.getX() * BALL_RADIUS;
-                double surfSpeed = Math.sqrt(surfVelX * surfVelX + surfVelY * surfVelY);
-                double hSpeed =
-                        Math.sqrt(
-                                ball.vel.getX() * ball.vel.getX()
-                                        + ball.vel.getY() * ball.vel.getY());
-
-                if (surfSpeed > 0.01) {
-                    // friction opposes surface velocity
-                    double fdx = -surfVelX / surfSpeed;
-                    double fdy = -surfVelY / surfSpeed;
-
-                    double maxImpulse = (2.0 / 7.0) * BALL_MASS * surfSpeed;
-                    double frictionImpulse =
-                            Math.min(MU_GROUND_KINETIC * BALL_MASS * GRAVITY * subDt, maxImpulse);
-
-                    // Friction changes both linear and angular velocity
-                    ball.vel =
-                            new Translation3d(
-                                    ball.vel.getX() + fdx * frictionImpulse / BALL_MASS,
-                                    ball.vel.getY() + fdy * frictionImpulse / BALL_MASS,
-                                    ball.vel.getZ());
-                    if (config.spinTransferEnabled) {
-                        // Torque
-                        ball.omega =
-                                new Translation3d(
-                                        ball.omega.getX()
-                                                + BALL_RADIUS
-                                                        * fdy
-                                                        * frictionImpulse
-                                                        / BALL_MOMENT_OF_INERTIA,
-                                        ball.omega.getY()
-                                                - BALL_RADIUS
-                                                        * fdx
-                                                        * frictionImpulse
-                                                        / BALL_MOMENT_OF_INERTIA,
-                                        ball.omega.getZ());
-                    }
-                } else if (hSpeed > 1e-4) {
-                    // Rolling resistance decelerates vel and omega together
-                    double decel = MU_GROUND_ROLLING * GRAVITY * subDt;
-                    double scale = Math.max(0, hSpeed - decel) / hSpeed;
-                    ball.vel =
-                            new Translation3d(
-                                    ball.vel.getX() * scale,
-                                    ball.vel.getY() * scale,
-                                    ball.vel.getZ());
-                    if (config.spinTransferEnabled) {
-                        ball.omega =
-                                new Translation3d(
-                                        ball.omega.getX() * scale,
-                                        ball.omega.getY() * scale,
-                                        ball.omega.getZ());
-                    }
-                }
-            }
-
-            // Settle near-zero vertical velocity when on ground
-            if (Math.abs(ball.vel.getZ()) < 0.05 && ball.pos.getZ() <= BALL_RADIUS + 0.01) {
-                ball.vel = new Translation3d(ball.vel.getX(), ball.vel.getY(), 0);
-            }
-        }
-    }
-
-    /** Handle collisions with the tent-shaped bump ramps. */
-    private void handleBumpCollisions(SimBall ball) {
-        for (BumpSegment seg : BUMP_SEGMENTS) {
-            if (ball.pos.getY() < seg.yStart() || ball.pos.getY() > seg.yEnd()) continue;
-
-            // Parametric projection onto line segment
-            double px = ball.pos.getX() - seg.xStart();
-            double pz = ball.pos.getZ() - seg.zStart();
-            double t = (px * seg.lineX() + pz * seg.lineZ()) / (seg.lineLen() * seg.lineLen());
-            if (t < 0 || t > 1) continue;
-
-            // Distance from ball center to nearest point on line (in XZ plane)
-            double nearX = seg.xStart() + t * seg.lineX();
-            double nearZ = seg.zStart() + t * seg.lineZ();
-            double dx = ball.pos.getX() - nearX;
-            double dz = ball.pos.getZ() - nearZ;
-            double dist = Math.sqrt(dx * dx + dz * dz);
-
-            if (dist < BALL_RADIUS) {
-                double nx = seg.nx(), nz = seg.nz();
-
-                // Push out
-                ball.pos =
-                        ball.pos.plus(
-                                new Translation3d(
-                                        nx * (BALL_RADIUS - dist), 0, nz * (BALL_RADIUS - dist)));
-
-                // Velocity reflection
-                double vDotN = ball.vel.getX() * nx + ball.vel.getZ() * nz;
-                if (vDotN < 0) {
-                    double cor = effectiveCOR(COR_HDPE, Math.abs(vDotN));
-                    ball.vel =
-                            ball.vel.minus(
-                                    new Translation3d(
-                                            nx * (1 + cor) * vDotN, 0, nz * (1 + cor) * vDotN));
-                }
-            }
-        }
+    // Broadphase: build spatial hash
+    buildSpatialHash();
+
+    // Generate contacts: ball-ball via spatial hash, ball-field via narrowphase
+    generateBallBallContacts();
+    generateBallFieldContacts();
+
+    // Sequential impulse solver
+    solveContacts();
+
+    // Simple wall/ground handling (direct impulse, not through solver)
+    for (int i = 0; i < balls.size(); i++) {
+      SimBall ball = balls.get(i);
+      if (ball.intaked || ball.outOfBounds) continue;
+      if (ball.sleeping && config.sleepingEnabled) continue;
+      handleWallBounce(ball);
+      handleGroundContact(ball, subDt);
+      handleBumpCollisions(ball);
     }
 
     // Hub scoring
-
-    private void handleHubScoring(SimBall ball) {
-        if (blueHub.didScore(ball)) {
-            ball.pos = blueHub.exit;
-            ball.vel = blueHub.getDispersalVelocity(rng);
-            ball.omega = new Translation3d();
-            blueHub.score++;
-            totalScored++;
-        } else if (redHub.didScore(ball)) {
-            ball.pos = redHub.exit;
-            ball.vel = redHub.getDispersalVelocity(rng);
-            ball.omega = new Translation3d();
-            redHub.score++;
-            totalScored++;
-        }
+    for (int i = 0; i < balls.size(); i++) {
+      SimBall ball = balls.get(i);
+      if (ball.intaked || ball.outOfBounds) continue;
+      handleHubScoring(ball);
     }
 
-    /** Hub net collision: catches overshots, but lets balls pass through from behind. */
-    private void handleNetCollision(SimBall ball, ScoringTarget hub) {
-        if (ball.pos.getZ() > NET_HEIGHT_MAX || ball.pos.getZ() < NET_HEIGHT_MIN) return;
-        if (ball.pos.getY() > hub.center.getY() + NET_WIDTH / 2.0
-                || ball.pos.getY() < hub.center.getY() - NET_WIDTH / 2.0) return;
-
-        double netX = hub.center.getX() + NET_OFFSET * hub.exitVelXSign;
-        double distToNet = ball.pos.getX() - netX;
-
-        if (Math.abs(distToNet) < BALL_RADIUS) {
-            // Only block balls moving toward the net
-            boolean movingTowardNet = ball.vel.getX() * hub.exitVelXSign > 0;
-            if (!movingTowardNet) return;
-
-            // Push ball out of net
-            double pushDir = distToNet >= 0 ? 1 : -1;
-            ball.pos =
-                    new Translation3d(
-                            netX + pushDir * BALL_RADIUS, ball.pos.getY(), ball.pos.getZ());
-            ball.vel =
-                    new Translation3d(
-                            -ball.vel.getX() * COR_NET, ball.vel.getY() * COR_NET, ball.vel.getZ());
-        }
+    // Net collisions
+    for (int i = 0; i < balls.size(); i++) {
+      SimBall ball = balls.get(i);
+      if (ball.intaked || ball.outOfBounds) continue;
+      if (ball.sleeping && config.sleepingEnabled) continue;
+      handleNetCollision(ball, blueHub);
+      handleNetCollision(ball, redHub);
     }
 
-    private void handleRobotCollision(SimBall ball, Pose2d robotPose, Translation2d robotVel) {
-        if (ball.pos.getZ() > bumperHeight) return;
+    // Robot interaction
+    if (robotPoseSupplier != null && robotSpeedsSupplier != null) {
+      Pose2d robotPose = robotPoseSupplier.get();
+      ChassisSpeeds speeds = robotSpeedsSupplier.get();
+      Translation2d robotVel =
+          new Translation2d(speeds.vxMetersPerSecond, speeds.vyMetersPerSecond);
 
-        Translation2d relPos =
-                new Pose2d(ball.pos.toTranslation2d(), Rotation2d.kZero)
-                        .relativeTo(robotPose)
-                        .getTranslation();
+      // Wake radius: robot half-diagonal plus margin so balls react before contact
+      double wakeRadius = Math.hypot(robotLength, robotWidth) / 2.0 + 0.3;
+      double wakeRadiusSq = wakeRadius * wakeRadius;
 
-        double halfL = robotLength / 2.0 + BALL_RADIUS;
-        double halfW = robotWidth / 2.0 + BALL_RADIUS;
-
-        if (relPos.getX() < -halfL
-                || relPos.getX() > halfL
-                || relPos.getY() < -halfW
-                || relPos.getY() > halfW) {
-            return;
+      for (int i = 0; i < balls.size(); i++) {
+        SimBall ball = balls.get(i);
+        if (ball.intaked || ball.outOfBounds) continue;
+        // Wake sleeping balls near the robot so bumpers push them
+        if (ball.sleeping && config.sleepingEnabled) {
+          double dx = ball.pos.getX() - robotPose.getX();
+          double dy = ball.pos.getY() - robotPose.getY();
+          if (dx * dx + dy * dy < wakeRadiusSq) {
+            wakeBall(ball);
+          } else {
+            continue;
+          }
         }
-
-        // Find nearest face and push out
-        double dxMin = relPos.getX() + halfL;
-        double dxMax = halfL - relPos.getX();
-        double dyMin = relPos.getY() + halfW;
-        double dyMax = halfW - relPos.getY();
-
-        double minDist = dxMin;
-        Translation2d pushDir = new Translation2d(-1, 0);
-
-        if (dxMax < minDist) {
-            minDist = dxMax;
-            pushDir = new Translation2d(1, 0);
-        }
-        if (dyMin < minDist) {
-            minDist = dyMin;
-            pushDir = new Translation2d(0, -1);
-        }
-        if (dyMax < minDist) {
-            minDist = dyMax;
-            pushDir = new Translation2d(0, 1);
-        }
-
-        // Rotate push direction back to field frame
-        pushDir = pushDir.rotateBy(robotPose.getRotation());
-        ball.pos = ball.pos.plus(new Translation3d(pushDir.times(minDist)));
-
-        // Velocity reflection
-        Translation3d normal3d = new Translation3d(pushDir.getX(), pushDir.getY(), 0);
-        double vDotN = ball.vel.toTranslation2d().dot(pushDir);
-        double robotVDotN = robotVel.dot(pushDir);
-        double closingVel = vDotN - robotVDotN;
-
-        if (closingVel < 0) {
-            ball.vel = ball.vel.minus(normal3d.times((1 + COR_BUMPER) * closingVel));
-        }
+        // Intake first so balls are consumed before bumper pushes them away
+        handleIntakePickup(ball, robotPose);
+        if (ball.intaked) continue;
+        handleRobotCollision(ball, robotPose, robotVel);
+      }
     }
 
-    private void handleIntakePickup(SimBall ball, Pose2d robotPose) {
-        for (IntakeZone intake : intakes) {
-            if (intake.shouldIntake(ball, robotPose, bumperHeight)) {
-                ball.intaked = true;
-                totalIntaked++;
-                return;
-            }
-        }
+    // Sleep update
+    if (config.sleepingEnabled) {
+      for (int i = 0; i < balls.size(); i++) {
+        updateSleepState(balls.get(i));
+      }
     }
 
-    // Sleeping
-
-    private void updateSleepState(SimBall ball) {
-        double speed = ball.vel.getNorm();
-        double omegaMag = ball.omega.getNorm();
-
-        if (speed < config.sleepVelocityThreshold
-                && omegaMag < 0.1
-                && ball.pos.getZ() <= BALL_RADIUS + 0.01) {
-            ball.sleepCounter++;
-            if (ball.sleepCounter >= config.sleepFrameThreshold) {
-                ball.sleeping = true;
-                ball.vel = new Translation3d();
-                ball.omega = new Translation3d();
-            }
-        } else {
-            ball.sleepCounter = 0;
-            ball.sleeping = false;
+    // Out-of-bounds cleanup (includes NaN guard, upper Z limit, and stuck-on-obstacle removal)
+    for (int i = 0; i < balls.size(); i++) {
+      SimBall ball = balls.get(i);
+      if (!Double.isFinite(ball.pos.getX())
+          || !Double.isFinite(ball.pos.getY())
+          || !Double.isFinite(ball.pos.getZ())
+          || !Double.isFinite(ball.vel.getX())
+          || !Double.isFinite(ball.vel.getY())
+          || !Double.isFinite(ball.vel.getZ())
+          || !Double.isFinite(ball.omega.getX())
+          || !Double.isFinite(ball.omega.getY())
+          || !Double.isFinite(ball.omega.getZ())
+          || ball.pos.getX() < -2.0
+          || ball.pos.getX() > FIELD_LENGTH + 2.0
+          || ball.pos.getY() < -2.0
+          || ball.pos.getY() > FIELD_WIDTH + 2.0
+          || ball.pos.getZ() < -1.0
+          || ball.pos.getZ() > 15.0) {
+        ball.outOfBounds = true;
+      }
+      // Remove balls stuck on elevated obstacles
+      if (ball.pos.getZ() > BALL_RADIUS + 0.3 && ball.vel.getNorm() < 0.5) {
+        ball.elevatedSlowCounter++;
+        if (ball.elevatedSlowCounter > 250) {
+          ball.outOfBounds = true;
         }
-    }
-
-    private void wakeBall(SimBall ball) {
-        ball.sleeping = false;
-        ball.sleepCounter = 0;
-    }
-
-    /** Wake up sleeping balls near a point (so launched balls disturb resting ones). */
-    private void wakeNearbyBalls(Translation3d pos, double radius) {
-        double radiusSq = radius * radius;
-        for (SimBall ball : balls) {
-            if (ball.sleeping) {
-                double dx = ball.pos.getX() - pos.getX();
-                double dy = ball.pos.getY() - pos.getY();
-                double dz = ball.pos.getZ() - pos.getZ();
-                if (dx * dx + dy * dy + dz * dz < radiusSq) {
-                    wakeBall(ball);
-                }
-            }
-        }
+      } else {
+        ball.elevatedSlowCounter = 0;
+      }
     }
 
     // Conservation monitor
+    if (config.conservationMonitor) {
+      computeConservationQuantities();
+    }
+  }
 
-    private void computeConservationQuantities() {
-        totalKE = 0;
-        totalPE = 0;
-        double mx = 0, my = 0, mz = 0;
+  /** Compute acceleration: gravity + drag + Magnus lift. Magnus only kicks in when airborne. */
+  private Translation3d computeAcceleration(SimBall ball) {
+    // Gravity always acts
+    double ax = 0, ay = 0, az = -GRAVITY;
 
-        for (SimBall ball : balls) {
-            double speed = ball.vel.getNorm();
-            totalKE += 0.5 * BALL_MASS * speed * speed;
+    double speed = ball.vel.getNorm();
+    boolean airborne = ball.pos.getZ() > BALL_RADIUS + 0.01;
 
-            // Rotational KE
-            double omegaMag = ball.omega.getNorm();
-            totalKE += 0.5 * BALL_MOMENT_OF_INERTIA * omegaMag * omegaMag;
+    // Drag acts whether on ground or airborne (air doesn't vanish at carpet level)
+    if (config.dragEnabled && speed > 1e-6) {
+      ax -= DRAG_ACCEL_FACTOR * speed * ball.vel.getX();
+      ay -= DRAG_ACCEL_FACTOR * speed * ball.vel.getY();
+      az -= DRAG_ACCEL_FACTOR * speed * ball.vel.getZ();
+    }
 
-            // Gravitational PE (relative to ground)
-            totalPE += BALL_MASS * GRAVITY * ball.pos.getZ();
-
-            // Linear momentum
-            mx += BALL_MASS * ball.vel.getX();
-            my += BALL_MASS * ball.vel.getY();
-            mz += BALL_MASS * ball.vel.getZ();
+    // Magnus only applies airborne (ground friction dominates spin behavior on carpet)
+    if (airborne && speed > 1e-6) {
+      if (config.magnusEnabled && ball.omega.getNorm() > 1e-3) {
+        Translation3d magnusDir = cross(ball.omega, ball.vel);
+        double magnusMag = magnusDir.getNorm();
+        if (magnusMag > 1e-6) {
+          // a_magnus = MAGNUS_ACCEL_FACTOR * (omega x v)
+          ax += MAGNUS_ACCEL_FACTOR * magnusDir.getX();
+          ay += MAGNUS_ACCEL_FACTOR * magnusDir.getY();
+          az += MAGNUS_ACCEL_FACTOR * magnusDir.getZ();
         }
-
-        totalMomentum = new Translation3d(mx, my, mz);
+      }
     }
 
-    /** 3D cross product. Using Translation3d directly to avoid WPILib Vector conversion. */
-    private static Translation3d cross(Translation3d a, Translation3d b) {
-        return new Translation3d(
-                a.getY() * b.getZ() - a.getZ() * b.getY(),
-                a.getZ() * b.getX() - a.getX() * b.getZ(),
-                a.getX() * b.getY() - a.getY() * b.getX());
+    return new Translation3d(ax, ay, az);
+  }
+
+  /** Continuous collision detection: sweep fast balls so they don't tunnel through walls. */
+  private void handleCCD(SimBall ball) {
+    Translation3d delta = ball.pos.minus(ball.prevPos);
+    double dist = delta.getNorm();
+    if (dist < 1e-6) return;
+
+    Translation3d dir = delta.div(dist);
+
+    // Check against field boundaries
+    double tMin = 1.0;
+    Translation3d hitNormal = null;
+
+    // X walls
+    if (dir.getX() < -1e-6) {
+      double t = (BALL_RADIUS - ball.prevPos.getX()) / (delta.getX());
+      if (t > 0 && t < tMin) {
+        tMin = t;
+        hitNormal = AXIS_X_POS;
+      }
+    } else if (dir.getX() > 1e-6) {
+      double t = (FIELD_LENGTH - BALL_RADIUS - ball.prevPos.getX()) / (delta.getX());
+      if (t > 0 && t < tMin) {
+        tMin = t;
+        hitNormal = AXIS_X_NEG;
+      }
     }
 
-    /** COR drops at higher impact speeds (balls deform more and lose more energy). */
-    private double velocityCOR(double e0, double impactSpeed) {
-        if (!config.velocityDependentCOR) return e0;
-        if (impactSpeed <= COR_VREF) return e0;
-        return e0 * Math.pow(COR_VREF / impactSpeed, COR_EXPONENT);
+    // Y walls
+    if (dir.getY() < -1e-6) {
+      double t = (BALL_RADIUS - ball.prevPos.getY()) / (delta.getY());
+      if (t > 0 && t < tMin) {
+        tMin = t;
+        hitNormal = AXIS_Y_POS;
+      }
+    } else if (dir.getY() > 1e-6) {
+      double t = (FIELD_WIDTH - BALL_RADIUS - ball.prevPos.getY()) / (delta.getY());
+      if (t > 0 && t < tMin) {
+        tMin = t;
+        hitNormal = AXIS_Y_NEG;
+      }
     }
 
-    /** Get the COR to use, with optional velocity-dependent scaling. */
-    private double effectiveCOR(double baseCOR, double impactSpeed) {
-        if (config.velocityDependentCOR) {
-            return velocityCOR(baseCOR, impactSpeed);
+    // Ground
+    if (dir.getZ() < -1e-6) {
+      double t = (BALL_RADIUS - ball.prevPos.getZ()) / (delta.getZ());
+      if (t > 0 && t < tMin) {
+        tMin = t;
+        hitNormal = AXIS_Z_POS;
+      }
+    }
+
+    // AABB obstacles (ray-box intersection)
+    for (AABB aabb : AABB_OBSTACLES) {
+      double tHit = sweepSphereAABB(ball.prevPos, delta, aabb);
+      if (tHit >= 0 && tHit < tMin) {
+        // Compute normal at hit point
+        Translation3d hitPos = ball.prevPos.plus(delta.times(tHit));
+        Translation3d n = computeAABBNormal(hitPos, aabb);
+        if (n != null) {
+          tMin = tHit;
+          hitNormal = n;
         }
-        return baseCOR;
+      }
     }
 
-    /** When a ball hits a wall, friction changes its spin. This handles that. */
-    private void applyWallSpinTransfer(SimBall ball, Translation3d wallNormal) {
-        if (!config.spinTransferEnabled || !config.frictionEnabled) return;
+    if (hitNormal != null && tMin < 1.0) {
+      // Move ball to contact point
+      ball.pos = ball.prevPos.plus(delta.times(tMin));
 
-        // Compute tangential velocity at contact point
-        Translation3d rContact = wallNormal.times(-BALL_RADIUS);
-        Translation3d surfaceVel = ball.vel.plus(cross(ball.omega, rContact));
+      // Reflect velocity
+      double vDotN = ball.vel.dot(hitNormal);
+      if (vDotN < 0) {
+        double cor = config.velocityDependentCOR ? velocityCOR(COR_WALL, -vDotN) : COR_WALL;
+        ball.vel = ball.vel.minus(hitNormal.times((1.0 + cor) * vDotN));
+      }
+    }
+  }
 
-        // Remove normal component
-        double vn = surfaceVel.dot(wallNormal);
-        Translation3d vTangent = surfaceVel.minus(wallNormal.times(vn));
-        double vTangentMag = vTangent.getNorm();
+  /**
+   * Ray-AABB intersection with sphere expansion (Minkowski sum). Returns hit time in [0,1] or -1.
+   */
+  private double sweepSphereAABB(Translation3d origin, Translation3d delta, AABB aabb) {
+    // Expand AABB by ball radius (Minkowski sum with sphere)
+    double minX = aabb.minX() - BALL_RADIUS;
+    double minY = aabb.minY() - BALL_RADIUS;
+    double minZ = aabb.minZ() - BALL_RADIUS;
+    double maxX = aabb.maxX() + BALL_RADIUS;
+    double maxY = aabb.maxY() + BALL_RADIUS;
+    double maxZ = aabb.maxZ() + BALL_RADIUS;
 
-        if (vTangentMag > 1e-4) {
-            // Total normal impulse includes restitution: j_n = m * |v_n| * (1 + e)
-            double impactSpeed = Math.abs(ball.vel.dot(wallNormal));
-            double cor = effectiveCOR(COR_WALL, impactSpeed);
-            double normalImpulse = BALL_MASS * impactSpeed * (1.0 + cor);
-            double frictionImpulse = Math.min(MU_WALL * normalImpulse, BALL_MASS * vTangentMag);
-            Translation3d frictionDir = vTangent.div(vTangentMag).unaryMinus();
+    double tEnter = 0;
+    double tExit = 1;
 
-            // Friction affects both linear velocity and spin (Newton's 3rd law)
-            ball.vel = ball.vel.plus(frictionDir.times(frictionImpulse / BALL_MASS));
-            Translation3d torqueImpulse = cross(rContact, frictionDir.times(frictionImpulse));
-            ball.omega = ball.omega.plus(torqueImpulse.div(BALL_MOMENT_OF_INERTIA));
-        }
+    // X slab
+    if (Math.abs(delta.getX()) > 1e-9) {
+      double invD = 1.0 / delta.getX();
+      double t1 = (minX - origin.getX()) * invD;
+      double t2 = (maxX - origin.getX()) * invD;
+      if (t1 > t2) {
+        double tmp = t1;
+        t1 = t2;
+        t2 = tmp;
+      }
+      tEnter = Math.max(tEnter, t1);
+      tExit = Math.min(tExit, t2);
+    } else {
+      if (origin.getX() < minX || origin.getX() > maxX) return -1;
     }
 
-    /** Grab a contact from the pool (grows the pool if we run out). */
-    private Contact allocateContact() {
-        if (contactPoolIndex >= contactPool.size()) {
-            Contact c = new Contact();
-            contactPool.add(c);
-            contactPoolIndex++;
-            return c;
-        }
-        return contactPool.get(contactPoolIndex++);
+    // Y slab
+    if (Math.abs(delta.getY()) > 1e-9) {
+      double invD = 1.0 / delta.getY();
+      double t1 = (minY - origin.getY()) * invD;
+      double t2 = (maxY - origin.getY()) * invD;
+      if (t1 > t2) {
+        double tmp = t1;
+        t1 = t2;
+        t2 = tmp;
+      }
+      tEnter = Math.max(tEnter, t1);
+      tExit = Math.min(tExit, t2);
+    } else {
+      if (origin.getY() < minY || origin.getY() > maxY) return -1;
     }
 
-    /** Clean up balls that got eaten by intakes or flew out of bounds. */
-    private void removeFlaggedBalls() {
-        balls.removeIf(b -> b.intaked || b.outOfBounds);
+    // Z slab
+    if (Math.abs(delta.getZ()) > 1e-9) {
+      double invD = 1.0 / delta.getZ();
+      double t1 = (minZ - origin.getZ()) * invD;
+      double t2 = (maxZ - origin.getZ()) * invD;
+      if (t1 > t2) {
+        double tmp = t1;
+        t1 = t2;
+        t2 = tmp;
+      }
+      tEnter = Math.max(tEnter, t1);
+      tExit = Math.min(tExit, t2);
+    } else {
+      if (origin.getZ() < minZ || origin.getZ() > maxZ) return -1;
     }
 
-    // Trajectory prediction
+    if (tEnter > tExit || tExit < 0) return -1;
+    return tEnter > 0 ? tEnter : -1; // Already inside if tEnter <= 0
+  }
 
-    /**
-     * Predict where a shot will go (gravity + drag only, no collisions). Returns points you can
-     * plot in AdvantageScope Field3d. Stops at the ground.
-     */
-    private Translation3d[] predictArc(Translation3d pos, Translation3d vel, int steps, double dt) {
-        List<Translation3d> arc = new ArrayList<>();
-        arc.add(pos);
-        double px = pos.getX(), py = pos.getY(), pz = pos.getZ();
-        double vx = vel.getX(), vy = vel.getY(), vz = vel.getZ();
-        for (int i = 0; i < steps; i++) {
-            double speed = Math.sqrt(vx * vx + vy * vy + vz * vz);
-            double drag = config.dragEnabled && speed > 1e-6 ? DRAG_ACCEL_FACTOR * speed : 0;
-            vx -= drag * vx * dt;
-            vy -= drag * vy * dt;
-            vz -= (GRAVITY + drag * vz) * dt;
-            px += vx * dt;
-            py += vy * dt;
-            pz += vz * dt;
-            if (pz < BALL_RADIUS) break;
-            arc.add(new Translation3d(px, py, pz));
-        }
-        return arc.toArray(new Translation3d[0]);
+  // Broadphase (spatial hash)
+
+  private void buildSpatialHash() {
+    for (int i = 0; i < GRID_COLS; i++) {
+      for (int j = 0; j < GRID_ROWS; j++) {
+        grid[i][j].clear();
+      }
     }
+    // Include sleeping balls so awake balls can detect them for wake-on-collision
+    for (int i = 0; i < balls.size(); i++) {
+      SimBall ball = balls.get(i);
+      if (ball.intaked || ball.outOfBounds) continue;
+      int col = (int) (ball.pos.getX() / CELL_SIZE);
+      int row = (int) (ball.pos.getY() / CELL_SIZE);
+      if (col >= 0 && col < GRID_COLS && row >= 0 && row < GRID_ROWS) {
+        grid[col][row].add(i);
+      }
+    }
+  }
 
-    /** Push ball positions and sim stats to NetworkTables for visualization. */
-    public void publishPositions() {
-        // All ball positions (for Field3d rendering)
-        Translation3d[] positions = new Translation3d[balls.size()];
-        for (int i = 0; i < balls.size(); i++) {
-            positions[i] = balls.get(i).pos;
-        }
-        positionPublisher.set(positions);
+  // Narrowphase contact generation
 
-        // In-flight positions only (airborne balls, can render separately in Field3d)
-        List<Translation3d> inFlight = new ArrayList<>();
-        int sleeping = 0;
-        for (SimBall b : balls) {
-            if (b.intaked || b.outOfBounds) continue;
-            if (b.pos.getZ() > BALL_RADIUS + 0.1) {
-                inFlight.add(b.pos);
+  private void generateBallBallContacts() {
+    for (int i = 0; i < balls.size(); i++) {
+      SimBall ballA = balls.get(i);
+      if (ballA.intaked || ballA.outOfBounds) continue;
+      if (ballA.sleeping && config.sleepingEnabled) continue;
+
+      int col = (int) (ballA.pos.getX() / CELL_SIZE);
+      int row = (int) (ballA.pos.getY() / CELL_SIZE);
+
+      for (int di = -1; di <= 1; di++) {
+        for (int dj = -1; dj <= 1; dj++) {
+          int ci = col + di;
+          int cj = row + dj;
+          if (ci < 0 || ci >= GRID_COLS || cj < 0 || cj >= GRID_ROWS) continue;
+          List<Integer> cell = grid[ci][cj];
+          for (int k = 0; k < cell.size(); k++) {
+            int j = cell.get(k);
+            if (j == i) continue; // same ball
+            if (j < i && !(config.sleepingEnabled && balls.get(j).sleeping)) continue;
+
+            SimBall ballB = balls.get(j);
+            double dx = ballA.pos.getX() - ballB.pos.getX();
+            double dy = ballA.pos.getY() - ballB.pos.getY();
+            double dz = ballA.pos.getZ() - ballB.pos.getZ();
+            double distSq = dx * dx + dy * dy + dz * dz;
+            double minDist = BALL_RADIUS * 2;
+
+            if (distSq < minDist * minDist) {
+              double dist = Math.sqrt(distSq);
+              Contact c = allocateContact();
+              if (dist < 1e-9) {
+                c.normal = AXIS_X_POS;
+                dist = 1e-9;
+              } else {
+                c.normal = ballA.pos.minus(ballB.pos).div(dist);
+              }
+              c.ballIndexA = i;
+              c.ballIndexB = j;
+              c.penetration = minDist - dist;
+              c.contactPoint = ballA.pos.plus(ballB.pos).div(2.0); // midpoint between centers
+              c.restitution = COR_BALL_BALL;
+              c.friction = config.frictionEnabled ? MU_BALL_BALL : 0;
+              c.normalImpulseAccum = 0;
+              c.tangentImpulseAccum = 0;
+              contacts.add(c);
+
+              // Wake sleeping ball on contact
+              if (ballB.sleeping) {
+                wakeBall(ballB);
+              }
             }
-            if (b.sleeping) sleeping++;
+          }
         }
-        inFlightPublisher.set(inFlight.toArray(new Translation3d[0]));
+      }
+    }
+  }
 
-        // Last shot arc (predicted trajectory visible in Field3d)
-        lastShotArcPublisher.set(lastShotArc);
+  private void generateBallFieldContacts() {
+    for (int i = 0; i < balls.size(); i++) {
+      SimBall ball = balls.get(i);
+      if (ball.intaked || ball.outOfBounds) continue;
+      if (ball.sleeping && config.sleepingEnabled) continue;
 
-        // Scoring
-        blueScorePub.set(blueHub.score);
-        redScorePub.set(redHub.score);
+      // AABB obstacles
+      for (AABB aabb : AABB_OBSTACLES) {
+        generateSphereAABBContact(i, ball, aabb);
+      }
 
-        // Stats
-        ballCountPub.set(balls.size());
-        activeBallsPub.set(balls.size() - sleeping);
-        sleepingBallsPub.set(sleeping);
-        contactCountPub.set(contacts.size());
-        physicsTimePub.set(lastPhysicsNanos / 1_000_000.0);
-        computeConservationQuantities();
-        totalEnergyPub.set(totalKE + totalPE);
+      // Cylinder obstacles
+      for (CylinderObstacle cyl : CYLINDER_OBSTACLES) {
+        generateSphereCylinderContact(i, ball, cyl);
+      }
+    }
+  }
+
+  private void generateSphereAABBContact(int ballIndex, SimBall ball, AABB aabb) {
+    // Find nearest point on AABB to sphere center
+    double cx = Math.max(aabb.minX(), Math.min(ball.pos.getX(), aabb.maxX()));
+    double cy = Math.max(aabb.minY(), Math.min(ball.pos.getY(), aabb.maxY()));
+    double cz = Math.max(aabb.minZ(), Math.min(ball.pos.getZ(), aabb.maxZ()));
+
+    double dx = ball.pos.getX() - cx;
+    double dy = ball.pos.getY() - cy;
+    double dz = ball.pos.getZ() - cz;
+    double distSq = dx * dx + dy * dy + dz * dz;
+
+    if (distSq < BALL_RADIUS * BALL_RADIUS && distSq >= 1e-9) {
+      double dist = Math.sqrt(distSq);
+      Contact c = allocateContact();
+      c.ballIndexA = ballIndex;
+      c.ballIndexB = -1;
+      c.normal = new Translation3d(dx / dist, dy / dist, dz / dist);
+      c.penetration = BALL_RADIUS - dist;
+      c.contactPoint = new Translation3d(cx, cy, cz);
+      c.restitution = aabb.cor();
+      c.friction = config.frictionEnabled ? MU_WALL : 0;
+      c.normalImpulseAccum = 0;
+      c.tangentImpulseAccum = 0;
+      contacts.add(c);
+    } else if (distSq < 1e-9) {
+      // Ball center is inside AABB.
+      Translation3d normal = computeEntryFaceNormal(ball.prevPos, ball.pos, aabb);
+      if (normal != null) {
+        double pen = computeAABBPenetration(ball.pos, aabb);
+        Contact c = allocateContact();
+        c.ballIndexA = ballIndex;
+        c.ballIndexB = -1;
+        c.normal = normal;
+        c.penetration = pen + BALL_RADIUS;
+        c.contactPoint = ball.pos;
+        c.restitution = aabb.cor();
+        c.friction = config.frictionEnabled ? MU_WALL : 0;
+        c.normalImpulseAccum = 0;
+        c.tangentImpulseAccum = 0;
+        contacts.add(c);
+      }
+    }
+  }
+
+  /** Which face of the AABB is the point closest to? Returns outward normal of that face. */
+  private Translation3d computeAABBNormal(Translation3d p, AABB aabb) {
+    double dxMin = p.getX() - aabb.minX();
+    double dxMax = aabb.maxX() - p.getX();
+    double dyMin = p.getY() - aabb.minY();
+    double dyMax = aabb.maxY() - p.getY();
+    double dzMin = p.getZ() - aabb.minZ();
+    double dzMax = aabb.maxZ() - p.getZ();
+
+    double min = dxMin;
+    Translation3d normal = AXIS_X_NEG;
+
+    if (dxMax < min) {
+      min = dxMax;
+      normal = AXIS_X_POS;
+    }
+    if (dyMin < min) {
+      min = dyMin;
+      normal = AXIS_Y_NEG;
+    }
+    if (dyMax < min) {
+      min = dyMax;
+      normal = AXIS_Y_POS;
+    }
+    if (dzMin < min) {
+      min = dzMin;
+      normal = AXIS_Z_NEG;
+    }
+    if (dzMax < min) {
+      min = dzMax;
+      normal = AXIS_Z_POS;
+    }
+    return normal;
+  }
+
+  /** How deep is a point inside an AABB? Returns min distance to any face. */
+  private double computeAABBPenetration(Translation3d p, AABB aabb) {
+    double dxMin = p.getX() - aabb.minX();
+    double dxMax = aabb.maxX() - p.getX();
+    double dyMin = p.getY() - aabb.minY();
+    double dyMax = aabb.maxY() - p.getY();
+    double dzMin = p.getZ() - aabb.minZ();
+    double dzMax = aabb.maxZ() - p.getZ();
+    return Math.min(
+        Math.min(Math.min(dxMin, dxMax), Math.min(dyMin, dyMax)), Math.min(dzMin, dzMax));
+  }
+
+  /**
+   * If a ball is inside an AABB, figure out which face it came in through by raycasting from
+   * prevPos to pos. Without this, balls pop onto the top of obstacles when they actually entered
+   * from the side. Falls back to nearest-face if the ray is degenerate (ball spawned inside).
+   */
+  private Translation3d computeEntryFaceNormal(Translation3d from, Translation3d to, AABB aabb) {
+    if (from == null) return computeAABBNormal(to, aabb);
+
+    double dx = to.getX() - from.getX();
+    double dy = to.getY() - from.getY();
+    double dz = to.getZ() - from.getZ();
+
+    // Slab intersection: the entry face is the axis with the latest entry time
+    double tMax = Double.NEGATIVE_INFINITY;
+    Translation3d bestNormal = null;
+
+    if (Math.abs(dx) > 1e-12) {
+      double invD = 1.0 / dx;
+      double t1 = (aabb.minX() - from.getX()) * invD;
+      double t2 = (aabb.maxX() - from.getX()) * invD;
+      double tEntry = Math.min(t1, t2);
+      if (tEntry > tMax) {
+        tMax = tEntry;
+        bestNormal = dx > 0 ? AXIS_X_NEG : AXIS_X_POS;
+      }
+    }
+    if (Math.abs(dy) > 1e-12) {
+      double invD = 1.0 / dy;
+      double t1 = (aabb.minY() - from.getY()) * invD;
+      double t2 = (aabb.maxY() - from.getY()) * invD;
+      double tEntry = Math.min(t1, t2);
+      if (tEntry > tMax) {
+        tMax = tEntry;
+        bestNormal = dy > 0 ? AXIS_Y_NEG : AXIS_Y_POS;
+      }
+    }
+    if (Math.abs(dz) > 1e-12) {
+      double invD = 1.0 / dz;
+      double t1 = (aabb.minZ() - from.getZ()) * invD;
+      double t2 = (aabb.maxZ() - from.getZ()) * invD;
+      double tEntry = Math.min(t1, t2);
+      if (tEntry > tMax) {
+        tMax = tEntry;
+        bestNormal = dz > 0 ? AXIS_Z_NEG : AXIS_Z_POS;
+      }
     }
 
-    public int getBallCount() {
-        return balls.size();
+    return bestNormal != null ? bestNormal : computeAABBNormal(to, aabb);
+  }
+
+  private void generateSphereCylinderContact(int ballIndex, SimBall ball, CylinderObstacle cyl) {
+    if (cyl.abLenSq() < 1e-12) return;
+
+    // Find nearest point on line segment to ball center
+
+    double apx = ball.pos.getX() - cyl.ax();
+    double apy = ball.pos.getY() - cyl.ay();
+    double apz = ball.pos.getZ() - cyl.az();
+    double t =
+        Math.max(
+            0, Math.min(1, (apx * cyl.abx() + apy * cyl.aby() + apz * cyl.abz()) / cyl.abLenSq()));
+
+    double nearX = cyl.ax() + t * cyl.abx();
+    double nearY = cyl.ay() + t * cyl.aby();
+    double nearZ = cyl.az() + t * cyl.abz();
+
+    double dx = ball.pos.getX() - nearX;
+    double dy = ball.pos.getY() - nearY;
+    double dz = ball.pos.getZ() - nearZ;
+    double distSq = dx * dx + dy * dy + dz * dz;
+    double minDist = BALL_RADIUS + cyl.radius();
+
+    if (distSq < minDist * minDist && distSq > 0) {
+      double dist = Math.sqrt(distSq);
+      Contact c = allocateContact();
+      c.ballIndexA = ballIndex;
+      c.ballIndexB = -1;
+      c.normal = new Translation3d(dx / dist, dy / dist, dz / dist);
+      c.penetration = minDist - dist;
+      c.contactPoint = new Translation3d(nearX, nearY, nearZ);
+      c.restitution = cyl.cor();
+      c.friction = config.frictionEnabled ? MU_WALL : 0;
+      c.normalImpulseAccum = 0;
+      c.tangentImpulseAccum = 0;
+      contacts.add(c);
+    }
+  }
+
+  /**
+   * Sequential impulse solver: resolve bounces, friction, and spin transfer across all contacts.
+   */
+  private void solveContacts() {
+    if (contacts.isEmpty()) return;
+
+    // Compute restitution targets from initial approach velocities (before any solving)
+    for (int i = 0; i < contacts.size(); i++) {
+      Contact c = contacts.get(i);
+      SimBall ballA = balls.get(c.ballIndexA);
+      Translation3d relVel;
+      if (c.ballIndexB >= 0) {
+        relVel = ballA.vel.minus(balls.get(c.ballIndexB).vel);
+      } else {
+        relVel = ballA.vel;
+      }
+      double vn = relVel.dot(c.normal);
+      double e = c.restitution;
+      if (config.velocityDependentCOR) {
+        e = velocityCOR(e, Math.abs(vn));
+      }
+      // Only bounce for significant approach speeds.
+      c.restitutionVelocity = vn < -0.5 ? -e * vn : 0;
     }
 
-    // Only counts balls above ground level + small margin
-    public int getBallsInFlight() {
-        int count = 0;
-        for (SimBall ball : balls) {
-            if (ball.pos.getZ() > BALL_RADIUS + 0.1) count++;
+    for (int iter = 0; iter < config.solverIterations; iter++) {
+      for (int i = 0; i < contacts.size(); i++) {
+        Contact c = contacts.get(i);
+        solveContact(c);
+      }
+    }
+
+    // Position correction
+    for (int i = 0; i < contacts.size(); i++) {
+      applyPositionCorrection(contacts.get(i));
+    }
+  }
+
+  private void solveContact(Contact c) {
+    SimBall ballA = balls.get(c.ballIndexA);
+    Translation3d relVel;
+    double invMassSum;
+
+    if (c.ballIndexB >= 0) {
+      // Ball-ball contact
+      SimBall ballB = balls.get(c.ballIndexB);
+      relVel = ballA.vel.minus(ballB.vel);
+      invMassSum = 2.0 / BALL_MASS; // both balls have same mass
+    } else {
+      // Ball-field contact
+      relVel = ballA.vel;
+      invMassSum = 1.0 / BALL_MASS;
+    }
+
+    double vRelNormal = relVel.dot(c.normal);
+    double jn = -(vRelNormal - c.restitutionVelocity) / invMassSum;
+    double oldAccum = c.normalImpulseAccum;
+    c.normalImpulseAccum = Math.max(0, oldAccum + jn);
+    jn = c.normalImpulseAccum - oldAccum;
+
+    // Apply normal impulse
+    Translation3d normalImpulse = c.normal.times(jn);
+    ballA.vel = ballA.vel.plus(normalImpulse.div(BALL_MASS));
+    if (c.ballIndexB >= 0) {
+      SimBall ballB = balls.get(c.ballIndexB);
+      ballB.vel = ballB.vel.minus(normalImpulse.div(BALL_MASS));
+    }
+
+    // Tangential impulse (friction)
+    if (c.friction > 0 && config.frictionEnabled) {
+      // Recompute relative velocity after normal impulse
+      if (c.ballIndexB >= 0) {
+        relVel = ballA.vel.minus(balls.get(c.ballIndexB).vel);
+      } else {
+        relVel = ballA.vel;
+      }
+
+      // Tangent velocity: remove normal component
+      double vn = relVel.dot(c.normal);
+      Translation3d vTangent = relVel.minus(c.normal.times(vn));
+      double vTangentMag = vTangent.getNorm();
+
+      if (vTangentMag > 1e-6) {
+        Translation3d tangentDir = vTangent.div(vTangentMag);
+
+        // Friction impulse magnitude
+        double jt = -vTangentMag / invMassSum;
+
+        // Coulomb clamp: |j_t| <= mu * j_n
+        double maxFriction = c.friction * c.normalImpulseAccum;
+        double oldTangentAccum = c.tangentImpulseAccum;
+        c.tangentImpulseAccum = Math.max(-maxFriction, Math.min(maxFriction, oldTangentAccum + jt));
+        jt = c.tangentImpulseAccum - oldTangentAccum;
+
+        // Apply tangent impulse
+        Translation3d frictionImpulse = tangentDir.times(jt);
+        ballA.vel = ballA.vel.plus(frictionImpulse.div(BALL_MASS));
+        if (c.ballIndexB >= 0) {
+          SimBall ballB = balls.get(c.ballIndexB);
+          ballB.vel = ballB.vel.minus(frictionImpulse.div(BALL_MASS));
         }
-        return count;
-    }
 
-    public int getBallsOnGround() {
-        int count = 0;
-        for (SimBall ball : balls) {
-            if (ball.pos.getZ() <= BALL_RADIUS + 0.1) count++;
+        // Spin transfer from friction torque
+        if (config.spinTransferEnabled && Math.abs(jt) > 1e-9) {
+          Translation3d rContact = c.normal.times(-BALL_RADIUS); // from center to contact
+          Translation3d torqueImpulse = cross(rContact, frictionImpulse);
+          Translation3d deltaOmega = torqueImpulse.div(BALL_MOMENT_OF_INERTIA);
+          ballA.omega = ballA.omega.plus(deltaOmega);
+
+          if (c.ballIndexB >= 0) {
+            SimBall ballB = balls.get(c.ballIndexB);
+            Translation3d rContactB = c.normal.times(BALL_RADIUS);
+            Translation3d torqueImpulseB = cross(rContactB, frictionImpulse.unaryMinus());
+            Translation3d deltaOmegaB = torqueImpulseB.div(BALL_MOMENT_OF_INERTIA);
+            ballB.omega = ballB.omega.plus(deltaOmegaB);
+          }
         }
-        return count;
+      }
     }
+  }
 
-    public List<Translation3d> getBallPositions() {
-        List<Translation3d> positions = new ArrayList<>(balls.size());
-        for (SimBall ball : balls) {
-            positions.add(ball.pos);
+  /** Push overlapping objects apart so they don't sink into each other. */
+  private void applyPositionCorrection(Contact c) {
+    double slop = config.baumgarteSlop;
+    double beta = config.baumgarteBeta;
+    double correction = Math.max(c.penetration - slop, 0) * beta;
+
+    if (correction < 1e-6) return;
+
+    SimBall ballA = balls.get(c.ballIndexA);
+    if (c.ballIndexB >= 0) {
+      SimBall ballB = balls.get(c.ballIndexB);
+      Translation3d corrVec = c.normal.times(correction * 0.5);
+      ballA.pos = ballA.pos.plus(corrVec);
+      ballB.pos = ballB.pos.minus(corrVec);
+    } else {
+      ballA.pos = ballA.pos.plus(c.normal.times(correction));
+    }
+  }
+
+  // Wall and ground handling
+
+  private void handleWallBounce(SimBall ball) {
+    double z = ball.pos.getZ();
+
+    // X walls (alliance walls: diamond plate + polycarbonate, height-aware)
+    if (ball.pos.getX() < BALL_RADIUS) {
+      if (z < ALLIANCE_WALL_HEIGHT) {
+        ball.pos = new Translation3d(BALL_RADIUS, ball.pos.getY(), ball.pos.getZ());
+        if (ball.vel.getX() < 0) {
+          applyWallSpinTransfer(ball, AXIS_X_POS);
+          double cor = effectiveCOR(COR_WALL, Math.abs(ball.vel.getX()));
+          ball.vel = new Translation3d(-ball.vel.getX() * cor, ball.vel.getY(), ball.vel.getZ());
         }
-        return positions;
-    }
-
-    public List<Translation3d> getBallVelocities() {
-        List<Translation3d> velocities = new ArrayList<>(balls.size());
-        for (SimBall ball : balls) {
-            velocities.add(ball.vel);
+      }
+    } else if (ball.pos.getX() > FIELD_LENGTH - BALL_RADIUS) {
+      if (z < ALLIANCE_WALL_HEIGHT) {
+        ball.pos = new Translation3d(FIELD_LENGTH - BALL_RADIUS, ball.pos.getY(), ball.pos.getZ());
+        if (ball.vel.getX() > 0) {
+          applyWallSpinTransfer(ball, AXIS_X_NEG);
+          double cor = effectiveCOR(COR_WALL, Math.abs(ball.vel.getX()));
+          ball.vel = new Translation3d(-ball.vel.getX() * cor, ball.vel.getY(), ball.vel.getZ());
         }
-        return velocities;
+      }
     }
 
-    public List<Translation3d> getBallOmegas() {
-        List<Translation3d> omegas = new ArrayList<>(balls.size());
-        for (SimBall ball : balls) {
-            omegas.add(ball.omega);
+    // Y walls (guardrails: polycarbonate on aluminum extrusion, height-aware)
+    if (ball.pos.getY() < BALL_RADIUS) {
+      if (z < GUARDRAIL_HEIGHT) {
+        ball.pos = new Translation3d(ball.pos.getX(), BALL_RADIUS, ball.pos.getZ());
+        if (ball.vel.getY() < 0) {
+          applyWallSpinTransfer(ball, AXIS_Y_POS);
+          double cor = effectiveCOR(COR_WALL, Math.abs(ball.vel.getY()));
+          ball.vel = new Translation3d(ball.vel.getX(), -ball.vel.getY() * cor, ball.vel.getZ());
         }
-        return omegas;
-    }
-
-    public PhysicsConfig getConfig() {
-        return config;
-    }
-
-    public void setConfig(PhysicsConfig config) {
-        this.config = config;
-        if (config.deterministic) {
-            this.rng = new Random(config.deterministicSeed);
+      }
+    } else if (ball.pos.getY() > FIELD_WIDTH - BALL_RADIUS) {
+      if (z < GUARDRAIL_HEIGHT) {
+        ball.pos = new Translation3d(ball.pos.getX(), FIELD_WIDTH - BALL_RADIUS, ball.pos.getZ());
+        if (ball.vel.getY() > 0) {
+          applyWallSpinTransfer(ball, AXIS_Y_NEG);
+          double cor = effectiveCOR(COR_WALL, Math.abs(ball.vel.getY()));
+          ball.vel = new Translation3d(ball.vel.getX(), -ball.vel.getY() * cor, ball.vel.getZ());
         }
+      }
     }
+  }
 
-    /** Lock the RNG seed so tests are repeatable. */
-    public void setDeterministic(long seed) {
-        config.deterministic = true;
-        config.deterministicSeed = seed;
-        this.rng = new Random(seed);
-    }
+  private void handleGroundContact(SimBall ball, double subDt) {
+    if (ball.pos.getZ() < BALL_RADIUS) {
+      ball.pos = new Translation3d(ball.pos.getX(), ball.pos.getY(), BALL_RADIUS);
 
-    // Translational + rotational KE
-    public double getTotalKineticEnergy() {
-        computeConservationQuantities();
-        return totalKE;
-    }
+      if (ball.vel.getZ() < 0) {
+        double cor = effectiveCOR(COR_CARPET, Math.abs(ball.vel.getZ()));
 
-    public double getTotalPotentialEnergy() {
-        computeConservationQuantities();
-        return totalPE;
-    }
-
-    public Translation3d getTotalMomentum() {
-        computeConservationQuantities();
-        return totalMomentum;
-    }
-
-    public int getTotalLaunched() {
-        return totalLaunched;
-    }
-
-    public int getTotalScored() {
-        return totalScored;
-    }
-
-    public int getTotalIntaked() {
-        return totalIntaked;
-    }
-
-    public double getLastLaunchSpeed() {
-        return lastLaunchSpeed;
-    }
-
-    public int getBlueScore() {
-        return blueHub.score;
-    }
-
-    public int getRedScore() {
-        return redHub.score;
-    }
-
-    public ScoringTarget getBlueHub() {
-        return blueHub;
-    }
-
-    public ScoringTarget getRedHub() {
-        return redHub;
-    }
-
-    // Package-private, for tests
-    List<SimBall> getBalls() {
-        return balls;
-    }
-
-    public int getSleepingBallCount() {
-        int count = 0;
-        for (SimBall ball : balls) {
-            if (ball.sleeping) count++;
+        // If bounce would be very small, just zero out vertical velocity
+        if (Math.abs(ball.vel.getZ() * cor) < 0.05) {
+          ball.vel = new Translation3d(ball.vel.getX(), ball.vel.getY(), 0);
+        } else {
+          ball.vel = new Translation3d(ball.vel.getX(), ball.vel.getY(), -ball.vel.getZ() * cor);
         }
-        return count;
+      }
+
+      // Ground friction: uses surface velocity (vel + omega x r) so spin-on-contact works
+      if (config.frictionEnabled) {
+        double surfVelX = ball.vel.getX() - ball.omega.getY() * BALL_RADIUS;
+        double surfVelY = ball.vel.getY() + ball.omega.getX() * BALL_RADIUS;
+        double surfSpeed = Math.sqrt(surfVelX * surfVelX + surfVelY * surfVelY);
+        double hSpeed =
+            Math.sqrt(ball.vel.getX() * ball.vel.getX() + ball.vel.getY() * ball.vel.getY());
+
+        if (surfSpeed > 0.01) {
+          // friction opposes surface velocity
+          double fdx = -surfVelX / surfSpeed;
+          double fdy = -surfVelY / surfSpeed;
+
+          double maxImpulse = (2.0 / 7.0) * BALL_MASS * surfSpeed;
+          double frictionImpulse =
+              Math.min(MU_GROUND_KINETIC * BALL_MASS * GRAVITY * subDt, maxImpulse);
+
+          // Friction changes both linear and angular velocity
+          ball.vel =
+              new Translation3d(
+                  ball.vel.getX() + fdx * frictionImpulse / BALL_MASS,
+                  ball.vel.getY() + fdy * frictionImpulse / BALL_MASS,
+                  ball.vel.getZ());
+          if (config.spinTransferEnabled) {
+            // Torque
+            ball.omega =
+                new Translation3d(
+                    ball.omega.getX()
+                        + BALL_RADIUS * fdy * frictionImpulse / BALL_MOMENT_OF_INERTIA,
+                    ball.omega.getY()
+                        - BALL_RADIUS * fdx * frictionImpulse / BALL_MOMENT_OF_INERTIA,
+                    ball.omega.getZ());
+          }
+        } else if (hSpeed > 1e-4) {
+          // Rolling resistance decelerates vel and omega together
+          double decel = MU_GROUND_ROLLING * GRAVITY * subDt;
+          double scale = Math.max(0, hSpeed - decel) / hSpeed;
+          ball.vel =
+              new Translation3d(ball.vel.getX() * scale, ball.vel.getY() * scale, ball.vel.getZ());
+          if (config.spinTransferEnabled) {
+            ball.omega =
+                new Translation3d(
+                    ball.omega.getX() * scale, ball.omega.getY() * scale, ball.omega.getZ());
+          }
+        }
+      }
+
+      // Settle near-zero vertical velocity when on ground
+      if (Math.abs(ball.vel.getZ()) < 0.05 && ball.pos.getZ() <= BALL_RADIUS + 0.01) {
+        ball.vel = new Translation3d(ball.vel.getX(), ball.vel.getY(), 0);
+      }
+    }
+  }
+
+  /** Handle collisions with the tent-shaped bump ramps. */
+  private void handleBumpCollisions(SimBall ball) {
+    for (BumpSegment seg : BUMP_SEGMENTS) {
+      if (ball.pos.getY() < seg.yStart() || ball.pos.getY() > seg.yEnd()) continue;
+
+      // Parametric projection onto line segment
+      double px = ball.pos.getX() - seg.xStart();
+      double pz = ball.pos.getZ() - seg.zStart();
+      double t = (px * seg.lineX() + pz * seg.lineZ()) / (seg.lineLen() * seg.lineLen());
+      if (t < 0 || t > 1) continue;
+
+      // Distance from ball center to nearest point on line (in XZ plane)
+      double nearX = seg.xStart() + t * seg.lineX();
+      double nearZ = seg.zStart() + t * seg.lineZ();
+      double dx = ball.pos.getX() - nearX;
+      double dz = ball.pos.getZ() - nearZ;
+      double dist = Math.sqrt(dx * dx + dz * dz);
+
+      if (dist < BALL_RADIUS) {
+        double nx = seg.nx(), nz = seg.nz();
+
+        // Push out
+        ball.pos =
+            ball.pos.plus(
+                new Translation3d(nx * (BALL_RADIUS - dist), 0, nz * (BALL_RADIUS - dist)));
+
+        // Velocity reflection
+        double vDotN = ball.vel.getX() * nx + ball.vel.getZ() * nz;
+        if (vDotN < 0) {
+          double cor = effectiveCOR(COR_HDPE, Math.abs(vDotN));
+          ball.vel =
+              ball.vel.minus(new Translation3d(nx * (1 + cor) * vDotN, 0, nz * (1 + cor) * vDotN));
+        }
+      }
+    }
+  }
+
+  // Hub scoring
+
+  private void handleHubScoring(SimBall ball) {
+    if (blueHub.didScore(ball)) {
+      ball.pos = blueHub.exit;
+      ball.vel = blueHub.getDispersalVelocity(rng);
+      ball.omega = new Translation3d();
+      blueHub.score++;
+      totalScored++;
+    } else if (redHub.didScore(ball)) {
+      ball.pos = redHub.exit;
+      ball.vel = redHub.getDispersalVelocity(rng);
+      ball.omega = new Translation3d();
+      redHub.score++;
+      totalScored++;
+    }
+  }
+
+  /** Hub net collision: catches overshots, but lets balls pass through from behind. */
+  private void handleNetCollision(SimBall ball, ScoringTarget hub) {
+    if (ball.pos.getZ() > NET_HEIGHT_MAX || ball.pos.getZ() < NET_HEIGHT_MIN) return;
+    if (ball.pos.getY() > hub.center.getY() + NET_WIDTH / 2.0
+        || ball.pos.getY() < hub.center.getY() - NET_WIDTH / 2.0) return;
+
+    double netX = hub.center.getX() + NET_OFFSET * hub.exitVelXSign;
+    double distToNet = ball.pos.getX() - netX;
+
+    if (Math.abs(distToNet) < BALL_RADIUS) {
+      // Only block balls moving toward the net
+      boolean movingTowardNet = ball.vel.getX() * hub.exitVelXSign > 0;
+      if (!movingTowardNet) return;
+
+      // Push ball out of net
+      double pushDir = distToNet >= 0 ? 1 : -1;
+      ball.pos = new Translation3d(netX + pushDir * BALL_RADIUS, ball.pos.getY(), ball.pos.getZ());
+      ball.vel =
+          new Translation3d(-ball.vel.getX() * COR_NET, ball.vel.getY() * COR_NET, ball.vel.getZ());
+    }
+  }
+
+  private void handleRobotCollision(SimBall ball, Pose2d robotPose, Translation2d robotVel) {
+    if (ball.pos.getZ() > bumperHeight) return;
+
+    Translation2d relPos =
+        new Pose2d(ball.pos.toTranslation2d(), Rotation2d.kZero)
+            .relativeTo(robotPose)
+            .getTranslation();
+
+    double halfL = robotLength / 2.0 + BALL_RADIUS;
+    double halfW = robotWidth / 2.0 + BALL_RADIUS;
+
+    if (relPos.getX() < -halfL
+        || relPos.getX() > halfL
+        || relPos.getY() < -halfW
+        || relPos.getY() > halfW) {
+      return;
     }
 
-    public static double getFieldLength() {
-        return FIELD_LENGTH;
+    // Find nearest face and push out
+    double dxMin = relPos.getX() + halfL;
+    double dxMax = halfL - relPos.getX();
+    double dyMin = relPos.getY() + halfW;
+    double dyMax = halfW - relPos.getY();
+
+    double minDist = dxMin;
+    Translation2d pushDir = new Translation2d(-1, 0);
+
+    if (dxMax < minDist) {
+      minDist = dxMax;
+      pushDir = new Translation2d(1, 0);
+    }
+    if (dyMin < minDist) {
+      minDist = dyMin;
+      pushDir = new Translation2d(0, -1);
+    }
+    if (dyMax < minDist) {
+      minDist = dyMax;
+      pushDir = new Translation2d(0, 1);
     }
 
-    public static double getFieldWidth() {
-        return FIELD_WIDTH;
+    // Rotate push direction back to field frame
+    pushDir = pushDir.rotateBy(robotPose.getRotation());
+    ball.pos = ball.pos.plus(new Translation3d(pushDir.times(minDist)));
+
+    // Velocity reflection
+    Translation3d normal3d = new Translation3d(pushDir.getX(), pushDir.getY(), 0);
+    double vDotN = ball.vel.toTranslation2d().dot(pushDir);
+    double robotVDotN = robotVel.dot(pushDir);
+    double closingVel = vDotN - robotVDotN;
+
+    if (closingVel < 0) {
+      ball.vel = ball.vel.minus(normal3d.times((1 + COR_BUMPER) * closingVel));
+    }
+  }
+
+  private void handleIntakePickup(SimBall ball, Pose2d robotPose) {
+    for (IntakeZone intake : intakes) {
+      if (intake.shouldIntake(ball, robotPose, bumperHeight)) {
+        ball.intaked = true;
+        totalIntaked++;
+        return;
+      }
+    }
+  }
+
+  // Sleeping
+
+  private void updateSleepState(SimBall ball) {
+    double speed = ball.vel.getNorm();
+    double omegaMag = ball.omega.getNorm();
+
+    if (speed < config.sleepVelocityThreshold
+        && omegaMag < 0.1
+        && ball.pos.getZ() <= BALL_RADIUS + 0.01) {
+      ball.sleepCounter++;
+      if (ball.sleepCounter >= config.sleepFrameThreshold) {
+        ball.sleeping = true;
+        ball.vel = new Translation3d();
+        ball.omega = new Translation3d();
+      }
+    } else {
+      ball.sleepCounter = 0;
+      ball.sleeping = false;
+    }
+  }
+
+  private void wakeBall(SimBall ball) {
+    ball.sleeping = false;
+    ball.sleepCounter = 0;
+  }
+
+  /** Wake up sleeping balls near a point (so launched balls disturb resting ones). */
+  private void wakeNearbyBalls(Translation3d pos, double radius) {
+    double radiusSq = radius * radius;
+    for (SimBall ball : balls) {
+      if (ball.sleeping) {
+        double dx = ball.pos.getX() - pos.getX();
+        double dy = ball.pos.getY() - pos.getY();
+        double dz = ball.pos.getZ() - pos.getZ();
+        if (dx * dx + dy * dy + dz * dz < radiusSq) {
+          wakeBall(ball);
+        }
+      }
+    }
+  }
+
+  // Conservation monitor
+
+  private void computeConservationQuantities() {
+    totalKE = 0;
+    totalPE = 0;
+    double mx = 0, my = 0, mz = 0;
+
+    for (SimBall ball : balls) {
+      double speed = ball.vel.getNorm();
+      totalKE += 0.5 * BALL_MASS * speed * speed;
+
+      // Rotational KE
+      double omegaMag = ball.omega.getNorm();
+      totalKE += 0.5 * BALL_MOMENT_OF_INERTIA * omegaMag * omegaMag;
+
+      // Gravitational PE (relative to ground)
+      totalPE += BALL_MASS * GRAVITY * ball.pos.getZ();
+
+      // Linear momentum
+      mx += BALL_MASS * ball.vel.getX();
+      my += BALL_MASS * ball.vel.getY();
+      mz += BALL_MASS * ball.vel.getZ();
     }
 
-    public static double getBallRadius() {
-        return BALL_RADIUS;
-    }
+    totalMomentum = new Translation3d(mx, my, mz);
+  }
 
-    public static double getBallMass() {
-        return BALL_MASS;
-    }
+  /** 3D cross product. Using Translation3d directly to avoid WPILib Vector conversion. */
+  private static Translation3d cross(Translation3d a, Translation3d b) {
+    return new Translation3d(
+        a.getY() * b.getZ() - a.getZ() * b.getY(),
+        a.getZ() * b.getX() - a.getX() * b.getZ(),
+        a.getX() * b.getY() - a.getY() * b.getX());
+  }
 
-    public static double getMomentOfInertia() {
-        return BALL_MOMENT_OF_INERTIA;
-    }
+  /** COR drops at higher impact speeds (balls deform more and lose more energy). */
+  private double velocityCOR(double e0, double impactSpeed) {
+    if (!config.velocityDependentCOR) return e0;
+    if (impactSpeed <= COR_VREF) return e0;
+    return e0 * Math.pow(COR_VREF / impactSpeed, COR_EXPONENT);
+  }
 
-    public static double getDragAccelFactor() {
-        return DRAG_ACCEL_FACTOR;
+  /** Get the COR to use, with optional velocity-dependent scaling. */
+  private double effectiveCOR(double baseCOR, double impactSpeed) {
+    if (config.velocityDependentCOR) {
+      return velocityCOR(baseCOR, impactSpeed);
     }
+    return baseCOR;
+  }
 
-    public static double getMagnusAccelFactor() {
-        return MAGNUS_ACCEL_FACTOR;
-    }
+  /** When a ball hits a wall, friction changes its spin. This handles that. */
+  private void applyWallSpinTransfer(SimBall ball, Translation3d wallNormal) {
+    if (!config.spinTransferEnabled || !config.frictionEnabled) return;
 
-    public static double getFieldCOR() {
-        return COR_CARPET;
-    }
+    // Compute tangential velocity at contact point
+    Translation3d rContact = wallNormal.times(-BALL_RADIUS);
+    Translation3d surfaceVel = ball.vel.plus(cross(ball.omega, rContact));
 
-    public static double getBallBallCOR() {
-        return COR_BALL_BALL;
-    }
+    // Remove normal component
+    double vn = surfaceVel.dot(wallNormal);
+    Translation3d vTangent = surfaceVel.minus(wallNormal.times(vn));
+    double vTangentMag = vTangent.getNorm();
 
-    public void resetCounters() {
-        totalLaunched = 0;
-        totalScored = 0;
-        totalIntaked = 0;
-        lastLaunchSpeed = 0;
-        blueHub.resetScore();
-        redHub.resetScore();
+    if (vTangentMag > 1e-4) {
+      // Total normal impulse includes restitution: j_n = m * |v_n| * (1 + e)
+      double impactSpeed = Math.abs(ball.vel.dot(wallNormal));
+      double cor = effectiveCOR(COR_WALL, impactSpeed);
+      double normalImpulse = BALL_MASS * impactSpeed * (1.0 + cor);
+      double frictionImpulse = Math.min(MU_WALL * normalImpulse, BALL_MASS * vTangentMag);
+      Translation3d frictionDir = vTangent.div(vTangentMag).unaryMinus();
+
+      // Friction affects both linear velocity and spin (Newton's 3rd law)
+      ball.vel = ball.vel.plus(frictionDir.times(frictionImpulse / BALL_MASS));
+      Translation3d torqueImpulse = cross(rContact, frictionDir.times(frictionImpulse));
+      ball.omega = ball.omega.plus(torqueImpulse.div(BALL_MOMENT_OF_INERTIA));
     }
+  }
+
+  /** Grab a contact from the pool (grows the pool if we run out). */
+  private Contact allocateContact() {
+    if (contactPoolIndex >= contactPool.size()) {
+      Contact c = new Contact();
+      contactPool.add(c);
+      contactPoolIndex++;
+      return c;
+    }
+    return contactPool.get(contactPoolIndex++);
+  }
+
+  /** Clean up balls that got eaten by intakes or flew out of bounds. */
+  private void removeFlaggedBalls() {
+    balls.removeIf(b -> b.intaked || b.outOfBounds);
+  }
+
+  // Trajectory prediction
+
+  /**
+   * Predict where a shot will go (gravity + drag only, no collisions). Returns points you can plot
+   * in AdvantageScope Field3d. Stops at the ground.
+   */
+  private Translation3d[] predictArc(Translation3d pos, Translation3d vel, int steps, double dt) {
+    List<Translation3d> arc = new ArrayList<>();
+    arc.add(pos);
+    double px = pos.getX(), py = pos.getY(), pz = pos.getZ();
+    double vx = vel.getX(), vy = vel.getY(), vz = vel.getZ();
+    for (int i = 0; i < steps; i++) {
+      double speed = Math.sqrt(vx * vx + vy * vy + vz * vz);
+      double drag = config.dragEnabled && speed > 1e-6 ? DRAG_ACCEL_FACTOR * speed : 0;
+      vx -= drag * vx * dt;
+      vy -= drag * vy * dt;
+      vz -= (GRAVITY + drag * vz) * dt;
+      px += vx * dt;
+      py += vy * dt;
+      pz += vz * dt;
+      if (pz < BALL_RADIUS) break;
+      arc.add(new Translation3d(px, py, pz));
+    }
+    return arc.toArray(new Translation3d[0]);
+  }
+
+  /** Push ball positions and sim stats to NetworkTables for visualization. */
+  public void publishPositions() {
+    // All ball positions (for Field3d rendering)
+    Translation3d[] positions = new Translation3d[balls.size()];
+    for (int i = 0; i < balls.size(); i++) {
+      positions[i] = balls.get(i).pos;
+    }
+    positionPublisher.set(positions);
+
+    // In-flight positions only (airborne balls, can render separately in Field3d)
+    List<Translation3d> inFlight = new ArrayList<>();
+    int sleeping = 0;
+    for (SimBall b : balls) {
+      if (b.intaked || b.outOfBounds) continue;
+      if (b.pos.getZ() > BALL_RADIUS + 0.1) {
+        inFlight.add(b.pos);
+      }
+      if (b.sleeping) sleeping++;
+    }
+    inFlightPublisher.set(inFlight.toArray(new Translation3d[0]));
+
+    // Last shot arc (predicted trajectory visible in Field3d)
+    lastShotArcPublisher.set(lastShotArc);
+
+    // Scoring
+    blueScorePub.set(blueHub.score);
+    redScorePub.set(redHub.score);
+
+    // Stats
+    ballCountPub.set(balls.size());
+    activeBallsPub.set(balls.size() - sleeping);
+    sleepingBallsPub.set(sleeping);
+    contactCountPub.set(contacts.size());
+    physicsTimePub.set(lastPhysicsNanos / 1_000_000.0);
+    computeConservationQuantities();
+    totalEnergyPub.set(totalKE + totalPE);
+  }
+
+  public int getBallCount() {
+    return balls.size();
+  }
+
+  // Only counts balls above ground level + small margin
+  public int getBallsInFlight() {
+    int count = 0;
+    for (SimBall ball : balls) {
+      if (ball.pos.getZ() > BALL_RADIUS + 0.1) count++;
+    }
+    return count;
+  }
+
+  public int getBallsOnGround() {
+    int count = 0;
+    for (SimBall ball : balls) {
+      if (ball.pos.getZ() <= BALL_RADIUS + 0.1) count++;
+    }
+    return count;
+  }
+
+  public List<Translation3d> getBallPositions() {
+    List<Translation3d> positions = new ArrayList<>(balls.size());
+    for (SimBall ball : balls) {
+      positions.add(ball.pos);
+    }
+    return positions;
+  }
+
+  public List<Translation3d> getBallVelocities() {
+    List<Translation3d> velocities = new ArrayList<>(balls.size());
+    for (SimBall ball : balls) {
+      velocities.add(ball.vel);
+    }
+    return velocities;
+  }
+
+  public List<Translation3d> getBallOmegas() {
+    List<Translation3d> omegas = new ArrayList<>(balls.size());
+    for (SimBall ball : balls) {
+      omegas.add(ball.omega);
+    }
+    return omegas;
+  }
+
+  public PhysicsConfig getConfig() {
+    return config;
+  }
+
+  public void setConfig(PhysicsConfig config) {
+    this.config = config;
+    if (config.deterministic) {
+      this.rng = new Random(config.deterministicSeed);
+    }
+  }
+
+  /** Lock the RNG seed so tests are repeatable. */
+  public void setDeterministic(long seed) {
+    config.deterministic = true;
+    config.deterministicSeed = seed;
+    this.rng = new Random(seed);
+  }
+
+  // Translational + rotational KE
+  public double getTotalKineticEnergy() {
+    computeConservationQuantities();
+    return totalKE;
+  }
+
+  public double getTotalPotentialEnergy() {
+    computeConservationQuantities();
+    return totalPE;
+  }
+
+  public Translation3d getTotalMomentum() {
+    computeConservationQuantities();
+    return totalMomentum;
+  }
+
+  public int getTotalLaunched() {
+    return totalLaunched;
+  }
+
+  public int getTotalScored() {
+    return totalScored;
+  }
+
+  public int getTotalIntaked() {
+    return totalIntaked;
+  }
+
+  public double getLastLaunchSpeed() {
+    return lastLaunchSpeed;
+  }
+
+  public int getBlueScore() {
+    return blueHub.score;
+  }
+
+  public int getRedScore() {
+    return redHub.score;
+  }
+
+  public ScoringTarget getBlueHub() {
+    return blueHub;
+  }
+
+  public ScoringTarget getRedHub() {
+    return redHub;
+  }
+
+  // Package-private, for tests
+  List<SimBall> getBalls() {
+    return balls;
+  }
+
+  public int getSleepingBallCount() {
+    int count = 0;
+    for (SimBall ball : balls) {
+      if (ball.sleeping) count++;
+    }
+    return count;
+  }
+
+  public static double getFieldLength() {
+    return FIELD_LENGTH;
+  }
+
+  public static double getFieldWidth() {
+    return FIELD_WIDTH;
+  }
+
+  public static double getBallRadius() {
+    return BALL_RADIUS;
+  }
+
+  public static double getBallMass() {
+    return BALL_MASS;
+  }
+
+  public static double getMomentOfInertia() {
+    return BALL_MOMENT_OF_INERTIA;
+  }
+
+  public static double getDragAccelFactor() {
+    return DRAG_ACCEL_FACTOR;
+  }
+
+  public static double getMagnusAccelFactor() {
+    return MAGNUS_ACCEL_FACTOR;
+  }
+
+  public static double getFieldCOR() {
+    return COR_CARPET;
+  }
+
+  public static double getBallBallCOR() {
+    return COR_BALL_BALL;
+  }
+
+  public void resetCounters() {
+    totalLaunched = 0;
+    totalScored = 0;
+    totalIntaked = 0;
+    lastLaunchSpeed = 0;
+    blueHub.resetScore();
+    redHub.resetScore();
+  }
 }

--- a/src/main/java/frc/robot/sim/SimDeviceManager.java
+++ b/src/main/java/frc/robot/sim/SimDeviceManager.java
@@ -1,258 +1,253 @@
 package frc.robot.sim;
 
 import com.revrobotics.spark.SparkSim;
-
 import edu.wpi.first.math.system.plant.DCMotor;
 import edu.wpi.first.wpilibj.Timer;
 import edu.wpi.first.wpilibj.simulation.RoboRioSim;
-
 import frc.robot.Constants;
 import frc.robot.Constants.ShooterConstants;
 import frc.robot.subsystems.Agitator;
 import frc.robot.subsystems.Hanger;
 import frc.robot.subsystems.Indexer;
-import frc.robot.subsystems.IntakeRoller;
 import frc.robot.subsystems.IntakePivot;
+import frc.robot.subsystems.IntakeRoller;
 import frc.robot.subsystems.Shooter;
 import frc.robot.telemetry.SafeLog;
 
 /**
- * SparkSim wiring for motor subsystems. Call update() each simulationPeriodic().
- * First-order dynamics bypass real PID gains (tuned for hardware, not sim).
+ * SparkSim wiring for motor subsystems. Call update() each simulationPeriodic(). First-order
+ * dynamics bypass real PID gains (tuned for hardware, not sim).
  */
 public class SimDeviceManager {
-    private static final double NEO_FREE_SPEED_RPM = 5676.0;
-    private static final double DT = 0.020;
-    private static final double SPINUP_TAU = 0.100; // 100ms spin-up
-    private static final double COASTDOWN_TAU = 0.300; // 300ms coast-down
+  private static final double NEO_FREE_SPEED_RPM = 5676.0;
+  private static final double DT = 0.020;
+  private static final double SPINUP_TAU = 0.100; // 100ms spin-up
+  private static final double COASTDOWN_TAU = 0.300; // 300ms coast-down
 
-    private SparkSim shooterSim;
-    private SparkSim indexerSim;
-    private SparkSim intakeSim;
-    private SparkSim agitatorSim;
-    private SparkSim intakeActuatorSim;
-    private SparkSim hangerSim;
-    private boolean initialized = false;
+  private SparkSim shooterSim;
+  private SparkSim indexerSim;
+  private SparkSim intakeSim;
+  private SparkSim agitatorSim;
+  private SparkSim intakeActuatorSim;
+  private SparkSim hangerSim;
+  private boolean initialized = false;
 
-    // Per-motor RPM state for first-order dynamics
-    private double shooterRPM = 0;
-    private double indexerRPM = 0;
-    private double intakeRPM = 0;
-    private double agitatorRPM = 0;
+  // Per-motor RPM state for first-order dynamics
+  private double shooterRPM = 0;
+  private double indexerRPM = 0;
+  private double intakeRPM = 0;
+  private double agitatorRPM = 0;
 
-    // Position motor state with sticky targets (same command-conflict fix as shooter)
-    private double intakeActuatorPos = 0;
-    private double hangerPos = 0;
-    private static final double POSITION_TAU = 0.300; // 300ms approach
-    private double lastActuatorTarget = 0;
-    private int actuatorHoldCycles = 0;
-    private double lastHangerTarget = 0;
-    private int hangerHoldCycles = 0;
+  // Position motor state with sticky targets (same command-conflict fix as shooter)
+  private double intakeActuatorPos = 0;
+  private double hangerPos = 0;
+  private static final double POSITION_TAU = 0.300; // 300ms approach
+  private double lastActuatorTarget = 0;
+  private int actuatorHoldCycles = 0;
+  private double lastHangerTarget = 0;
+  private int hangerHoldCycles = 0;
 
-    // Sticky target: holds last nonzero target for a brief grace period,
-    // avoiding brief 0s from command scheduler transitions
-    private double lastShooterTarget = 0;
-    private int targetHoldCycles = 0;
-    private static final int TARGET_HOLD_COUNT = 10; // 200ms grace
+  // Sticky target: holds last nonzero target for a brief grace period,
+  // avoiding brief 0s from command scheduler transitions
+  private double lastShooterTarget = 0;
+  private int targetHoldCycles = 0;
+  private static final int TARGET_HOLD_COUNT = 10; // 200ms grace
 
-    // Shot simulation: periodic RPM drops when indexing at speed
-    private static final double SHOT_RPM_DROP = 350.0;
-    private static final double SHOT_SIM_INTERVAL = 0.500; // one shot per 500ms
-    private double lastShotSimTime = 0;
-    private boolean shotFiredThisCycle = false;
+  // Shot simulation: periodic RPM drops when indexing at speed
+  private static final double SHOT_RPM_DROP = 350.0;
+  private static final double SHOT_SIM_INTERVAL = 0.500; // one shot per 500ms
+  private double lastShotSimTime = 0;
+  private boolean shotFiredThisCycle = false;
 
-    public void init() {
-        try {
-            Shooter shooter = Shooter.getInstance();
-            Indexer indexer = Indexer.getInstance();
-            IntakeRoller intake = IntakeRoller.getInstance();
-            Agitator agitator = Agitator.getInstance();
-            IntakePivot intakeActuator = IntakePivot.getInstance();
-            Hanger hanger = Hanger.getInstance();
-            if (shooter == null
-                    || indexer == null
-                    || intake == null
-                    || agitator == null
-                    || intakeActuator == null
-                    || hanger == null) {
-                SafeLog.put("Sim/DeviceManager/InitError", "NullSubsystem");
-                initialized = false;
-                return;
-            }
-            shooterSim = new SparkSim(shooter.getMotor(), DCMotor.getNEO(1));
-            indexerSim = new SparkSim(indexer.getMotor(), DCMotor.getNEO(1));
-            intakeSim = new SparkSim(intake.getMotor(), DCMotor.getNEO(1));
-            agitatorSim = new SparkSim(agitator.getMotor(), DCMotor.getNEO(1));
-            intakeActuatorSim = new SparkSim(intakeActuator.getMotor(), DCMotor.getNEO(1));
-            hangerSim = new SparkSim(hanger.getMotor(), DCMotor.getNEO(1));
-            initialized = true;
-        } catch (RuntimeException e) {
-            SafeLog.put("Sim/DeviceManager/InitError", e.getClass().getSimpleName());
-            initialized = false;
-        }
+  public void init() {
+    try {
+      Shooter shooter = Shooter.getInstance();
+      Indexer indexer = Indexer.getInstance();
+      IntakeRoller intake = IntakeRoller.getInstance();
+      Agitator agitator = Agitator.getInstance();
+      IntakePivot intakeActuator = IntakePivot.getInstance();
+      Hanger hanger = Hanger.getInstance();
+      if (shooter == null
+          || indexer == null
+          || intake == null
+          || agitator == null
+          || intakeActuator == null
+          || hanger == null) {
+        SafeLog.put("Sim/DeviceManager/InitError", "NullSubsystem");
+        initialized = false;
+        return;
+      }
+      shooterSim = new SparkSim(shooter.getMotor(), DCMotor.getNEO(1));
+      indexerSim = new SparkSim(indexer.getMotor(), DCMotor.getNEO(1));
+      intakeSim = new SparkSim(intake.getMotor(), DCMotor.getNEO(1));
+      agitatorSim = new SparkSim(agitator.getMotor(), DCMotor.getNEO(1));
+      intakeActuatorSim = new SparkSim(intakeActuator.getMotor(), DCMotor.getNEO(1));
+      hangerSim = new SparkSim(hanger.getMotor(), DCMotor.getNEO(1));
+      initialized = true;
+    } catch (RuntimeException e) {
+      SafeLog.put("Sim/DeviceManager/InitError", e.getClass().getSimpleName());
+      initialized = false;
     }
+  }
 
-    /** Call from Robot.simulationPeriodic() */
-    public void update() {
-        if (!initialized) return;
-        try {
-            // Shooter: sticky target rides through brief command transitions
-            Shooter shooterInst = Shooter.getInstance();
-            if (shooterInst == null) return;
-            double rawTarget = shooterInst.getTargetRPM();
-            if (rawTarget > 0) {
-                lastShooterTarget = rawTarget;
-                targetHoldCycles = TARGET_HOLD_COUNT;
-            } else if (targetHoldCycles > 0) {
-                targetHoldCycles--;
-            } else {
-                lastShooterTarget = 0;
-            }
-            double shooterTarget = lastShooterTarget;
-            shooterRPM = updateMotorToTarget(shooterSim, shooterRPM, shooterTarget);
+  /** Call from Robot.simulationPeriodic() */
+  public void update() {
+    if (!initialized) return;
+    try {
+      // Shooter: sticky target rides through brief command transitions
+      Shooter shooterInst = Shooter.getInstance();
+      if (shooterInst == null) return;
+      double rawTarget = shooterInst.getTargetRPM();
+      if (rawTarget > 0) {
+        lastShooterTarget = rawTarget;
+        targetHoldCycles = TARGET_HOLD_COUNT;
+      } else if (targetHoldCycles > 0) {
+        targetHoldCycles--;
+      } else {
+        lastShooterTarget = 0;
+      }
+      double shooterTarget = lastShooterTarget;
+      shooterRPM = updateMotorToTarget(shooterSim, shooterRPM, shooterTarget);
 
-            double indexerTarget =
-                    (Math.abs(indexerSim.getAppliedOutput()) > 0.01)
-                            ? Constants.MotorConstants.DESIRED_INDEXER_RPM
-                            : 0;
-            indexerRPM = updateMotorToTarget(indexerSim, indexerRPM, indexerTarget);
+      double indexerTarget =
+          (Math.abs(indexerSim.getAppliedOutput()) > 0.01)
+              ? Constants.MotorConstants.DESIRED_INDEXER_RPM
+              : 0;
+      indexerRPM = updateMotorToTarget(indexerSim, indexerRPM, indexerTarget);
 
-            double intakeOutput = intakeSim.getAppliedOutput();
-            double intakeTarget = intakeOutput * NEO_FREE_SPEED_RPM;
-            intakeRPM = updateMotorToTarget(intakeSim, intakeRPM, intakeTarget);
+      double intakeOutput = intakeSim.getAppliedOutput();
+      double intakeTarget = intakeOutput * NEO_FREE_SPEED_RPM;
+      intakeRPM = updateMotorToTarget(intakeSim, intakeRPM, intakeTarget);
 
-            double agitatorOutput = agitatorSim.getAppliedOutput();
-            double agitatorTarget = agitatorOutput * NEO_FREE_SPEED_RPM;
-            agitatorRPM = updateMotorToTarget(agitatorSim, agitatorRPM, agitatorTarget);
+      double agitatorOutput = agitatorSim.getAppliedOutput();
+      double agitatorTarget = agitatorOutput * NEO_FREE_SPEED_RPM;
+      agitatorRPM = updateMotorToTarget(agitatorSim, agitatorRPM, agitatorTarget);
 
-            // When indexer is active and shooter is at speed, periodically drop
-            // shooter RPM to trigger shot detection in ShooterTelemetry
-            boolean indexerActive = indexerRPM > 100;
-            boolean shooterAtSpeed =
-                    shooterRPM
-                            > (ShooterConstants.TARGET_RPM - ShooterConstants.SPEED_TOLERANCE_RPM);
-            double now = Timer.getFPGATimestamp();
+      // When indexer is active and shooter is at speed, periodically drop
+      // shooter RPM to trigger shot detection in ShooterTelemetry
+      boolean indexerActive = indexerRPM > 100;
+      boolean shooterAtSpeed =
+          shooterRPM > (ShooterConstants.TARGET_RPM - ShooterConstants.SPEED_TOLERANCE_RPM);
+      double now = Timer.getFPGATimestamp();
 
-            if (indexerActive && shooterAtSpeed && (now - lastShotSimTime) > SHOT_SIM_INTERVAL) {
-                shooterRPM -= SHOT_RPM_DROP;
-                shooterSim.getRelativeEncoderSim().setVelocity(shooterRPM);
-                lastShotSimTime = now;
-                shotFiredThisCycle = true;
-                SafeLog.put("Sim/Debug/ShotSimulated", true);
-            } else {
-                shotFiredThisCycle = false;
-                SafeLog.put("Sim/Debug/ShotSimulated", false);
-            }
+      if (indexerActive && shooterAtSpeed && (now - lastShotSimTime) > SHOT_SIM_INTERVAL) {
+        shooterRPM -= SHOT_RPM_DROP;
+        shooterSim.getRelativeEncoderSim().setVelocity(shooterRPM);
+        lastShotSimTime = now;
+        shotFiredThisCycle = true;
+        SafeLog.put("Sim/Debug/ShotSimulated", true);
+      } else {
+        shotFiredThisCycle = false;
+        SafeLog.put("Sim/Debug/ShotSimulated", false);
+      }
 
-            // Refresh hold whenever we see a nonzero target >= current sticky.
-            // This keeps hold alive during 50/0 oscillation (refreshed every other cycle).
-            // Hold only expires after 10 consecutive zero-target cycles (real release).
-            IntakePivot actuatorInst = IntakePivot.getInstance();
-            if (actuatorInst == null) return;
-            double rawActuatorTarget = actuatorInst.getTargetPosition();
-            if (rawActuatorTarget != 0
-                    && Math.abs(rawActuatorTarget) >= Math.abs(lastActuatorTarget)) {
-                lastActuatorTarget = rawActuatorTarget;
-                actuatorHoldCycles = TARGET_HOLD_COUNT;
-            } else if (actuatorHoldCycles > 0) {
-                actuatorHoldCycles--;
-            } else {
-                lastActuatorTarget = rawActuatorTarget;
-            }
-            intakeActuatorPos =
-                    updatePositionToTarget(
-                            intakeActuatorSim, intakeActuatorPos, lastActuatorTarget);
+      // Refresh hold whenever we see a nonzero target >= current sticky.
+      // This keeps hold alive during 50/0 oscillation (refreshed every other cycle).
+      // Hold only expires after 10 consecutive zero-target cycles (real release).
+      IntakePivot actuatorInst = IntakePivot.getInstance();
+      if (actuatorInst == null) return;
+      double rawActuatorTarget = actuatorInst.getTargetPosition();
+      if (rawActuatorTarget != 0 && Math.abs(rawActuatorTarget) >= Math.abs(lastActuatorTarget)) {
+        lastActuatorTarget = rawActuatorTarget;
+        actuatorHoldCycles = TARGET_HOLD_COUNT;
+      } else if (actuatorHoldCycles > 0) {
+        actuatorHoldCycles--;
+      } else {
+        lastActuatorTarget = rawActuatorTarget;
+      }
+      intakeActuatorPos =
+          updatePositionToTarget(intakeActuatorSim, intakeActuatorPos, lastActuatorTarget);
 
-            Hanger hangerInst = Hanger.getInstance();
-            if (hangerInst == null) return;
-            double rawHangerTarget = hangerInst.getTargetPosition();
-            if (rawHangerTarget != 0 && Math.abs(rawHangerTarget) >= Math.abs(lastHangerTarget)) {
-                lastHangerTarget = rawHangerTarget;
-                hangerHoldCycles = TARGET_HOLD_COUNT;
-            } else if (hangerHoldCycles > 0) {
-                hangerHoldCycles--;
-            } else {
-                lastHangerTarget = rawHangerTarget;
-            }
-            hangerPos = updatePositionToTarget(hangerSim, hangerPos, lastHangerTarget);
+      Hanger hangerInst = Hanger.getInstance();
+      if (hangerInst == null) return;
+      double rawHangerTarget = hangerInst.getTargetPosition();
+      if (rawHangerTarget != 0 && Math.abs(rawHangerTarget) >= Math.abs(lastHangerTarget)) {
+        lastHangerTarget = rawHangerTarget;
+        hangerHoldCycles = TARGET_HOLD_COUNT;
+      } else if (hangerHoldCycles > 0) {
+        hangerHoldCycles--;
+      } else {
+        lastHangerTarget = rawHangerTarget;
+      }
+      hangerPos = updatePositionToTarget(hangerSim, hangerPos, lastHangerTarget);
 
-            SafeLog.put("Sim/Debug/ShooterOutput", shooterSim.getAppliedOutput());
-            SafeLog.put("Sim/Debug/ShooterRPM", shooterRPM);
-            SafeLog.put("Sim/Debug/ShooterTarget", shooterTarget);
-            SafeLog.put("Sim/Debug/IndexerOutput", indexerSim.getAppliedOutput());
-            SafeLog.put("Sim/Debug/IndexerRPM", indexerRPM);
-            SafeLog.put("Sim/Debug/IntakeOutput", intakeSim.getAppliedOutput());
-            SafeLog.put("Sim/Debug/IntakeRPM", intakeRPM);
-            SafeLog.put("Sim/Debug/AgitatorOutput", agitatorSim.getAppliedOutput());
-            SafeLog.put("Sim/Debug/AgitatorRPM", agitatorRPM);
-            SafeLog.put("Sim/Debug/IntakeActuatorPos", intakeActuatorPos);
-            SafeLog.put("Sim/Debug/IntakeActuatorTarget", lastActuatorTarget);
-            SafeLog.put("Sim/Debug/HangerPos", hangerPos);
-            SafeLog.put("Sim/Debug/HangerTarget", lastHangerTarget);
-        } catch (RuntimeException e) {
-            SafeLog.put("Sim/DeviceManager/UpdateError", e.getClass().getSimpleName());
-        }
+      SafeLog.put("Sim/Debug/ShooterOutput", shooterSim.getAppliedOutput());
+      SafeLog.put("Sim/Debug/ShooterRPM", shooterRPM);
+      SafeLog.put("Sim/Debug/ShooterTarget", shooterTarget);
+      SafeLog.put("Sim/Debug/IndexerOutput", indexerSim.getAppliedOutput());
+      SafeLog.put("Sim/Debug/IndexerRPM", indexerRPM);
+      SafeLog.put("Sim/Debug/IntakeOutput", intakeSim.getAppliedOutput());
+      SafeLog.put("Sim/Debug/IntakeRPM", intakeRPM);
+      SafeLog.put("Sim/Debug/AgitatorOutput", agitatorSim.getAppliedOutput());
+      SafeLog.put("Sim/Debug/AgitatorRPM", agitatorRPM);
+      SafeLog.put("Sim/Debug/IntakeActuatorPos", intakeActuatorPos);
+      SafeLog.put("Sim/Debug/IntakeActuatorTarget", lastActuatorTarget);
+      SafeLog.put("Sim/Debug/HangerPos", hangerPos);
+      SafeLog.put("Sim/Debug/HangerTarget", lastHangerTarget);
+    } catch (RuntimeException e) {
+      SafeLog.put("Sim/DeviceManager/UpdateError", e.getClass().getSimpleName());
     }
+  }
 
-    private double updateMotorToTarget(SparkSim sim, double currentRPM, double targetRPM) {
-        double vbus = Math.max(1.0, RoboRioSim.getVInVoltage());
+  private double updateMotorToTarget(SparkSim sim, double currentRPM, double targetRPM) {
+    double vbus = Math.max(1.0, RoboRioSim.getVInVoltage());
 
-        double tau = (Math.abs(targetRPM) > Math.abs(currentRPM)) ? SPINUP_TAU : COASTDOWN_TAU;
-        double alpha = 1.0 - Math.exp(-DT / tau);
-        currentRPM += (targetRPM - currentRPM) * alpha;
+    double tau = (Math.abs(targetRPM) > Math.abs(currentRPM)) ? SPINUP_TAU : COASTDOWN_TAU;
+    double alpha = 1.0 - Math.exp(-DT / tau);
+    currentRPM += (targetRPM - currentRPM) * alpha;
 
-        if (Math.abs(currentRPM) < 0.5) currentRPM = 0;
+    if (Math.abs(currentRPM) < 0.5) currentRPM = 0;
 
-        // iterate() first (updates PID state), then setVelocity() to override
-        // firmware averaging filter that would otherwise cap velocity at ~80%
-        sim.iterate(currentRPM, vbus, DT);
-        sim.getRelativeEncoderSim().setVelocity(currentRPM);
+    // iterate() first (updates PID state), then setVelocity() to override
+    // firmware averaging filter that would otherwise cap velocity at ~80%
+    sim.iterate(currentRPM, vbus, DT);
+    sim.getRelativeEncoderSim().setVelocity(currentRPM);
 
-        return currentRPM;
-    }
+    return currentRPM;
+  }
 
-    private double updatePositionToTarget(SparkSim sim, double currentPos, double targetPos) {
-        double alpha = 1.0 - Math.exp(-DT / POSITION_TAU);
-        currentPos += (targetPos - currentPos) * alpha;
-        sim.getRelativeEncoderSim().setPosition(currentPos);
-        return currentPos;
-    }
+  private double updatePositionToTarget(SparkSim sim, double currentPos, double targetPos) {
+    double alpha = 1.0 - Math.exp(-DT / POSITION_TAU);
+    currentPos += (targetPos - currentPos) * alpha;
+    sim.getRelativeEncoderSim().setPosition(currentPos);
+    return currentPos;
+  }
 
-    public SparkSim getShooterSim() {
-        return shooterSim;
-    }
+  public SparkSim getShooterSim() {
+    return shooterSim;
+  }
 
-    public SparkSim getIndexerSim() {
-        return indexerSim;
-    }
+  public SparkSim getIndexerSim() {
+    return indexerSim;
+  }
 
-    public SparkSim getIntakeSim() {
-        return intakeSim;
-    }
+  public SparkSim getIntakeSim() {
+    return intakeSim;
+  }
 
-    public SparkSim getAgitatorSim() {
-        return agitatorSim;
-    }
+  public SparkSim getAgitatorSim() {
+    return agitatorSim;
+  }
 
-    public SparkSim getIntakeActuatorSim() {
-        return intakeActuatorSim;
-    }
+  public SparkSim getIntakeActuatorSim() {
+    return intakeActuatorSim;
+  }
 
-    public SparkSim getHangerSim() {
-        return hangerSim;
-    }
+  public SparkSim getHangerSim() {
+    return hangerSim;
+  }
 
-    public boolean isInitialized() {
-        return initialized;
-    }
+  public boolean isInitialized() {
+    return initialized;
+  }
 
-    /** True if a shot was simulated this cycle (rising-edge for FuelPhysicsSim). */
-    public boolean wasShotFiredThisCycle() {
-        return shotFiredThisCycle;
-    }
+  /** True if a shot was simulated this cycle (rising-edge for FuelPhysicsSim). */
+  public boolean wasShotFiredThisCycle() {
+    return shotFiredThisCycle;
+  }
 
-    /** Current simulated shooter RPM (for FuelPhysicsSim exit velocity). */
-    public double getShooterRPM() {
-        return shooterRPM;
-    }
+  /** Current simulated shooter RPM (for FuelPhysicsSim exit velocity). */
+  public double getShooterRPM() {
+    return shooterRPM;
+  }
 }

--- a/src/main/java/frc/robot/sim/SimFuelManager.java
+++ b/src/main/java/frc/robot/sim/SimFuelManager.java
@@ -5,364 +5,355 @@ import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.math.geometry.Translation2d;
 import edu.wpi.first.math.geometry.Translation3d;
 import edu.wpi.first.math.kinematics.ChassisSpeeds;
-
 import frc.robot.Constants.ProjectileSimConstants;
 import frc.robot.Constants.ShotCalculatorConstants;
 import frc.robot.telemetry.SafeLog;
 import frc.robot.util.TunableNumber;
-
 import java.util.List;
 import java.util.function.BooleanSupplier;
 import java.util.function.Supplier;
 
 /** Wires SimDeviceManager shot detection to FuelPhysicsSim ball physics. */
 public class SimFuelManager {
-    private static final TunableNumber enabled = new TunableNumber("Sim/FuelSim/Enabled", 1);
-    private static final TunableNumber subticks = new TunableNumber("Sim/FuelSim/Subticks", 5);
-    private static final TunableNumber magnusToggle =
-            new TunableNumber("Sim/FuelSim/MagnusEnabled", 1);
-    private static final TunableNumber frictionToggle =
-            new TunableNumber("Sim/FuelSim/FrictionEnabled", 1);
-    private static final TunableNumber sleepingToggle =
-            new TunableNumber("Sim/FuelSim/SleepingEnabled", 1);
-    private static final TunableNumber ccdToggle = new TunableNumber("Sim/FuelSim/CCDEnabled", 1);
+  private static final TunableNumber enabled = new TunableNumber("Sim/FuelSim/Enabled", 1);
+  private static final TunableNumber subticks = new TunableNumber("Sim/FuelSim/Subticks", 5);
+  private static final TunableNumber magnusToggle =
+      new TunableNumber("Sim/FuelSim/MagnusEnabled", 1);
+  private static final TunableNumber frictionToggle =
+      new TunableNumber("Sim/FuelSim/FrictionEnabled", 1);
+  private static final TunableNumber sleepingToggle =
+      new TunableNumber("Sim/FuelSim/SleepingEnabled", 1);
+  private static final TunableNumber ccdToggle = new TunableNumber("Sim/FuelSim/CCDEnabled", 1);
 
-    private final FuelPhysicsSim sim;
-    private boolean lastShotSignal = false;
+  private final FuelPhysicsSim sim;
+  private boolean lastShotSignal = false;
 
-    // Ball tracking: how many balls the robot is currently holding.
-    // Only enforced when intake is registered (otherwise shots fire freely for backward compat).
-    private int ballsHeld = 0;
-    private boolean intakeRegistered = false;
-    private static final int MAX_BALLS_HELD = 50;
-    private static volatile boolean simBallPresent = true; // default true until intake is wired
-    private boolean adaptiveShotSpeed = true; // true = always-score, false = real RPM physics
+  // Ball tracking: how many balls the robot is currently holding.
+  // Only enforced when intake is registered (otherwise shots fire freely for backward compat).
+  private int ballsHeld = 0;
+  private boolean intakeRegistered = false;
+  private static final int MAX_BALLS_HELD = 50;
+  private static volatile boolean simBallPresent = true; // default true until intake is wired
+  private boolean adaptiveShotSpeed = true; // true = always-score, false = real RPM physics
 
-    // Actual ball trail: tracks the in-flight ball's XY after each shot for "predicted vs actual"
-    private static final int MAX_TRAIL_POINTS = 100;
-    private final Pose2d[] actualTrailBuffer = new Pose2d[MAX_TRAIL_POINTS];
-    private int actualTrailCount = 0;
-    private boolean trackingBall = false;
-    private int prevTotalLaunched = 0;
-    private int prevTotalScored = 0;
-    private Pose2d lastRobotPose = null;
-    private Pose2d[] actualBallTrail = new Pose2d[0];
+  // Actual ball trail: tracks the in-flight ball's XY after each shot for "predicted vs actual"
+  private static final int MAX_TRAIL_POINTS = 100;
+  private final Pose2d[] actualTrailBuffer = new Pose2d[MAX_TRAIL_POINTS];
+  private int actualTrailCount = 0;
+  private boolean trackingBall = false;
+  private int prevTotalLaunched = 0;
+  private int prevTotalScored = 0;
+  private Pose2d lastRobotPose = null;
+  private Pose2d[] actualBallTrail = new Pose2d[0];
 
-    /** True if the robot has a ball in sim. Volatile so telemetry can read it safely. */
-    public static boolean isSimBallPresent() {
-        return simBallPresent;
-    }
+  /** True if the robot has a ball in sim. Volatile so telemetry can read it safely. */
+  public static boolean isSimBallPresent() {
+    return simBallPresent;
+  }
 
-    /**
-     * When false, shots use real shooter RPM so wrong speed = miss. Default true (always-score).
-     */
-    public void setAdaptiveShotSpeed(boolean adaptive) {
-        this.adaptiveShotSpeed = adaptive;
-    }
+  /** When false, shots use real shooter RPM so wrong speed = miss. Default true (always-score). */
+  public void setAdaptiveShotSpeed(boolean adaptive) {
+    this.adaptiveShotSpeed = adaptive;
+  }
 
-    // Shot parameters from measured constants
-    private static final double EXIT_HEIGHT_M = ProjectileSimConstants.EXIT_HEIGHT_M;
-    private static final double FIXED_LAUNCH_ANGLE_DEG =
-            ShotCalculatorConstants.FIXED_LAUNCH_ANGLE_DEG;
-    private static final double WHEEL_DIAMETER_M = ProjectileSimConstants.WHEEL_DIAMETER_M;
-    private static final double SLIP_FACTOR = 0.6; // matches ShotCalculator default
-    private static final double DEFAULT_SPIN_RPM = 2000.0;
+  // Shot parameters from measured constants
+  private static final double EXIT_HEIGHT_M = ProjectileSimConstants.EXIT_HEIGHT_M;
+  private static final double FIXED_LAUNCH_ANGLE_DEG =
+      ShotCalculatorConstants.FIXED_LAUNCH_ANGLE_DEG;
+  private static final double WHEEL_DIAMETER_M = ProjectileSimConstants.WHEEL_DIAMETER_M;
+  private static final double SLIP_FACTOR = 0.6; // matches ShotCalculator default
+  private static final double DEFAULT_SPIN_RPM = 2000.0;
 
-    // Hub geometry (must match FuelPhysicsSim for accurate scoring detection)
-    private static final Translation2d BLUE_HUB = new Translation2d(4.5974, 4.035);
-    private static final Translation2d RED_HUB = new Translation2d(11.938, 4.035);
-    private static final double HUB_ENTRY_HEIGHT = 1.829; // m, 72 in
-    private static final double FIELD_MID_X = 16.541 / 2.0;
-    private static final double GRAVITY = 9.81;
+  // Hub geometry (must match FuelPhysicsSim for accurate scoring detection)
+  private static final Translation2d BLUE_HUB = new Translation2d(4.5974, 4.035);
+  private static final Translation2d RED_HUB = new Translation2d(11.938, 4.035);
+  private static final double HUB_ENTRY_HEIGHT = 1.829; // m, 72 in
+  private static final double FIELD_MID_X = 16.541 / 2.0;
+  private static final double GRAVITY = 9.81;
 
-    // FuelPhysicsSim applies aerodynamic drag (Cd=0.47) which slows the ball ~4-5%
-    // over typical flight distances. This factor bumps the vacuum-trajectory exit
-    // speed so the ball arrives with enough energy to clear the hub rim.
-    private static final double DRAG_COMPENSATION = 1.05;
+  // FuelPhysicsSim applies aerodynamic drag (Cd=0.47) which slows the ball ~4-5%
+  // over typical flight distances. This factor bumps the vacuum-trajectory exit
+  // speed so the ball arrives with enough energy to clear the hub rim.
+  private static final double DRAG_COMPENSATION = 1.05;
 
-    public SimFuelManager(FuelPhysicsSim sim) {
-        this.sim = sim;
-    }
+  public SimFuelManager(FuelPhysicsSim sim) {
+    this.sim = sim;
+  }
 
-    public SimFuelManager(String tableKey) {
-        this(new FuelPhysicsSim(tableKey));
-    }
+  public SimFuelManager(String tableKey) {
+    this(new FuelPhysicsSim(tableKey));
+  }
 
-    /** Wire robot pose and speed suppliers so the sim can do bumper collisions. */
-    public void configureRobot(
-            double width,
-            double length,
-            double bumperHeight,
-            Supplier<Pose2d> poseSupplier,
-            Supplier<ChassisSpeeds> speedsSupplier) {
-        sim.configureRobot(width, length, bumperHeight, poseSupplier, speedsSupplier);
-    }
+  /** Wire robot pose and speed suppliers so the sim can do bumper collisions. */
+  public void configureRobot(
+      double width,
+      double length,
+      double bumperHeight,
+      Supplier<Pose2d> poseSupplier,
+      Supplier<ChassisSpeeds> speedsSupplier) {
+    sim.configureRobot(width, length, bumperHeight, poseSupplier, speedsSupplier);
+  }
 
-    /** Register a bounding box where balls get picked up when the intake is running. */
-    public void addIntakeZone(
-            double xMin, double xMax, double yMin, double yMax, BooleanSupplier active) {
-        intakeRegistered = true;
-        sim.addIntakeZone(
-                xMin,
-                xMax,
-                yMin,
-                yMax,
-                active,
-                () -> {
-                    if (ballsHeld < MAX_BALLS_HELD) {
-                        ballsHeld++;
-                    }
-                });
-    }
+  /** Register a bounding box where balls get picked up when the intake is running. */
+  public void addIntakeZone(
+      double xMin, double xMax, double yMin, double yMax, BooleanSupplier active) {
+    intakeRegistered = true;
+    sim.addIntakeZone(
+        xMin,
+        xMax,
+        yMin,
+        yMax,
+        active,
+        () -> {
+          if (ballsHeld < MAX_BALLS_HELD) {
+            ballsHeld++;
+          }
+        });
+  }
 
-    /** Call each simulationPeriodic(). Runs shot detection, physics step, and logging. */
-    public void update(boolean shotSignal, Pose2d robotPose, double robotYaw, double shooterRPM) {
-        try {
-            boolean isEnabled = enabled.get() >= 0.5;
-            SafeLog.put("Sim/Fuel/Enabled", isEnabled);
+  /** Call each simulationPeriodic(). Runs shot detection, physics step, and logging. */
+  public void update(boolean shotSignal, Pose2d robotPose, double robotYaw, double shooterRPM) {
+    try {
+      boolean isEnabled = enabled.get() >= 0.5;
+      SafeLog.put("Sim/Fuel/Enabled", isEnabled);
 
-            if (!isEnabled) return;
+      if (!isEnabled) return;
 
-            // Update feature flags from TunableNumbers
-            updateConfigFromTunables();
+      // Update feature flags from TunableNumbers
+      updateConfigFromTunables();
 
-            // Detect rising edge of shot signal.
-            // When intake is registered, require ballsHeld > 0 (realistic practice mode).
-            // When no intake registered, fire freely (tests and scenarios).
-            if (shotSignal && !lastShotSignal && shooterRPM > 100) {
-                if (!intakeRegistered || ballsHeld > 0) {
-                    if (adaptiveShotSpeed) {
-                        launchAdaptive(robotPose, robotYaw);
-                    } else {
-                        launchAtRPM(robotPose, robotYaw, shooterRPM);
-                    }
-                    if (intakeRegistered && ballsHeld > 0) {
-                        ballsHeld--;
-                    }
-                }
-            }
-            lastShotSignal = shotSignal;
-
-            // Update static flag for ScoringTelemetry
-            simBallPresent = !intakeRegistered || ballsHeld > 0;
-
-            // Run physics
-            long startNs = System.nanoTime();
-            sim.tick();
-            double elapsedMs = (System.nanoTime() - startNs) / 1_000_000.0;
-
-            // Actual ball trail: track the highest in-flight ball each frame
-            lastRobotPose = robotPose;
-            updateActualBallTrail();
-
-            // Log telemetry
-            SafeLog.put("Sim/Fuel/BallsInFlight", sim.getBallsInFlight());
-            SafeLog.put("Sim/Fuel/BallsOnGround", sim.getBallsOnGround());
-            SafeLog.put("Sim/Fuel/TotalLaunched", sim.getTotalLaunched());
-            SafeLog.put("Sim/Fuel/TotalScored", sim.getTotalScored());
-            SafeLog.put("Sim/Fuel/TotalIntaked", sim.getTotalIntaked());
-            SafeLog.put("Sim/Fuel/BallsHeld", ballsHeld);
-            SafeLog.put("Sim/Fuel/LastLaunchSpeedMps", sim.getLastLaunchSpeed());
-            SafeLog.put("Sim/Fuel/PhysicsStepMs", elapsedMs);
-            SafeLog.put("Sim/Fuel/ActualBallTrail", actualBallTrail);
-
-            // Height diagnostics: count balls in Z ranges to identify floating balls
-            int above05 = 0, above1 = 0, above2 = 0;
-            double maxZ = 0;
-            for (var pos : sim.getBallPositions()) {
-                double z = pos.getZ();
-                if (z > maxZ) maxZ = z;
-                if (z > 0.5) above05++;
-                if (z > 1.0) above1++;
-                if (z > 2.0) above2++;
-            }
-            SafeLog.put("Sim/Fuel/Debug/MaxZ", maxZ);
-            SafeLog.put("Sim/Fuel/Debug/Above05m", above05);
-            SafeLog.put("Sim/Fuel/Debug/Above1m", above1);
-            SafeLog.put("Sim/Fuel/Debug/Above2m", above2);
-        } catch (Throwable t) {
-            // Never let fuel sim crash the robot sim loop
-            SafeLog.put("Sim/Fuel/Error", t.getClass().getSimpleName());
+      // Detect rising edge of shot signal.
+      // When intake is registered, require ballsHeld > 0 (realistic practice mode).
+      // When no intake registered, fire freely (tests and scenarios).
+      if (shotSignal && !lastShotSignal && shooterRPM > 100) {
+        if (!intakeRegistered || ballsHeld > 0) {
+          if (adaptiveShotSpeed) {
+            launchAdaptive(robotPose, robotYaw);
+          } else {
+            launchAtRPM(robotPose, robotYaw, shooterRPM);
+          }
+          if (intakeRegistered && ballsHeld > 0) {
+            ballsHeld--;
+          }
         }
+      }
+      lastShotSignal = shotSignal;
+
+      // Update static flag for ScoringTelemetry
+      simBallPresent = !intakeRegistered || ballsHeld > 0;
+
+      // Run physics
+      long startNs = System.nanoTime();
+      sim.tick();
+      double elapsedMs = (System.nanoTime() - startNs) / 1_000_000.0;
+
+      // Actual ball trail: track the highest in-flight ball each frame
+      lastRobotPose = robotPose;
+      updateActualBallTrail();
+
+      // Log telemetry
+      SafeLog.put("Sim/Fuel/BallsInFlight", sim.getBallsInFlight());
+      SafeLog.put("Sim/Fuel/BallsOnGround", sim.getBallsOnGround());
+      SafeLog.put("Sim/Fuel/TotalLaunched", sim.getTotalLaunched());
+      SafeLog.put("Sim/Fuel/TotalScored", sim.getTotalScored());
+      SafeLog.put("Sim/Fuel/TotalIntaked", sim.getTotalIntaked());
+      SafeLog.put("Sim/Fuel/BallsHeld", ballsHeld);
+      SafeLog.put("Sim/Fuel/LastLaunchSpeedMps", sim.getLastLaunchSpeed());
+      SafeLog.put("Sim/Fuel/PhysicsStepMs", elapsedMs);
+      SafeLog.put("Sim/Fuel/ActualBallTrail", actualBallTrail);
+
+      // Height diagnostics: count balls in Z ranges to identify floating balls
+      int above05 = 0, above1 = 0, above2 = 0;
+      double maxZ = 0;
+      for (var pos : sim.getBallPositions()) {
+        double z = pos.getZ();
+        if (z > maxZ) maxZ = z;
+        if (z > 0.5) above05++;
+        if (z > 1.0) above1++;
+        if (z > 2.0) above2++;
+      }
+      SafeLog.put("Sim/Fuel/Debug/MaxZ", maxZ);
+      SafeLog.put("Sim/Fuel/Debug/Above05m", above05);
+      SafeLog.put("Sim/Fuel/Debug/Above1m", above1);
+      SafeLog.put("Sim/Fuel/Debug/Above2m", above2);
+    } catch (Throwable t) {
+      // Never let fuel sim crash the robot sim loop
+      SafeLog.put("Sim/Fuel/Error", t.getClass().getSimpleName());
+    }
+  }
+
+  /**
+   * Track the highest in-flight ball's XY position each frame after a new shot launches. When the
+   * ball scores (gets removed by BallPhysicsSim), extend the trail to the hub center so you see the
+   * full path. When the ball misses and lands, freeze the trail as-is.
+   */
+  private void updateActualBallTrail() {
+    int totalLaunched = sim.getTotalLaunched();
+    int totalScored = sim.getTotalScored();
+
+    // New shot fired: reset trail and start tracking
+    if (totalLaunched > prevTotalLaunched) {
+      trackingBall = true;
+      actualTrailCount = 0;
+    }
+    prevTotalLaunched = totalLaunched;
+
+    // Ball scored: extend trail to hub center and stop tracking
+    if (trackingBall
+        && totalScored > prevTotalScored
+        && actualTrailCount > 0
+        && actualTrailCount < MAX_TRAIL_POINTS) {
+      Translation2d hub = (lastRobotPose != null) ? getNearestHub(lastRobotPose) : BLUE_HUB;
+      double dx = hub.getX() - actualTrailBuffer[actualTrailCount - 1].getX();
+      double dy = hub.getY() - actualTrailBuffer[actualTrailCount - 1].getY();
+      actualTrailBuffer[actualTrailCount++] =
+          new Pose2d(hub.getX(), hub.getY(), new Rotation2d(Math.atan2(dy, dx)));
+      actualBallTrail = new Pose2d[actualTrailCount];
+      System.arraycopy(actualTrailBuffer, 0, actualBallTrail, 0, actualTrailCount);
+      trackingBall = false;
+    }
+    prevTotalScored = totalScored;
+
+    if (!trackingBall) return;
+
+    // Find the highest-Z ball (most likely the one we just shot)
+    List<Translation3d> positions = sim.getBallPositions();
+    Translation3d highest = null;
+    double maxZ = -1;
+    for (Translation3d pos : positions) {
+      if (pos.getZ() > maxZ) {
+        maxZ = pos.getZ();
+        highest = pos;
+      }
     }
 
-    /**
-     * Track the highest in-flight ball's XY position each frame after a new shot launches. When the
-     * ball scores (gets removed by BallPhysicsSim), extend the trail to the hub center so you see
-     * the full path. When the ball misses and lands, freeze the trail as-is.
-     */
-    private void updateActualBallTrail() {
-        int totalLaunched = sim.getTotalLaunched();
-        int totalScored = sim.getTotalScored();
+    // Record its XY if still in flight (Z > 0.3m, above ground resting height)
+    if (highest != null && maxZ > 0.3 && actualTrailCount < MAX_TRAIL_POINTS) {
+      double dx = 0, dy = 0;
+      if (actualTrailCount > 0) {
+        dx = highest.getX() - actualTrailBuffer[actualTrailCount - 1].getX();
+        dy = highest.getY() - actualTrailBuffer[actualTrailCount - 1].getY();
+      }
+      actualTrailBuffer[actualTrailCount++] =
+          new Pose2d(highest.getX(), highest.getY(), new Rotation2d(Math.atan2(dy, dx)));
 
-        // New shot fired: reset trail and start tracking
-        if (totalLaunched > prevTotalLaunched) {
-            trackingBall = true;
-            actualTrailCount = 0;
-        }
-        prevTotalLaunched = totalLaunched;
-
-        // Ball scored: extend trail to hub center and stop tracking
-        if (trackingBall
-                && totalScored > prevTotalScored
-                && actualTrailCount > 0
-                && actualTrailCount < MAX_TRAIL_POINTS) {
-            Translation2d hub = (lastRobotPose != null) ? getNearestHub(lastRobotPose) : BLUE_HUB;
-            double dx = hub.getX() - actualTrailBuffer[actualTrailCount - 1].getX();
-            double dy = hub.getY() - actualTrailBuffer[actualTrailCount - 1].getY();
-            actualTrailBuffer[actualTrailCount++] =
-                    new Pose2d(hub.getX(), hub.getY(), new Rotation2d(Math.atan2(dy, dx)));
-            actualBallTrail = new Pose2d[actualTrailCount];
-            System.arraycopy(actualTrailBuffer, 0, actualBallTrail, 0, actualTrailCount);
-            trackingBall = false;
-        }
-        prevTotalScored = totalScored;
-
-        if (!trackingBall) return;
-
-        // Find the highest-Z ball (most likely the one we just shot)
-        List<Translation3d> positions = sim.getBallPositions();
-        Translation3d highest = null;
-        double maxZ = -1;
-        for (Translation3d pos : positions) {
-            if (pos.getZ() > maxZ) {
-                maxZ = pos.getZ();
-                highest = pos;
-            }
-        }
-
-        // Record its XY if still in flight (Z > 0.3m, above ground resting height)
-        if (highest != null && maxZ > 0.3 && actualTrailCount < MAX_TRAIL_POINTS) {
-            double dx = 0, dy = 0;
-            if (actualTrailCount > 0) {
-                dx = highest.getX() - actualTrailBuffer[actualTrailCount - 1].getX();
-                dy = highest.getY() - actualTrailBuffer[actualTrailCount - 1].getY();
-            }
-            actualTrailBuffer[actualTrailCount++] =
-                    new Pose2d(highest.getX(), highest.getY(), new Rotation2d(Math.atan2(dy, dx)));
-
-            // Build output array
-            actualBallTrail = new Pose2d[actualTrailCount];
-            System.arraycopy(actualTrailBuffer, 0, actualBallTrail, 0, actualTrailCount);
-        } else if (maxZ <= 0.3) {
-            // Ball missed and landed on ground, stop tracking
-            trackingBall = false;
-        }
+      // Build output array
+      actualBallTrail = new Pose2d[actualTrailCount];
+      System.arraycopy(actualTrailBuffer, 0, actualBallTrail, 0, actualTrailCount);
+    } else if (maxZ <= 0.3) {
+      // Ball missed and landed on ground, stop tracking
+      trackingBall = false;
     }
+  }
 
-    /**
-     * Compute vacuum-trajectory exit speed to lob a ball from distance d at our fixed angle into
-     * the hub entry. Adds drag compensation for FuelPhysicsSim air resistance.
-     *
-     * <p>From projectile kinematics: v² = g·d² / (2·cos²(θ)·(z₀ + d·tan(θ) - h))
-     *
-     * @return required exit speed in m/s, or -1 if the shot geometry is impossible
-     */
-    private double computeExitSpeedForDistance(double horizontalDist) {
-        double theta = Math.toRadians(FIXED_LAUNCH_ANGLE_DEG);
-        double cosTheta = Math.cos(theta);
-        double tanTheta = Math.tan(theta);
-        double denom =
-                2.0
-                        * cosTheta
-                        * cosTheta
-                        * (EXIT_HEIGHT_M + horizontalDist * tanTheta - HUB_ENTRY_HEIGHT);
-        if (denom <= 0) return -1;
-        return DRAG_COMPENSATION * Math.sqrt(GRAVITY * horizontalDist * horizontalDist / denom);
-    }
+  /**
+   * Compute vacuum-trajectory exit speed to lob a ball from distance d at our fixed angle into the
+   * hub entry. Adds drag compensation for FuelPhysicsSim air resistance.
+   *
+   * <p>From projectile kinematics: v² = g·d² / (2·cos²(θ)·(z₀ + d·tan(θ) - h))
+   *
+   * @return required exit speed in m/s, or -1 if the shot geometry is impossible
+   */
+  private double computeExitSpeedForDistance(double horizontalDist) {
+    double theta = Math.toRadians(FIXED_LAUNCH_ANGLE_DEG);
+    double cosTheta = Math.cos(theta);
+    double tanTheta = Math.tan(theta);
+    double denom =
+        2.0 * cosTheta * cosTheta * (EXIT_HEIGHT_M + horizontalDist * tanTheta - HUB_ENTRY_HEIGHT);
+    if (denom <= 0) return -1;
+    return DRAG_COMPENSATION * Math.sqrt(GRAVITY * horizontalDist * horizontalDist / denom);
+  }
 
-    /** Pick the hub on the robot's half of the field. */
-    private Translation2d getNearestHub(Pose2d robotPose) {
-        return (robotPose.getX() > FIELD_MID_X) ? RED_HUB : BLUE_HUB;
-    }
+  /** Pick the hub on the robot's half of the field. */
+  private Translation2d getNearestHub(Pose2d robotPose) {
+    return (robotPose.getX() > FIELD_MID_X) ? RED_HUB : BLUE_HUB;
+  }
 
-    /**
-     * Launch a ball with distance-adaptive exit speed. Computes the exact speed needed to reach the
-     * nearest hub from the robot's current position, so shots score from any distance (not just one
-     * tuned distance).
-     */
-    private void launchAdaptive(Pose2d robotPose, double robotYaw) {
-        Translation3d launchPos =
-                new Translation3d(robotPose.getX(), robotPose.getY(), EXIT_HEIGHT_M);
+  /**
+   * Launch a ball with distance-adaptive exit speed. Computes the exact speed needed to reach the
+   * nearest hub from the robot's current position, so shots score from any distance (not just one
+   * tuned distance).
+   */
+  private void launchAdaptive(Pose2d robotPose, double robotYaw) {
+    Translation3d launchPos = new Translation3d(robotPose.getX(), robotPose.getY(), EXIT_HEIGHT_M);
 
-        Translation2d hub = getNearestHub(robotPose);
-        double dx = hub.getX() - robotPose.getX();
-        double dy = hub.getY() - robotPose.getY();
-        double horizontalDist = Math.sqrt(dx * dx + dy * dy);
+    Translation2d hub = getNearestHub(robotPose);
+    double dx = hub.getX() - robotPose.getX();
+    double dy = hub.getY() - robotPose.getY();
+    double horizontalDist = Math.sqrt(dx * dx + dy * dy);
 
-        double exitSpeed = computeExitSpeedForDistance(horizontalDist);
-        if (exitSpeed < 0) exitSpeed = 7.0; // fallback for impossible geometry
+    double exitSpeed = computeExitSpeedForDistance(horizontalDist);
+    if (exitSpeed < 0) exitSpeed = 7.0; // fallback for impossible geometry
 
-        double launchAngleRad = Math.toRadians(FIXED_LAUNCH_ANGLE_DEG);
-        double vHorizontal = exitSpeed * Math.cos(launchAngleRad);
-        double vVertical = exitSpeed * Math.sin(launchAngleRad);
+    double launchAngleRad = Math.toRadians(FIXED_LAUNCH_ANGLE_DEG);
+    double vHorizontal = exitSpeed * Math.cos(launchAngleRad);
+    double vVertical = exitSpeed * Math.sin(launchAngleRad);
 
-        double vx = vHorizontal * Math.cos(robotYaw);
-        double vy = vHorizontal * Math.sin(robotYaw);
+    double vx = vHorizontal * Math.cos(robotYaw);
+    double vy = vHorizontal * Math.sin(robotYaw);
 
-        Translation3d launchVel = new Translation3d(vx, vy, vVertical);
-        sim.launchBall(launchPos, launchVel, DEFAULT_SPIN_RPM);
-    }
+    Translation3d launchVel = new Translation3d(vx, vy, vVertical);
+    sim.launchBall(launchPos, launchVel, DEFAULT_SPIN_RPM);
+  }
 
-    /** Launch a ball using raw RPM-to-speed conversion. For testing specific RPM values. */
-    private void launchAtRPM(Pose2d robotPose, double robotYaw, double shooterRPM) {
-        Translation3d launchPos =
-                new Translation3d(robotPose.getX(), robotPose.getY(), EXIT_HEIGHT_M);
+  /** Launch a ball using raw RPM-to-speed conversion. For testing specific RPM values. */
+  private void launchAtRPM(Pose2d robotPose, double robotYaw, double shooterRPM) {
+    Translation3d launchPos = new Translation3d(robotPose.getX(), robotPose.getY(), EXIT_HEIGHT_M);
 
-        double launchAngleRad = Math.toRadians(FIXED_LAUNCH_ANGLE_DEG);
-        double exitSpeed = SLIP_FACTOR * shooterRPM * Math.PI * WHEEL_DIAMETER_M / 60.0;
-        double vHorizontal = exitSpeed * Math.cos(launchAngleRad);
-        double vVertical = exitSpeed * Math.sin(launchAngleRad);
+    double launchAngleRad = Math.toRadians(FIXED_LAUNCH_ANGLE_DEG);
+    double exitSpeed = SLIP_FACTOR * shooterRPM * Math.PI * WHEEL_DIAMETER_M / 60.0;
+    double vHorizontal = exitSpeed * Math.cos(launchAngleRad);
+    double vVertical = exitSpeed * Math.sin(launchAngleRad);
 
-        double vx = vHorizontal * Math.cos(robotYaw);
-        double vy = vHorizontal * Math.sin(robotYaw);
+    double vx = vHorizontal * Math.cos(robotYaw);
+    double vy = vHorizontal * Math.sin(robotYaw);
 
-        Translation3d launchVel = new Translation3d(vx, vy, vVertical);
-        sim.launchBall(launchPos, launchVel, DEFAULT_SPIN_RPM);
-    }
+    Translation3d launchVel = new Translation3d(vx, vy, vVertical);
+    sim.launchBall(launchPos, launchVel, DEFAULT_SPIN_RPM);
+  }
 
-    private void updateConfigFromTunables() {
-        FuelPhysicsSim.PhysicsConfig cfg = sim.getConfig();
-        cfg.subticks = Math.max(1, (int) subticks.get());
-        cfg.magnusEnabled = magnusToggle.get() >= 0.5;
-        cfg.frictionEnabled = frictionToggle.get() >= 0.5;
-        cfg.sleepingEnabled = sleepingToggle.get() >= 0.5;
-        cfg.ccdEnabled = ccdToggle.get() >= 0.5;
-    }
+  private void updateConfigFromTunables() {
+    FuelPhysicsSim.PhysicsConfig cfg = sim.getConfig();
+    cfg.subticks = Math.max(1, (int) subticks.get());
+    cfg.magnusEnabled = magnusToggle.get() >= 0.5;
+    cfg.frictionEnabled = frictionToggle.get() >= 0.5;
+    cfg.sleepingEnabled = sleepingToggle.get() >= 0.5;
+    cfg.ccdEnabled = ccdToggle.get() >= 0.5;
+  }
 
-    /**
-     * Force-launch a ball at a specific RPM, bypassing normal shot detection. Used by test
-     * scenarios to sweep RPM ranges.
-     */
-    public void forceShot(Pose2d robotPose, double robotYaw, double overrideRPM) {
-        launchAtRPM(robotPose, robotYaw, overrideRPM);
-    }
+  /**
+   * Force-launch a ball at a specific RPM, bypassing normal shot detection. Used by test scenarios
+   * to sweep RPM ranges.
+   */
+  public void forceShot(Pose2d robotPose, double robotYaw, double overrideRPM) {
+    launchAtRPM(robotPose, robotYaw, overrideRPM);
+  }
 
-    /**
-     * Force-launch with distance-adaptive exit speed. Computes the right speed to score from any
-     * distance. Used by distance sweep test scenarios.
-     */
-    public void forceShotAdaptive(Pose2d robotPose, double robotYaw) {
-        launchAdaptive(robotPose, robotYaw);
-    }
+  /**
+   * Force-launch with distance-adaptive exit speed. Computes the right speed to score from any
+   * distance. Used by distance sweep test scenarios.
+   */
+  public void forceShotAdaptive(Pose2d robotPose, double robotYaw) {
+    launchAdaptive(robotPose, robotYaw);
+  }
 
-    public FuelPhysicsSim getSim() {
-        return sim;
-    }
+  public FuelPhysicsSim getSim() {
+    return sim;
+  }
 
-    public void placeFieldBalls() {
-        sim.placeFieldBalls();
-    }
+  public void placeFieldBalls() {
+    sim.placeFieldBalls();
+  }
 
-    public void enable() {
-        sim.enable();
-    }
+  public void enable() {
+    sim.enable();
+  }
 
-    public void disable() {
-        sim.disable();
-    }
+  public void disable() {
+    sim.disable();
+  }
 
-    public void clearBalls() {
-        sim.clearBalls();
-    }
+  public void clearBalls() {
+    sim.clearBalls();
+  }
 }

--- a/src/main/java/frc/robot/telemetry/SafeLog.java
+++ b/src/main/java/frc/robot/telemetry/SafeLog.java
@@ -3,157 +3,155 @@ package frc.robot.telemetry;
 import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.math.geometry.Pose3d;
 import edu.wpi.first.math.kinematics.SwerveModuleState;
-
-import org.littletonrobotics.junction.Logger;
-
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
+import org.littletonrobotics.junction.Logger;
 
 /** Wraps Logger.recordOutput() so one bad signal can't crash the whole robot. */
 public final class SafeLog {
-    private static final AtomicInteger cycleFailures = new AtomicInteger(0);
-    private static final AtomicReference<String> lastFailedKey = new AtomicReference<>("");
+  private static final AtomicInteger cycleFailures = new AtomicInteger(0);
+  private static final AtomicReference<String> lastFailedKey = new AtomicReference<>("");
 
-    private SafeLog() {}
+  private SafeLog() {}
 
-    public static void put(String key, double value) {
-        try {
-            Logger.recordOutput(key, value);
-        } catch (Throwable t) {
-            recordFailure(key);
-        }
+  public static void put(String key, double value) {
+    try {
+      Logger.recordOutput(key, value);
+    } catch (Throwable t) {
+      recordFailure(key);
     }
+  }
 
-    public static void put(String key, boolean value) {
-        try {
-            Logger.recordOutput(key, value);
-        } catch (Throwable t) {
-            recordFailure(key);
-        }
+  public static void put(String key, boolean value) {
+    try {
+      Logger.recordOutput(key, value);
+    } catch (Throwable t) {
+      recordFailure(key);
     }
+  }
 
-    public static void put(String key, int value) {
-        try {
-            Logger.recordOutput(key, value);
-        } catch (Throwable t) {
-            recordFailure(key);
-        }
+  public static void put(String key, int value) {
+    try {
+      Logger.recordOutput(key, value);
+    } catch (Throwable t) {
+      recordFailure(key);
     }
+  }
 
-    public static void put(String key, long value) {
-        try {
-            Logger.recordOutput(key, value);
-        } catch (Throwable t) {
-            recordFailure(key);
-        }
+  public static void put(String key, long value) {
+    try {
+      Logger.recordOutput(key, value);
+    } catch (Throwable t) {
+      recordFailure(key);
     }
+  }
 
-    public static void put(String key, String value) {
-        try {
-            Logger.recordOutput(key, value);
-        } catch (Throwable t) {
-            recordFailure(key);
-        }
+  public static void put(String key, String value) {
+    try {
+      Logger.recordOutput(key, value);
+    } catch (Throwable t) {
+      recordFailure(key);
     }
+  }
 
-    public static void put(String key, double[] value) {
-        try {
-            Logger.recordOutput(key, value);
-        } catch (Throwable t) {
-            recordFailure(key);
-        }
+  public static void put(String key, double[] value) {
+    try {
+      Logger.recordOutput(key, value);
+    } catch (Throwable t) {
+      recordFailure(key);
     }
+  }
 
-    public static void put(String key, String[] value) {
-        try {
-            Logger.recordOutput(key, value);
-        } catch (Throwable t) {
-            recordFailure(key);
-        }
+  public static void put(String key, String[] value) {
+    try {
+      Logger.recordOutput(key, value);
+    } catch (Throwable t) {
+      recordFailure(key);
     }
+  }
 
-    public static void put(String key, int[] value) {
-        try {
-            Logger.recordOutput(key, value);
-        } catch (Throwable t) {
-            recordFailure(key);
-        }
+  public static void put(String key, int[] value) {
+    try {
+      Logger.recordOutput(key, value);
+    } catch (Throwable t) {
+      recordFailure(key);
     }
+  }
 
-    public static void put(String key, Pose2d value) {
-        try {
-            Logger.recordOutput(key, value);
-        } catch (Throwable t) {
-            recordFailure(key);
-        }
+  public static void put(String key, Pose2d value) {
+    try {
+      Logger.recordOutput(key, value);
+    } catch (Throwable t) {
+      recordFailure(key);
     }
+  }
 
-    public static void put(String key, Pose3d value) {
-        try {
-            Logger.recordOutput(key, value);
-        } catch (Throwable t) {
-            recordFailure(key);
-        }
+  public static void put(String key, Pose3d value) {
+    try {
+      Logger.recordOutput(key, value);
+    } catch (Throwable t) {
+      recordFailure(key);
     }
+  }
 
-    public static void put(String key, Pose2d[] value) {
-        try {
-            Logger.recordOutput(key, value);
-        } catch (Throwable t) {
-            recordFailure(key);
-        }
+  public static void put(String key, Pose2d[] value) {
+    try {
+      Logger.recordOutput(key, value);
+    } catch (Throwable t) {
+      recordFailure(key);
     }
+  }
 
-    public static void put(String key, Pose3d[] value) {
-        try {
-            Logger.recordOutput(key, value);
-        } catch (Throwable t) {
-            recordFailure(key);
-        }
+  public static void put(String key, Pose3d[] value) {
+    try {
+      Logger.recordOutput(key, value);
+    } catch (Throwable t) {
+      recordFailure(key);
     }
+  }
 
-    public static void put(String key, SwerveModuleState[] value) {
-        try {
-            Logger.recordOutput(key, value);
-        } catch (Throwable t) {
-            recordFailure(key);
-        }
+  public static void put(String key, SwerveModuleState[] value) {
+    try {
+      Logger.recordOutput(key, value);
+    } catch (Throwable t) {
+      recordFailure(key);
     }
+  }
 
-    /** Run an action, swallowing any exception. */
-    public static void run(Runnable action) {
-        try {
-            action.run();
-        } catch (Throwable t) {
-            // swallow
-        }
+  /** Run an action, swallowing any exception. */
+  public static void run(Runnable action) {
+    try {
+      action.run();
+    } catch (Throwable t) {
+      // swallow
     }
+  }
 
-    private static void recordFailure(String key) {
-        cycleFailures.incrementAndGet();
-        lastFailedKey.set(key);
-    }
+  private static void recordFailure(String key) {
+    cycleFailures.incrementAndGet();
+    lastFailedKey.set(key);
+  }
 
-    public static int getCycleFailures() {
-        return cycleFailures.get();
-    }
+  public static int getCycleFailures() {
+    return cycleFailures.get();
+  }
 
-    public static String getLastFailedKey() {
-        return lastFailedKey.get();
-    }
+  public static String getLastFailedKey() {
+    return lastFailedKey.get();
+  }
 
-    /** Log health metrics and reset. Call once per cycle after all telemetry. */
-    public static void logAndReset() {
-        try {
-            int failures = cycleFailures.get();
-            if (failures > 0) {
-                Logger.recordOutput("Health/SafeLog/CycleFailures", failures);
-                Logger.recordOutput("Health/SafeLog/LastFailedKey", lastFailedKey.get());
-            }
-        } catch (Throwable t) {
-            // If even health logging fails, nothing we can do
-        }
-        cycleFailures.set(0);
-        lastFailedKey.set("");
+  /** Log health metrics and reset. Call once per cycle after all telemetry. */
+  public static void logAndReset() {
+    try {
+      int failures = cycleFailures.get();
+      if (failures > 0) {
+        Logger.recordOutput("Health/SafeLog/CycleFailures", failures);
+        Logger.recordOutput("Health/SafeLog/LastFailedKey", lastFailedKey.get());
+      }
+    } catch (Throwable t) {
+      // If even health logging fails, nothing we can do
     }
+    cycleFailures.set(0);
+    lastFailedKey.set("");
+  }
 }

--- a/src/test/java/frc/robot/sim/DragBallProjectileTest.java
+++ b/src/test/java/frc/robot/sim/DragBallProjectileTest.java
@@ -4,9 +4,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import edu.wpi.first.hal.HAL;
 import edu.wpi.first.math.geometry.Translation3d;
-
 import frc.robot.sim.FuelPhysicsSim.PhysicsConfig;
-
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -14,259 +12,246 @@ import org.junit.jupiter.api.Test;
 /** Physics trajectory tests: drag, Magnus, and spin decay vs. analytical baselines. */
 class DragBallProjectileTest {
 
-    private FuelPhysicsSim sim;
-    private PhysicsConfig config;
+  private FuelPhysicsSim sim;
+  private PhysicsConfig config;
 
-    @BeforeAll
-    static void initHAL() {
-        HAL.initialize(500, 0);
+  @BeforeAll
+  static void initHAL() {
+    HAL.initialize(500, 0);
+  }
+
+  @BeforeEach
+  void setUp() {
+    config = new PhysicsConfig();
+    config.deterministic = true;
+    config.deterministicSeed = 42L;
+    config.sleepingEnabled = false;
+    config.subticks = 10; // Higher subticks for trajectory accuracy
+    config.conservationMonitor = true;
+    sim = new FuelPhysicsSim("Test/DragBall", config);
+    sim.enable();
+  }
+
+  @Test
+  void dragReducesRangeVsVacuum() {
+    // Compute vacuum range analytically
+    double vx = 10.0, vz = 10.0;
+    double v = Math.sqrt(vx * vx + vz * vz);
+    double theta = Math.atan2(vz, vx);
+    double vacuumRange = v * v * Math.sin(2 * theta) / 9.81;
+
+    // With drag (default Cd=0.47); Y=1 avoids hub geometry
+    config.magnusEnabled = false;
+    config.frictionEnabled = false;
+    sim.setConfig(config);
+
+    sim.launchBall(
+        new Translation3d(2, 1, FuelPhysicsSim.getBallRadius()), new Translation3d(vx, 0, vz), 0);
+
+    double maxX = 2;
+    for (int i = 0; i < 500; i++) {
+      sim.advancePhysics(0.02);
+      if (sim.getBallCount() > 0) {
+        maxX = Math.max(maxX, sim.getBallPositions().get(0).getX());
+      }
     }
 
-    @BeforeEach
-    void setUp() {
-        config = new PhysicsConfig();
-        config.deterministic = true;
-        config.deterministicSeed = 42L;
-        config.sleepingEnabled = false;
-        config.subticks = 10; // Higher subticks for trajectory accuracy
-        config.conservationMonitor = true;
-        sim = new FuelPhysicsSim("Test/DragBall", config);
-        sim.enable();
+    double dragRange = maxX - 2.0;
+    assertTrue(
+        dragRange < vacuumRange * 0.95,
+        "Drag should reduce range by at least 5%: drag=" + dragRange + " vacuum=" + vacuumRange);
+    assertTrue(
+        dragRange > vacuumRange * 0.3,
+        "Drag shouldn't reduce range by more than 70%: drag=" + dragRange);
+  }
+
+  @Test
+  void magnusBackspinAddsLift() {
+    config.frictionEnabled = false;
+    config.spinDecayEnabled = false;
+    sim.setConfig(config);
+
+    // Y=7.5 avoids hub geometry entirely (hub ramp Y range is [1.28, 6.79])
+    sim.launchBall(
+        new Translation3d(3, 7.5, 0.5), new Translation3d(10, 0, 5), 3000); // 3000 RPM backspin
+
+    double maxZWithSpin = 0;
+    for (int i = 0; i < 300; i++) {
+      sim.advancePhysics(0.02);
+      if (sim.getBallCount() > 0) {
+        maxZWithSpin = Math.max(maxZWithSpin, sim.getBallPositions().get(0).getZ());
+      }
     }
 
-    @Test
-    void dragReducesRangeVsVacuum() {
-        // Compute vacuum range analytically
-        double vx = 10.0, vz = 10.0;
-        double v = Math.sqrt(vx * vx + vz * vz);
-        double theta = Math.atan2(vz, vx);
-        double vacuumRange = v * v * Math.sin(2 * theta) / 9.81;
+    // Without backspin (new sim, no Magnus)
+    PhysicsConfig noMagnusCfg = config.copy();
+    noMagnusCfg.magnusEnabled = false;
+    FuelPhysicsSim simNoSpin = new FuelPhysicsSim("Test/NoMagnus", noMagnusCfg);
+    simNoSpin.enable();
+    simNoSpin.launchBall(new Translation3d(3, 7.5, 0.5), new Translation3d(10, 0, 5), 0);
 
-        // With drag (default Cd=0.47); Y=1 avoids hub geometry
-        config.magnusEnabled = false;
-        config.frictionEnabled = false;
-        sim.setConfig(config);
-
-        sim.launchBall(
-                new Translation3d(2, 1, FuelPhysicsSim.getBallRadius()),
-                new Translation3d(vx, 0, vz),
-                0);
-
-        double maxX = 2;
-        for (int i = 0; i < 500; i++) {
-            sim.advancePhysics(0.02);
-            if (sim.getBallCount() > 0) {
-                maxX = Math.max(maxX, sim.getBallPositions().get(0).getX());
-            }
-        }
-
-        double dragRange = maxX - 2.0;
-        assertTrue(
-                dragRange < vacuumRange * 0.95,
-                "Drag should reduce range by at least 5%: drag="
-                        + dragRange
-                        + " vacuum="
-                        + vacuumRange);
-        assertTrue(
-                dragRange > vacuumRange * 0.3,
-                "Drag shouldn't reduce range by more than 70%: drag=" + dragRange);
+    double maxZNoSpin = 0;
+    for (int i = 0; i < 300; i++) {
+      simNoSpin.advancePhysics(0.02);
+      if (simNoSpin.getBallCount() > 0) {
+        maxZNoSpin = Math.max(maxZNoSpin, simNoSpin.getBallPositions().get(0).getZ());
+      }
     }
 
-    @Test
-    void magnusBackspinAddsLift() {
-        config.frictionEnabled = false;
-        config.spinDecayEnabled = false;
-        sim.setConfig(config);
+    assertTrue(
+        maxZWithSpin > maxZNoSpin,
+        "Magnus backspin should increase apex: withSpin=" + maxZWithSpin + " noSpin=" + maxZNoSpin);
+  }
 
-        // Y=7.5 avoids hub geometry entirely (hub ramp Y range is [1.28, 6.79])
-        sim.launchBall(
-                new Translation3d(3, 7.5, 0.5),
-                new Translation3d(10, 0, 5),
-                3000); // 3000 RPM backspin
+  @Test
+  void trajectoryStartHeightCorrect() {
+    double startZ = 1.5;
+    sim.launchBall(new Translation3d(8, 4, startZ), new Translation3d(5, 0, 5), 0);
 
-        double maxZWithSpin = 0;
-        for (int i = 0; i < 300; i++) {
-            sim.advancePhysics(0.02);
-            if (sim.getBallCount() > 0) {
-                maxZWithSpin = Math.max(maxZWithSpin, sim.getBallPositions().get(0).getZ());
-            }
-        }
+    Translation3d pos = sim.getBallPositions().get(0);
+    assertEquals(startZ, pos.getZ(), 1e-6, "Initial height should match launch height");
+  }
 
-        // Without backspin (new sim, no Magnus)
-        PhysicsConfig noMagnusCfg = config.copy();
-        noMagnusCfg.magnusEnabled = false;
-        FuelPhysicsSim simNoSpin = new FuelPhysicsSim("Test/NoMagnus", noMagnusCfg);
-        simNoSpin.enable();
-        simNoSpin.launchBall(new Translation3d(3, 7.5, 0.5), new Translation3d(10, 0, 5), 0);
+  @Test
+  void zeroVelocityDropsStraight() {
+    config.magnusEnabled = false;
+    sim.setConfig(config);
 
-        double maxZNoSpin = 0;
-        for (int i = 0; i < 300; i++) {
-            simNoSpin.advancePhysics(0.02);
-            if (simNoSpin.getBallCount() > 0) {
-                maxZNoSpin = Math.max(maxZNoSpin, simNoSpin.getBallPositions().get(0).getZ());
-            }
-        }
+    sim.launchBall(new Translation3d(8, 4, 3), new Translation3d(0, 0, 0), 0);
 
-        assertTrue(
-                maxZWithSpin > maxZNoSpin,
-                "Magnus backspin should increase apex: withSpin="
-                        + maxZWithSpin
-                        + " noSpin="
-                        + maxZNoSpin);
+    for (int i = 0; i < 100; i++) sim.advancePhysics(0.02);
+
+    Translation3d pos = sim.getBallPositions().get(0);
+    assertEquals(8.0, pos.getX(), 0.01, "Ball with zero velocity should drop straight (X)");
+    assertEquals(4.0, pos.getY(), 0.01, "Ball with zero velocity should drop straight (Y)");
+    assertTrue(pos.getZ() < 3.0, "Ball should have fallen");
+  }
+
+  @Test
+  void highSpeedReachesFarther() {
+    config.magnusEnabled = false;
+    config.frictionEnabled = false;
+    sim.setConfig(config);
+
+    // Y=1 avoids hub geometry for both balls
+    FuelPhysicsSim simSlow = new FuelPhysicsSim("Test/Slow", config);
+    simSlow.enable();
+    simSlow.launchBall(new Translation3d(2, 1, 0.5), new Translation3d(5, 0, 5), 0);
+
+    FuelPhysicsSim simFast = new FuelPhysicsSim("Test/Fast", config);
+    simFast.enable();
+    simFast.launchBall(new Translation3d(2, 1, 0.5), new Translation3d(12, 0, 5), 0);
+
+    // Compare X positions at t=1s (50 steps). Both balls still mid-flight,
+    // before either reaches the far wall where maxX would be identical.
+    for (int i = 0; i < 50; i++) {
+      simSlow.advancePhysics(0.02);
+      simFast.advancePhysics(0.02);
     }
 
-    @Test
-    void trajectoryStartHeightCorrect() {
-        double startZ = 1.5;
-        sim.launchBall(new Translation3d(8, 4, startZ), new Translation3d(5, 0, 5), 0);
+    double xSlow = simSlow.getBallPositions().get(0).getX();
+    double xFast = simFast.getBallPositions().get(0).getX();
 
-        Translation3d pos = sim.getBallPositions().get(0);
-        assertEquals(startZ, pos.getZ(), 1e-6, "Initial height should match launch height");
+    assertTrue(
+        xFast > xSlow,
+        "Faster ball should be farther at t=1s: slow=" + (xSlow - 2) + " fast=" + (xFast - 2));
+  }
+
+  @Test
+  void gravityBringsItDown() {
+    sim.launchBall(new Translation3d(8, 4, 0.5), new Translation3d(5, 0, 15), 0);
+
+    // Track Z: should go up then come back down
+    double maxZ = 0;
+    boolean wentUp = false;
+    boolean cameDown = false;
+
+    for (int i = 0; i < 500; i++) {
+      sim.advancePhysics(0.02);
+      if (sim.getBallCount() > 0) {
+        double z = sim.getBallPositions().get(0).getZ();
+        if (z > 2.0) wentUp = true;
+        maxZ = Math.max(maxZ, z);
+        if (wentUp && z < maxZ * 0.5) cameDown = true;
+      }
     }
 
-    @Test
-    void zeroVelocityDropsStraight() {
-        config.magnusEnabled = false;
-        sim.setConfig(config);
+    assertTrue(wentUp, "Ball should go up");
+    assertTrue(cameDown, "Gravity should bring it back down");
+  }
 
-        sim.launchBall(new Translation3d(8, 4, 3), new Translation3d(0, 0, 0), 0);
+  @Test
+  void spinDecayReducesOmegaOverTime() {
+    config.magnusEnabled = false;
+    config.frictionEnabled = false;
+    config.spinDecayTau = 2.0;
+    sim.setConfig(config);
 
-        for (int i = 0; i < 100; i++) sim.advancePhysics(0.02);
+    double initialRPM = 5000;
+    sim.launchBall(new Translation3d(8, 4, 3), new Translation3d(0, 0, 0), initialRPM);
 
-        Translation3d pos = sim.getBallPositions().get(0);
-        assertEquals(8.0, pos.getX(), 0.01, "Ball with zero velocity should drop straight (X)");
-        assertEquals(4.0, pos.getY(), 0.01, "Ball with zero velocity should drop straight (Y)");
-        assertTrue(pos.getZ() < 3.0, "Ball should have fallen");
-    }
+    double initialOmega = Math.abs(sim.getBallOmegas().get(0).getY());
 
-    @Test
-    void highSpeedReachesFarther() {
-        config.magnusEnabled = false;
-        config.frictionEnabled = false;
-        sim.setConfig(config);
+    // Run for 2 * tau = 4 seconds
+    for (int i = 0; i < 200; i++) sim.advancePhysics(0.02);
 
-        // Y=1 avoids hub geometry for both balls
-        FuelPhysicsSim simSlow = new FuelPhysicsSim("Test/Slow", config);
-        simSlow.enable();
-        simSlow.launchBall(new Translation3d(2, 1, 0.5), new Translation3d(5, 0, 5), 0);
+    double finalOmega = Math.abs(sim.getBallOmegas().get(0).getY());
+    // At t = 2*tau, omega should be about e^(-2) = 13.5% of initial
+    double expectedRatio = Math.exp(-2.0);
 
-        FuelPhysicsSim simFast = new FuelPhysicsSim("Test/Fast", config);
-        simFast.enable();
-        simFast.launchBall(new Translation3d(2, 1, 0.5), new Translation3d(12, 0, 5), 0);
+    double actualRatio = finalOmega / initialOmega;
+    assertEquals(
+        expectedRatio,
+        actualRatio,
+        expectedRatio * 0.15,
+        "Spin decay should follow exponential: expected ratio="
+            + expectedRatio
+            + " actual="
+            + actualRatio);
+  }
 
-        // Compare X positions at t=1s (50 steps). Both balls still mid-flight,
-        // before either reaches the far wall where maxX would be identical.
-        for (int i = 0; i < 50; i++) {
-            simSlow.advancePhysics(0.02);
-            simFast.advancePhysics(0.02);
-        }
+  @Test
+  void dragCoefficientsArePhysicallyReasonable() {
+    // Verify precomputed constants match the physics
+    double expectedDragFactor = 0.5 * 1.225 * 0.47 * Math.PI * 0.075 * 0.075 / 0.215;
+    assertEquals(
+        expectedDragFactor,
+        FuelPhysicsSim.getDragAccelFactor(),
+        expectedDragFactor * 0.01,
+        "Drag acceleration factor should match physics constants");
 
-        double xSlow = simSlow.getBallPositions().get(0).getX();
-        double xFast = simFast.getBallPositions().get(0).getX();
+    double expectedMagnusFactor = 0.5 * 1.225 * 0.2 * Math.PI * 0.075 * 0.075 * 0.075 / 0.215;
+    assertEquals(
+        expectedMagnusFactor,
+        FuelPhysicsSim.getMagnusAccelFactor(),
+        expectedMagnusFactor * 0.01,
+        "Magnus acceleration factor should match physics constants");
+  }
 
-        assertTrue(
-                xFast > xSlow,
-                "Faster ball should be farther at t=1s: slow="
-                        + (xSlow - 2)
-                        + " fast="
-                        + (xFast - 2));
-    }
+  @Test
+  void crossProductDirectionCorrect() {
+    // Backspin around -Y with velocity in +X should produce lift in +Z
+    // omega = (0, -omega, 0), vel = (vx, 0, 0)
+    // omega x vel = (-omega*0 - 0*0, 0*vx - 0*0, 0*0 - (-omega)*vx) = (0, 0, omega*vx)
+    // So Magnus force should be in +Z (upward) for backspin, which is correct
 
-    @Test
-    void gravityBringsItDown() {
-        sim.launchBall(new Translation3d(8, 4, 0.5), new Translation3d(5, 0, 15), 0);
+    config.frictionEnabled = false;
+    config.sleepingEnabled = false;
+    config.spinDecayEnabled = false;
+    sim.setConfig(config);
 
-        // Track Z: should go up then come back down
-        double maxZ = 0;
-        boolean wentUp = false;
-        boolean cameDown = false;
+    // Ball with backspin moving in +X
+    sim.launchBall(
+        new Translation3d(5, 4, 1),
+        new Translation3d(10, 0, 0), // purely horizontal
+        5000); // high backspin for visible effect
 
-        for (int i = 0; i < 500; i++) {
-            sim.advancePhysics(0.02);
-            if (sim.getBallCount() > 0) {
-                double z = sim.getBallPositions().get(0).getZ();
-                if (z > 2.0) wentUp = true;
-                maxZ = Math.max(maxZ, z);
-                if (wentUp && z < maxZ * 0.5) cameDown = true;
-            }
-        }
+    sim.advancePhysics(0.1);
 
-        assertTrue(wentUp, "Ball should go up");
-        assertTrue(cameDown, "Gravity should bring it back down");
-    }
-
-    @Test
-    void spinDecayReducesOmegaOverTime() {
-        config.magnusEnabled = false;
-        config.frictionEnabled = false;
-        config.spinDecayTau = 2.0;
-        sim.setConfig(config);
-
-        double initialRPM = 5000;
-        sim.launchBall(new Translation3d(8, 4, 3), new Translation3d(0, 0, 0), initialRPM);
-
-        double initialOmega = Math.abs(sim.getBallOmegas().get(0).getY());
-
-        // Run for 2 * tau = 4 seconds
-        for (int i = 0; i < 200; i++) sim.advancePhysics(0.02);
-
-        double finalOmega = Math.abs(sim.getBallOmegas().get(0).getY());
-        // At t = 2*tau, omega should be about e^(-2) = 13.5% of initial
-        double expectedRatio = Math.exp(-2.0);
-
-        double actualRatio = finalOmega / initialOmega;
-        assertEquals(
-                expectedRatio,
-                actualRatio,
-                expectedRatio * 0.15,
-                "Spin decay should follow exponential: expected ratio="
-                        + expectedRatio
-                        + " actual="
-                        + actualRatio);
-    }
-
-    @Test
-    void dragCoefficientsArePhysicallyReasonable() {
-        // Verify precomputed constants match the physics
-        double expectedDragFactor = 0.5 * 1.225 * 0.47 * Math.PI * 0.075 * 0.075 / 0.215;
-        assertEquals(
-                expectedDragFactor,
-                FuelPhysicsSim.getDragAccelFactor(),
-                expectedDragFactor * 0.01,
-                "Drag acceleration factor should match physics constants");
-
-        double expectedMagnusFactor = 0.5 * 1.225 * 0.2 * Math.PI * 0.075 * 0.075 * 0.075 / 0.215;
-        assertEquals(
-                expectedMagnusFactor,
-                FuelPhysicsSim.getMagnusAccelFactor(),
-                expectedMagnusFactor * 0.01,
-                "Magnus acceleration factor should match physics constants");
-    }
-
-    @Test
-    void crossProductDirectionCorrect() {
-        // Backspin around -Y with velocity in +X should produce lift in +Z
-        // omega = (0, -omega, 0), vel = (vx, 0, 0)
-        // omega x vel = (-omega*0 - 0*0, 0*vx - 0*0, 0*0 - (-omega)*vx) = (0, 0, omega*vx)
-        // So Magnus force should be in +Z (upward) for backspin, which is correct
-
-        config.frictionEnabled = false;
-        config.sleepingEnabled = false;
-        config.spinDecayEnabled = false;
-        sim.setConfig(config);
-
-        // Ball with backspin moving in +X
-        sim.launchBall(
-                new Translation3d(5, 4, 1),
-                new Translation3d(10, 0, 0), // purely horizontal
-                5000); // high backspin for visible effect
-
-        sim.advancePhysics(0.1);
-
-        // After a short time, the ball should have moved upward from Magnus
-        Translation3d vel = sim.getBallVelocities().get(0);
-        assertTrue(
-                vel.getZ() > -5.0, // Should be less negative than pure gravity (-0.981)
-                "Magnus backspin should add upward force: vz=" + vel.getZ());
-    }
+    // After a short time, the ball should have moved upward from Magnus
+    Translation3d vel = sim.getBallVelocities().get(0);
+    assertTrue(
+        vel.getZ() > -5.0, // Should be less negative than pure gravity (-0.981)
+        "Magnus backspin should add upward force: vz=" + vel.getZ());
+  }
 }

--- a/src/test/java/frc/robot/sim/FuelPhysicsSimTest.java
+++ b/src/test/java/frc/robot/sim/FuelPhysicsSimTest.java
@@ -4,1174 +4,1122 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import edu.wpi.first.hal.HAL;
 import edu.wpi.first.math.geometry.Translation3d;
-
 import frc.robot.sim.FuelPhysicsSim.PhysicsConfig;
-
+import java.util.List;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
-import java.util.List;
-
 class FuelPhysicsSimTest {
 
-    private FuelPhysicsSim sim;
-    private PhysicsConfig config;
+  private FuelPhysicsSim sim;
+  private PhysicsConfig config;
 
-    @BeforeAll
-    static void initHAL() {
-        HAL.initialize(500, 0);
+  @BeforeAll
+  static void initHAL() {
+    HAL.initialize(500, 0);
+  }
+
+  @BeforeEach
+  void setUp() {
+    config = new PhysicsConfig();
+    config.deterministic = true;
+    config.deterministicSeed = 42L;
+    config.conservationMonitor = true;
+    sim = new FuelPhysicsSim("Test/Fuel", config);
+    sim.enable();
+  }
+
+  @Nested
+  class Lifecycle {
+    @Test
+    void launchBallIncrementsCount() {
+      sim.launchBall(new Translation3d(8, 4, 1), new Translation3d(5, 0, 5), 2000);
+      assertEquals(1, sim.getBallCount());
+      assertEquals(1, sim.getTotalLaunched());
     }
 
-    @BeforeEach
-    void setUp() {
-        config = new PhysicsConfig();
-        config.deterministic = true;
-        config.deterministicSeed = 42L;
-        config.conservationMonitor = true;
-        sim = new FuelPhysicsSim("Test/Fuel", config);
-        sim.enable();
+    @Test
+    void spawnBallAtRest() {
+      sim.spawnBall(new Translation3d(8, 4, FuelPhysicsSim.getBallRadius()));
+      assertEquals(1, sim.getBallCount());
+      sim.advancePhysics(0.02);
+      // Ball should stay near initial position
+      Translation3d pos = sim.getBallPositions().get(0);
+      assertEquals(FuelPhysicsSim.getBallRadius(), pos.getZ(), 0.01);
     }
 
-    @Nested
-    class Lifecycle {
-        @Test
-        void launchBallIncrementsCount() {
-            sim.launchBall(new Translation3d(8, 4, 1), new Translation3d(5, 0, 5), 2000);
-            assertEquals(1, sim.getBallCount());
-            assertEquals(1, sim.getTotalLaunched());
-        }
-
-        @Test
-        void spawnBallAtRest() {
-            sim.spawnBall(new Translation3d(8, 4, FuelPhysicsSim.getBallRadius()));
-            assertEquals(1, sim.getBallCount());
-            sim.advancePhysics(0.02);
-            // Ball should stay near initial position
-            Translation3d pos = sim.getBallPositions().get(0);
-            assertEquals(FuelPhysicsSim.getBallRadius(), pos.getZ(), 0.01);
-        }
-
-        @Test
-        void clearBallsRemovesAll() {
-            for (int i = 0; i < 10; i++) {
-                sim.spawnBall(new Translation3d(8, 4, FuelPhysicsSim.getBallRadius()));
-            }
-            assertEquals(10, sim.getBallCount());
-            sim.clearBalls();
-            assertEquals(0, sim.getBallCount());
-        }
-
-        @Test
-        void placeFieldBallsCreatesMany() {
-            sim.placeFieldBalls();
-            assertTrue(sim.getBallCount() > 100, "Should spawn many balls");
-        }
-
-        @Test
-        void tickDoesNothingWhenStopped() {
-            sim.disable();
-            sim.spawnBall(new Translation3d(8, 4, 1));
-            Translation3d posBefore = sim.getBallPositions().get(0);
-            sim.tick();
-            Translation3d posAfter = sim.getBallPositions().get(0);
-            assertEquals(posBefore.getX(), posAfter.getX(), 1e-9);
-        }
-
-        @Test
-        void resetCountersWorks() {
-            sim.launchBall(new Translation3d(8, 4, 1), new Translation3d(5, 0, 5), 0);
-            sim.resetCounters();
-            assertEquals(0, sim.getTotalLaunched());
-            assertEquals(0, sim.getTotalScored());
-        }
-
-        @Test
-        void outOfBoundsBallsRemoved() {
-            // Spawn a ball moving fast toward the wall edge
-            sim.spawnBall(new Translation3d(-3, 4, 1), new Translation3d(-10, 0, 0));
-            sim.advancePhysics(0.02);
-            // Ball at -3 with -10 vel over 5 subticks should trigger OOB
-            // After enough steps the ball should be removed
-            for (int i = 0; i < 50; i++) sim.advancePhysics(0.02);
-            assertEquals(0, sim.getBallCount(), "OOB ball should be removed");
-        }
-
-        @Test
-        void maxBallsLimitRespected() {
-            for (int i = 0; i < 2100; i++) {
-                sim.spawnBall(new Translation3d(8, 4, FuelPhysicsSim.getBallRadius()));
-            }
-            assertTrue(sim.getBallCount() <= 2000, "Should respect MAX_BALLS");
-        }
+    @Test
+    void clearBallsRemovesAll() {
+      for (int i = 0; i < 10; i++) {
+        sim.spawnBall(new Translation3d(8, 4, FuelPhysicsSim.getBallRadius()));
+      }
+      assertEquals(10, sim.getBallCount());
+      sim.clearBalls();
+      assertEquals(0, sim.getBallCount());
     }
 
-    @Nested
-    class PhysicsAccuracy {
-        @Test
-        void symplecticEulerEnergyBounded() {
-            // With no drag, total energy should be conserved within 1% (decreases from COR on
-            // bounces)
-            config.dragEnabled = false;
-            config.magnusEnabled = false;
-            config.frictionEnabled = false;
-            config.spinTransferEnabled = false;
-            config.sleepingEnabled = false;
-            config.velocityDependentCOR = false;
-            config.subticks = 10;
-            sim.setConfig(config);
+    @Test
+    void placeFieldBallsCreatesMany() {
+      sim.placeFieldBalls();
+      assertTrue(sim.getBallCount() > 100, "Should spawn many balls");
+    }
 
-            // Use Y=1 to avoid hub geometry collisions
-            sim.launchBall(new Translation3d(8, 1, 2), new Translation3d(3, 0, 5), 0);
-            double initialEnergy = sim.getTotalKineticEnergy() + sim.getTotalPotentialEnergy();
+    @Test
+    void tickDoesNothingWhenStopped() {
+      sim.disable();
+      sim.spawnBall(new Translation3d(8, 4, 1));
+      Translation3d posBefore = sim.getBallPositions().get(0);
+      sim.tick();
+      Translation3d posAfter = sim.getBallPositions().get(0);
+      assertEquals(posBefore.getX(), posAfter.getX(), 1e-9);
+    }
 
-            for (int i = 0; i < 1000; i++) {
-                sim.advancePhysics(0.02);
-            }
+    @Test
+    void resetCountersWorks() {
+      sim.launchBall(new Translation3d(8, 4, 1), new Translation3d(5, 0, 5), 0);
+      sim.resetCounters();
+      assertEquals(0, sim.getTotalLaunched());
+      assertEquals(0, sim.getTotalScored());
+    }
 
-            double finalEnergy = sim.getTotalKineticEnergy() + sim.getTotalPotentialEnergy();
-            // Energy should decrease (COR < 1 on bounces) but not increase
-            // With field COR < 1, energy decreases on each bounce
-            assertTrue(
-                    finalEnergy <= initialEnergy * 1.01,
-                    "Energy should not increase: initial="
-                            + initialEnergy
-                            + " final="
-                            + finalEnergy);
+    @Test
+    void outOfBoundsBallsRemoved() {
+      // Spawn a ball moving fast toward the wall edge
+      sim.spawnBall(new Translation3d(-3, 4, 1), new Translation3d(-10, 0, 0));
+      sim.advancePhysics(0.02);
+      // Ball at -3 with -10 vel over 5 subticks should trigger OOB
+      // After enough steps the ball should be removed
+      for (int i = 0; i < 50; i++) sim.advancePhysics(0.02);
+      assertEquals(0, sim.getBallCount(), "OOB ball should be removed");
+    }
+
+    @Test
+    void maxBallsLimitRespected() {
+      for (int i = 0; i < 2100; i++) {
+        sim.spawnBall(new Translation3d(8, 4, FuelPhysicsSim.getBallRadius()));
+      }
+      assertTrue(sim.getBallCount() <= 2000, "Should respect MAX_BALLS");
+    }
+  }
+
+  @Nested
+  class PhysicsAccuracy {
+    @Test
+    void symplecticEulerEnergyBounded() {
+      // With no drag, total energy should be conserved within 1% (decreases from COR on
+      // bounces)
+      config.dragEnabled = false;
+      config.magnusEnabled = false;
+      config.frictionEnabled = false;
+      config.spinTransferEnabled = false;
+      config.sleepingEnabled = false;
+      config.velocityDependentCOR = false;
+      config.subticks = 10;
+      sim.setConfig(config);
+
+      // Use Y=1 to avoid hub geometry collisions
+      sim.launchBall(new Translation3d(8, 1, 2), new Translation3d(3, 0, 5), 0);
+      double initialEnergy = sim.getTotalKineticEnergy() + sim.getTotalPotentialEnergy();
+
+      for (int i = 0; i < 1000; i++) {
+        sim.advancePhysics(0.02);
+      }
+
+      double finalEnergy = sim.getTotalKineticEnergy() + sim.getTotalPotentialEnergy();
+      // Energy should decrease (COR < 1 on bounces) but not increase
+      // With field COR < 1, energy decreases on each bounce
+      assertTrue(
+          finalEnergy <= initialEnergy * 1.01,
+          "Energy should not increase: initial=" + initialEnergy + " final=" + finalEnergy);
+    }
+
+    @Test
+    void vacuumTrajectoryMatchesAnalytical() {
+      // No drag, no Magnus: apex height = Z0 + vz^2 / (2g)
+      // Testing apex avoids ground-bounce complications (COR causes multi-bounce)
+      config.dragEnabled = false;
+      config.magnusEnabled = false;
+      config.frictionEnabled = false;
+      config.sleepingEnabled = false;
+      config.subticks = 10;
+      sim.setConfig(config);
+
+      double v = 10.0;
+      double theta = Math.toRadians(45);
+      double vx = v * Math.cos(theta);
+      double vz = v * Math.sin(theta);
+
+      // Y=1 avoids hub geometry
+      double startZ = 0.5;
+      sim.launchBall(
+          new Translation3d(2, 1, startZ), new Translation3d(vx, 0, vz), new Translation3d());
+
+      // Track apex height and X at apex
+      double maxZ = 0;
+      double xAtMaxZ = 0;
+      for (int i = 0; i < 200; i++) {
+        sim.advancePhysics(0.02);
+        if (sim.getBallCount() == 0) break;
+        Translation3d pos = sim.getBallPositions().get(0);
+        if (pos.getZ() > maxZ) {
+          maxZ = pos.getZ();
+          xAtMaxZ = pos.getX();
         }
+      }
 
-        @Test
-        void vacuumTrajectoryMatchesAnalytical() {
-            // No drag, no Magnus: apex height = Z0 + vz^2 / (2g)
-            // Testing apex avoids ground-bounce complications (COR causes multi-bounce)
-            config.dragEnabled = false;
-            config.magnusEnabled = false;
-            config.frictionEnabled = false;
-            config.sleepingEnabled = false;
-            config.subticks = 10;
-            sim.setConfig(config);
+      // Apex height: Z0 + vz^2/(2g)
+      double expectedApex = startZ + vz * vz / (2 * 9.81);
+      assertEquals(
+          expectedApex,
+          maxZ,
+          expectedApex * 0.05,
+          "Apex height should match analytical: expected=" + expectedApex + " actual=" + maxZ);
 
-            double v = 10.0;
-            double theta = Math.toRadians(45);
-            double vx = v * Math.cos(theta);
-            double vz = v * Math.sin(theta);
+      // X at apex should be half the vacuum range: X0 + vx * (vz/g)
+      double expectedXAtApex = 2.0 + vx * (vz / 9.81);
+      assertEquals(
+          expectedXAtApex,
+          xAtMaxZ,
+          expectedXAtApex * 0.05,
+          "X at apex should match analytical: expected=" + expectedXAtApex + " actual=" + xAtMaxZ);
+    }
 
-            // Y=1 avoids hub geometry
-            double startZ = 0.5;
-            sim.launchBall(
-                    new Translation3d(2, 1, startZ),
-                    new Translation3d(vx, 0, vz),
-                    new Translation3d());
+    @Test
+    void gravityPullsBallDown() {
+      sim.launchBall(new Translation3d(8, 4, 2), new Translation3d(0, 0, 0), 0);
+      sim.advancePhysics(0.5);
+      Translation3d pos = sim.getBallPositions().get(0);
+      // After 0.5s of free fall from 2m, z = 2 - 0.5*9.81*0.25 = 0.77m
+      assertTrue(pos.getZ() < 2.0, "Ball should fall");
+      assertTrue(pos.getZ() > 0, "Ball should not go below ground");
+    }
 
-            // Track apex height and X at apex
-            double maxZ = 0;
-            double xAtMaxZ = 0;
-            for (int i = 0; i < 200; i++) {
-                sim.advancePhysics(0.02);
-                if (sim.getBallCount() == 0) break;
-                Translation3d pos = sim.getBallPositions().get(0);
-                if (pos.getZ() > maxZ) {
-                    maxZ = pos.getZ();
-                    xAtMaxZ = pos.getX();
-                }
-            }
+    @Test
+    void highSpeedReachesFarther() {
+      config.magnusEnabled = false;
+      config.sleepingEnabled = false;
+      sim.setConfig(config);
 
-            // Apex height: Z0 + vz^2/(2g)
-            double expectedApex = startZ + vz * vz / (2 * 9.81);
-            assertEquals(
-                    expectedApex,
-                    maxZ,
-                    expectedApex * 0.05,
-                    "Apex height should match analytical: expected="
-                            + expectedApex
-                            + " actual="
-                            + maxZ);
+      // Y=1 avoids hub geometry; use same Y for fair comparison
+      sim.launchBall(new Translation3d(2, 1, 0.5), new Translation3d(5, 0, 5), 0);
+      sim.launchBall(new Translation3d(2, 1, 0.5), new Translation3d(10, 0, 5), 0);
 
-            // X at apex should be half the vacuum range: X0 + vx * (vz/g)
-            double expectedXAtApex = 2.0 + vx * (vz / 9.81);
-            assertEquals(
-                    expectedXAtApex,
-                    xAtMaxZ,
-                    expectedXAtApex * 0.05,
-                    "X at apex should match analytical: expected="
-                            + expectedXAtApex
-                            + " actual="
-                            + xAtMaxZ);
+      for (int i = 0; i < 200; i++) sim.advancePhysics(0.02);
+
+      List<Translation3d> positions = sim.getBallPositions();
+      // Fast ball (index 1) should have traveled farther in X
+      assertTrue(positions.size() >= 2);
+      assertTrue(
+          positions.get(1).getX() > positions.get(0).getX(), "Faster ball should travel farther");
+    }
+
+    @Test
+    void zeroVelocityDropsStraight() {
+      sim.launchBall(new Translation3d(8, 4, 3), new Translation3d(0, 0, 0), 0);
+
+      for (int i = 0; i < 100; i++) sim.advancePhysics(0.02);
+
+      Translation3d pos = sim.getBallPositions().get(0);
+      assertEquals(8.0, pos.getX(), 0.01, "Should not drift in X");
+      assertEquals(4.0, pos.getY(), 0.01, "Should not drift in Y");
+    }
+  }
+
+  @Nested
+  class MagnusAndSpin {
+    @Test
+    void magnusBackspinCurvesUpward() {
+      config.frictionEnabled = false;
+      config.sleepingEnabled = false;
+      config.spinDecayEnabled = false; // keep spin constant for clearer test
+      sim.setConfig(config);
+
+      // Ball with backspin (positive RPM = lift)
+      sim.launchBall(new Translation3d(3, 4, 0.5), new Translation3d(10, 0, 5), 3000);
+
+      // Ball without spin
+      FuelPhysicsSim simNoSpin = new FuelPhysicsSim("Test/NoSpin", config);
+      simNoSpin.enable();
+      PhysicsConfig noMagnusCfg = config.copy();
+      noMagnusCfg.magnusEnabled = false;
+      simNoSpin.setConfig(noMagnusCfg);
+      simNoSpin.launchBall(new Translation3d(3, 4, 0.5), new Translation3d(10, 0, 5), 0);
+
+      // Track max height
+      double maxZSpin = 0, maxZNoSpin = 0;
+      for (int i = 0; i < 200; i++) {
+        sim.advancePhysics(0.02);
+        simNoSpin.advancePhysics(0.02);
+        if (sim.getBallCount() > 0)
+          maxZSpin = Math.max(maxZSpin, sim.getBallPositions().get(0).getZ());
+        if (simNoSpin.getBallCount() > 0)
+          maxZNoSpin = Math.max(maxZNoSpin, simNoSpin.getBallPositions().get(0).getZ());
+      }
+
+      assertTrue(
+          maxZSpin > maxZNoSpin,
+          "Backspin should increase max height: spin=" + maxZSpin + " noSpin=" + maxZNoSpin);
+    }
+
+    @Test
+    void magnusSidespinCurvesSideways() {
+      config.frictionEnabled = false;
+      config.sleepingEnabled = false;
+      config.spinDecayEnabled = false;
+      sim.setConfig(config);
+
+      // Sidespin: omega around Z axis
+      double omegaZ = 300.0; // rad/s (about 2860 RPM around vertical axis)
+      sim.launchBall(
+          new Translation3d(3, 4, 1), new Translation3d(10, 0, 3), new Translation3d(0, 0, omegaZ));
+
+      double maxYDisplacement = 0;
+      for (int i = 0; i < 200; i++) {
+        sim.advancePhysics(0.02);
+        if (sim.getBallCount() > 0) {
+          double yDisp = Math.abs(sim.getBallPositions().get(0).getY() - 4.0);
+          maxYDisplacement = Math.max(maxYDisplacement, yDisp);
         }
+      }
 
-        @Test
-        void gravityPullsBallDown() {
-            sim.launchBall(new Translation3d(8, 4, 2), new Translation3d(0, 0, 0), 0);
-            sim.advancePhysics(0.5);
-            Translation3d pos = sim.getBallPositions().get(0);
-            // After 0.5s of free fall from 2m, z = 2 - 0.5*9.81*0.25 = 0.77m
-            assertTrue(pos.getZ() < 2.0, "Ball should fall");
-            assertTrue(pos.getZ() > 0, "Ball should not go below ground");
+      assertTrue(
+          maxYDisplacement > 0.05, "Sidespin should curve ball sideways: maxY=" + maxYDisplacement);
+    }
+
+    @Test
+    void magnusTopspinCurvesDownward() {
+      config.frictionEnabled = false;
+      config.sleepingEnabled = false;
+      config.spinDecayEnabled = false;
+      sim.setConfig(config);
+
+      // Topspin: negative of backspin (positive omega Y = topspin for +X velocity)
+      sim.launchBall(new Translation3d(3, 4, 0.5), new Translation3d(10, 0, 5), -3000);
+
+      FuelPhysicsSim simNoSpin = new FuelPhysicsSim("Test/NoSpin2", config);
+      simNoSpin.enable();
+      PhysicsConfig noMagnusCfg = config.copy();
+      noMagnusCfg.magnusEnabled = false;
+      simNoSpin.setConfig(noMagnusCfg);
+      simNoSpin.launchBall(new Translation3d(3, 4, 0.5), new Translation3d(10, 0, 5), 0);
+
+      // Only track the first arc (stop after apex to avoid ground bounce contamination)
+      double maxZTopSpin = 0, maxZNoSpin = 0;
+      boolean topPassed = false, noPassed = false;
+      double prevZTop = 0, prevZNo = 0;
+      for (int i = 0; i < 200; i++) {
+        sim.advancePhysics(0.02);
+        simNoSpin.advancePhysics(0.02);
+        if (sim.getBallCount() > 0 && !topPassed) {
+          double z = sim.getBallPositions().get(0).getZ();
+          if (z < prevZTop && prevZTop > 0.6) topPassed = true;
+          maxZTopSpin = Math.max(maxZTopSpin, z);
+          prevZTop = z;
         }
-
-        @Test
-        void highSpeedReachesFarther() {
-            config.magnusEnabled = false;
-            config.sleepingEnabled = false;
-            sim.setConfig(config);
-
-            // Y=1 avoids hub geometry; use same Y for fair comparison
-            sim.launchBall(new Translation3d(2, 1, 0.5), new Translation3d(5, 0, 5), 0);
-            sim.launchBall(new Translation3d(2, 1, 0.5), new Translation3d(10, 0, 5), 0);
-
-            for (int i = 0; i < 200; i++) sim.advancePhysics(0.02);
-
-            List<Translation3d> positions = sim.getBallPositions();
-            // Fast ball (index 1) should have traveled farther in X
-            assertTrue(positions.size() >= 2);
-            assertTrue(
-                    positions.get(1).getX() > positions.get(0).getX(),
-                    "Faster ball should travel farther");
+        if (simNoSpin.getBallCount() > 0 && !noPassed) {
+          double z = simNoSpin.getBallPositions().get(0).getZ();
+          if (z < prevZNo && prevZNo > 0.6) noPassed = true;
+          maxZNoSpin = Math.max(maxZNoSpin, z);
+          prevZNo = z;
         }
+      }
 
-        @Test
-        void zeroVelocityDropsStraight() {
-            sim.launchBall(new Translation3d(8, 4, 3), new Translation3d(0, 0, 0), 0);
+      assertTrue(
+          maxZTopSpin < maxZNoSpin,
+          "Topspin should lower apex: topspin=" + maxZTopSpin + " noSpin=" + maxZNoSpin);
+    }
 
+    @Test
+    void spinDecaysExponentially() {
+      config.frictionEnabled = false;
+      config.sleepingEnabled = false;
+      config.spinDecayTau = 1.0; // 1 second for easier testing
+      config.subticks = 10;
+      sim.setConfig(config);
+
+      double initialRPM = 5000;
+      sim.launchBall(new Translation3d(8, 4, 3), new Translation3d(0, 0, 0), initialRPM);
+
+      // Run for tau seconds
+      for (int i = 0; i < 50; i++) sim.advancePhysics(0.02); // 1 second total
+
+      List<Translation3d> omegas = sim.getBallOmegas();
+      double currentOmegaY = Math.abs(omegas.get(0).getY());
+      double initialOmegaY = initialRPM * 2.0 * Math.PI / 60.0;
+      double expectedOmega = initialOmegaY * Math.exp(-1.0); // 37% at t=tau
+
+      assertEquals(
+          expectedOmega,
+          currentOmegaY,
+          expectedOmega * 0.10,
+          "Spin should be ~37% of initial at t=tau");
+    }
+
+    @Test
+    void noMagnusDisablesCurve() {
+      config.magnusEnabled = false;
+      config.frictionEnabled = false;
+      config.sleepingEnabled = false;
+      sim.setConfig(config);
+
+      sim.launchBall(new Translation3d(3, 4, 1), new Translation3d(10, 0, 5), 5000);
+
+      // Without Magnus, spin should not affect trajectory
+      FuelPhysicsSim simNoSpin = new FuelPhysicsSim("Test/NoSpinRef", config);
+      simNoSpin.enable();
+      simNoSpin.setConfig(config);
+      simNoSpin.launchBall(new Translation3d(3, 4, 1), new Translation3d(10, 0, 5), 0);
+
+      for (int i = 0; i < 100; i++) {
+        sim.advancePhysics(0.02);
+        simNoSpin.advancePhysics(0.02);
+      }
+
+      if (sim.getBallCount() > 0 && simNoSpin.getBallCount() > 0) {
+        Translation3d posSpin = sim.getBallPositions().get(0);
+        Translation3d posNoSpin = simNoSpin.getBallPositions().get(0);
+        // Positions should be very close since Magnus is disabled
+        assertEquals(posNoSpin.getZ(), posSpin.getZ(), 0.1, "No Magnus = same trajectory");
+      }
+    }
+  }
+
+  @Nested
+  class ConservationLaws {
+    @Test
+    void energyDecreasesMonotonically() {
+      // With real COR values, energy should never increase
+      config.sleepingEnabled = false;
+      config.subticks = 5;
+      sim.setConfig(config);
+
+      sim.launchBall(new Translation3d(8, 4, 3), new Translation3d(5, 2, 8), 1000);
+
+      double prevEnergy = sim.getTotalKineticEnergy() + sim.getTotalPotentialEnergy();
+      int violations = 0;
+
+      for (int i = 0; i < 500; i++) {
+        sim.advancePhysics(0.02);
+        double energy = sim.getTotalKineticEnergy() + sim.getTotalPotentialEnergy();
+        if (energy > prevEnergy + 0.01) { // 10mJ tolerance for numerical noise
+          violations++;
+        }
+        prevEnergy = energy;
+      }
+
+      // Allow a few violations from numerical noise, but not many
+      assertTrue(violations < 10, "Energy increased " + violations + " times out of 500 steps");
+    }
+
+    @Test
+    void momentumConservedInBallBallCollision() {
+      // Two balls colliding in vacuum with no gravity or drag
+      config.magnusEnabled = false;
+      config.frictionEnabled = false;
+      config.sleepingEnabled = false;
+      config.spinTransferEnabled = false;
+      config.subticks = 10;
+      sim.setConfig(config);
+
+      // Two balls approaching each other
+      sim.spawnBall(new Translation3d(7.5, 4, 2), new Translation3d(3, 0, 0));
+      sim.spawnBall(new Translation3d(8.5, 4, 2), new Translation3d(-3, 0, 0));
+
+      Translation3d initialMomentum = sim.getTotalMomentum();
+
+      // Step until collision happens and resolves
+      for (int i = 0; i < 100; i++) sim.advancePhysics(0.02);
+
+      Translation3d finalMomentum = sim.getTotalMomentum();
+
+      // Momentum should be conserved (X components should sum to 0 since equal and opposite)
+      assertEquals(initialMomentum.getX(), finalMomentum.getX(), 0.01, "X momentum not conserved");
+      assertEquals(initialMomentum.getY(), finalMomentum.getY(), 0.01, "Y momentum not conserved");
+    }
+
+    @Test
+    void angularMomentumConservedInIsolatedCollision() {
+      // Two spinning balls collide. Total angular momentum should be roughly conserved.
+      config.magnusEnabled = false;
+      config.sleepingEnabled = false;
+      config.subticks = 10;
+      sim.setConfig(config);
+
+      double omega1 = 100.0; // rad/s
+      sim.launchBall(
+          new Translation3d(7.5, 4, 2),
+          new Translation3d(3, 0, 0),
+          new Translation3d(0, omega1, 0));
+      sim.launchBall(
+          new Translation3d(8.5, 4, 2),
+          new Translation3d(-3, 0, 0),
+          new Translation3d(0, -omega1, 0));
+
+      double mass = FuelPhysicsSim.getBallMass();
+      double I = FuelPhysicsSim.getMomentOfInertia();
+
+      // Compute initial total angular momentum about origin
+      // L = r x (m*v) + I*omega for each ball
+      // This is complex, so just check omega conservation
+      List<Translation3d> initialOmegas = sim.getBallOmegas();
+      double initialTotalOmegaY = 0;
+      for (Translation3d o : initialOmegas) initialTotalOmegaY += o.getY();
+
+      for (int i = 0; i < 100; i++) sim.advancePhysics(0.02);
+
+      List<Translation3d> finalOmegas = sim.getBallOmegas();
+      double finalTotalOmegaY = 0;
+      for (Translation3d o : finalOmegas) finalTotalOmegaY += o.getY();
+
+      // Total spin should be roughly conserved (some energy goes to translation)
+      // Use a wider tolerance since spin-transfer mechanics are approximate
+      assertEquals(
+          initialTotalOmegaY,
+          finalTotalOmegaY,
+          Math.abs(initialTotalOmegaY) * 0.5 + 1.0,
+          "Angular momentum should be approximately conserved");
+    }
+  }
+
+  @Nested
+  class Collisions {
+    @Test
+    void multiBodyPileSettlesInFiniteIterations() {
+      config.sleepingEnabled = false;
+      config.subticks = 5;
+      sim.setConfig(config);
+
+      // Stack 5 balls vertically
+      for (int i = 0; i < 5; i++) {
+        sim.spawnBall(
+            new Translation3d(
+                8, 4, FuelPhysicsSim.getBallRadius() + i * FuelPhysicsSim.getBallRadius() * 2.5),
+            new Translation3d(0, 0, -1));
+      }
+
+      // Let them settle
+      for (int i = 0; i < 200; i++) sim.advancePhysics(0.02);
+
+      // All balls should have low velocity
+      for (Translation3d vel : sim.getBallVelocities()) {
+        assertTrue(vel.getNorm() < 0.5, "Ball should have settled: speed=" + vel.getNorm());
+      }
+    }
+
+    @Test
+    void stackedBallsDoNotJitter() {
+      config.sleepingEnabled = false;
+      config.subticks = 5;
+      sim.setConfig(config);
+
+      // Let balls settle first
+      for (int i = 0; i < 3; i++) {
+        sim.spawnBall(
+            new Translation3d(
+                8, 4, FuelPhysicsSim.getBallRadius() + i * FuelPhysicsSim.getBallRadius() * 2.2));
+      }
+      for (int i = 0; i < 300; i++) sim.advancePhysics(0.02);
+
+      // Record positions, run 200 more steps, check stability
+      List<Translation3d> posBefore = sim.getBallPositions();
+      for (int i = 0; i < 200; i++) sim.advancePhysics(0.02);
+      List<Translation3d> posAfter = sim.getBallPositions();
+
+      for (int i = 0; i < Math.min(posBefore.size(), posAfter.size()); i++) {
+        double drift = posBefore.get(i).getDistance(posAfter.get(i));
+        assertTrue(drift < 0.05, "Ball " + i + " jittered by " + drift + "m");
+      }
+    }
+
+    @Test
+    void penetrationStaysBelowTolerance() {
+      config.sleepingEnabled = false;
+      sim.setConfig(config);
+
+      // Ball bouncing on ground
+      sim.launchBall(new Translation3d(8, 4, 3), new Translation3d(0, 0, -10), 0);
+
+      double maxPenetration = 0;
+      for (int i = 0; i < 500; i++) {
+        sim.advancePhysics(0.02);
+        if (sim.getBallCount() > 0) {
+          double z = sim.getBallPositions().get(0).getZ();
+          double pen = FuelPhysicsSim.getBallRadius() - z;
+          maxPenetration = Math.max(maxPenetration, pen);
+        }
+      }
+
+      assertTrue(
+          maxPenetration < 0.005, "Penetration should stay below 5mm: " + maxPenetration + "m");
+    }
+
+    @Test
+    void wallBounceWithCorrectCOR() {
+      config.magnusEnabled = false;
+      config.frictionEnabled = false;
+      config.sleepingEnabled = false;
+      config.velocityDependentCOR = false;
+      sim.setConfig(config);
+
+      // Ball moving toward X=0 wall
+      double incomingSpeed = 5.0;
+      sim.spawnBall(
+          new Translation3d(FuelPhysicsSim.getBallRadius() + 0.01, 4, 0.3),
+          new Translation3d(-incomingSpeed, 0, 0));
+
+      sim.advancePhysics(0.02);
+
+      Translation3d vel = sim.getBallVelocities().get(0);
+      double expectedBounceSpeed = incomingSpeed * FuelPhysicsSim.getFieldCOR();
+      assertEquals(
+          expectedBounceSpeed,
+          vel.getX(),
+          expectedBounceSpeed * 0.15,
+          "Bounce speed should match COR");
+      assertTrue(vel.getX() > 0, "Ball should bounce away from wall");
+    }
+
+    @Test
+    void ballBallCollisionWorks() {
+      config.magnusEnabled = false;
+      config.frictionEnabled = false;
+      config.sleepingEnabled = false;
+      config.subticks = 10;
+      sim.setConfig(config);
+
+      // Two balls on collision course (at same height, no gravity effect)
+      sim.spawnBall(new Translation3d(7.8, 4, 2), new Translation3d(5, 0, 0));
+      sim.spawnBall(new Translation3d(8.2, 4, 2), new Translation3d(-5, 0, 0));
+
+      // Run until they collide and separate
+      for (int i = 0; i < 50; i++) sim.advancePhysics(0.02);
+
+      List<Translation3d> vels = sim.getBallVelocities();
+      if (vels.size() >= 2) {
+        // After collision, velocities should have reversed direction
+        // (with COR < 1, they'll be slower)
+        assertTrue(vels.get(0).getX() < 0, "Ball A should reverse: " + vels.get(0).getX());
+        assertTrue(vels.get(1).getX() > 0, "Ball B should reverse: " + vels.get(1).getX());
+      }
+    }
+
+    @Test
+    void fastBallDoesNotTunnelThroughWall() {
+      config.ccdEnabled = true;
+      config.sleepingEnabled = false;
+      sim.setConfig(config);
+
+      // Very fast ball aimed at alliance wall
+      sim.spawnBall(new Translation3d(1, 4, 0.3), new Translation3d(-50, 0, 0));
+
+      sim.advancePhysics(0.02);
+
+      // Ball should NOT have gone through the wall
+      Translation3d pos = sim.getBallPositions().get(0);
+      assertTrue(
+          pos.getX() >= FuelPhysicsSim.getBallRadius() - 0.01,
+          "Ball tunneled through wall: x=" + pos.getX());
+    }
+
+    @Test
+    void fastBallDoesNotTunnelThroughThinObstacle() {
+      config.ccdEnabled = true;
+      config.sleepingEnabled = false;
+      config.subticks = 1; // Deliberately low to test CCD
+      sim.setConfig(config);
+
+      // Fast ball aimed at a trench pillar (about 0.3m wide)
+      // Trench pillar at approximately X=3.96..4.265
+      sim.spawnBall(new Translation3d(3.5, 1.4, 0.5), new Translation3d(50, 0, 0));
+
+      sim.advancePhysics(0.02);
+
+      // Ball should have been stopped by CCD
+      Translation3d pos = sim.getBallPositions().get(0);
+      // Should not have passed through to X > 4.3
+      // (it might bounce back or stop at the pillar)
+      assertTrue(
+          pos.getX() < 5.0 || pos.getX() > 4.3, "CCD should prevent tunneling: x=" + pos.getX());
+    }
+
+    @Test
+    void higherImpactSpeedLowerBounceHeight() {
+      config.velocityDependentCOR = true;
+      config.magnusEnabled = false;
+      config.frictionEnabled = false;
+      config.sleepingEnabled = false;
+      sim.setConfig(config);
+
+      // Slow drop
+      FuelPhysicsSim simSlow = new FuelPhysicsSim("Test/Slow", config);
+      simSlow.enable();
+      simSlow.setConfig(config);
+      simSlow.spawnBall(new Translation3d(8, 3, 1)); // 1m drop
+
+      // Fast drop
+      FuelPhysicsSim simFast = new FuelPhysicsSim("Test/Fast", config);
+      simFast.enable();
+      simFast.setConfig(config);
+      simFast.spawnBall(new Translation3d(8, 5, 5)); // 5m drop
+
+      double maxBounceSlow = 0, maxBounceFast = 0;
+      boolean slowBounced = false, fastBounced = false;
+
+      for (int i = 0; i < 300; i++) {
+        simSlow.advancePhysics(0.02);
+        simFast.advancePhysics(0.02);
+
+        if (simSlow.getBallCount() > 0) {
+          double z = simSlow.getBallPositions().get(0).getZ();
+          double vz = simSlow.getBallVelocities().get(0).getZ();
+          if (slowBounced) maxBounceSlow = Math.max(maxBounceSlow, z);
+          if (vz > 0 && z < 0.2) slowBounced = true;
+        }
+        if (simFast.getBallCount() > 0) {
+          double z = simFast.getBallPositions().get(0).getZ();
+          double vz = simFast.getBallVelocities().get(0).getZ();
+          if (fastBounced) maxBounceFast = Math.max(maxBounceFast, z);
+          if (vz > 0 && z < 0.2) fastBounced = true;
+        }
+      }
+
+      if (maxBounceSlow > 0 && maxBounceFast > 0) {
+        // COR ratio: fast should bounce relatively lower than slow
+        double ratioSlow = maxBounceSlow / 1.0;
+        double ratioFast = maxBounceFast / 5.0;
+        assertTrue(
+            ratioFast < ratioSlow,
+            "Higher impact should have lower COR ratio: slow=" + ratioSlow + " fast=" + ratioFast);
+      }
+    }
+
+    @Test
+    void ballGrazingRungDeflectsTangentially() {
+      config.sleepingEnabled = false;
+      config.magnusEnabled = false;
+      sim.setConfig(config);
+
+      // Ball at tower rung height, moving toward it at a tangent
+      // Blue tower rung at X=0, Y~3.6..4.5, Z=0.686
+      sim.spawnBall(new Translation3d(0.3, 3.5, 0.686), new Translation3d(-3, 1, 0));
+
+      for (int i = 0; i < 50; i++) sim.advancePhysics(0.02);
+
+      // Ball should have been deflected (Y component changed)
+      Translation3d vel = sim.getBallVelocities().get(0);
+      assertTrue(vel.getNorm() > 0.1, "Ball should still be moving after rung deflection");
+    }
+  }
+
+  @Nested
+  class Sleeping {
+    @Test
+    void sleepingBallsReduceComputeTime() {
+      config.sleepingEnabled = true;
+      config.subticks = 5;
+      sim.setConfig(config);
+
+      // Spawn many balls at rest (they should sleep quickly)
+      for (int i = 0; i < 350; i++) {
+        sim.spawnBall(
+            new Translation3d(
+                2 + (i % 50) * 0.2, 1 + (i / 50) * 0.2, FuelPhysicsSim.getBallRadius()));
+      }
+
+      // Let them settle and sleep
+      for (int i = 0; i < 100; i++) sim.advancePhysics(0.02);
+
+      int sleeping = sim.getSleepingBallCount();
+      assertTrue(sleeping > 200, "Most resting balls should be sleeping: " + sleeping);
+
+      // Time a step with mostly sleeping balls
+      long start = System.nanoTime();
+      for (int i = 0; i < 10; i++) sim.advancePhysics(0.02);
+      double elapsedMs = (System.nanoTime() - start) / 1_000_000.0 / 10.0;
+
+      assertTrue(elapsedMs < 2.0, "Step with sleeping balls should be fast: " + elapsedMs + "ms");
+    }
+
+    @Test
+    void sleepingBallWakesOnExternalCollision() {
+      config.sleepingEnabled = true;
+      sim.setConfig(config);
+
+      // Spawn ball at rest, let it sleep (Y=1 avoids hub geometry)
+      sim.spawnBall(new Translation3d(8, 1, FuelPhysicsSim.getBallRadius()));
+      for (int i = 0; i < 50; i++) sim.advancePhysics(0.02);
+
+      assertTrue(sim.getSleepingBallCount() > 0, "Ball should be sleeping");
+
+      // Launch a ball at it
+      sim.launchBall(
+          new Translation3d(7, 1, FuelPhysicsSim.getBallRadius()), new Translation3d(5, 0, 0), 0);
+
+      // Run until collision
+      for (int i = 0; i < 50; i++) sim.advancePhysics(0.02);
+
+      // The resting ball should have woken up
+      assertEquals(0, sim.getSleepingBallCount(), "Collision should wake sleeping ball");
+    }
+
+    @Test
+    void allBallsEventuallySleep() {
+      config.sleepingEnabled = true;
+      sim.setConfig(config);
+
+      // Spawn 50 balls with small velocities
+      for (int i = 0; i < 50; i++) {
+        sim.spawnBall(
+            new Translation3d(
+                3 + (i % 10) * 0.3, 2 + (i / 10) * 0.3, FuelPhysicsSim.getBallRadius()),
+            new Translation3d(0.1, 0.05, 0));
+      }
+
+      for (int i = 0; i < 500; i++) sim.advancePhysics(0.02);
+
+      int sleeping = sim.getSleepingBallCount();
+      assertTrue(sleeping >= 25, "Most balls should eventually sleep: " + sleeping + "/50");
+    }
+
+    @Test
+    void noSleepingAllBallsAlwaysActive() {
+      config.sleepingEnabled = false;
+      sim.setConfig(config);
+
+      for (int i = 0; i < 10; i++) {
+        sim.spawnBall(new Translation3d(8, 4, FuelPhysicsSim.getBallRadius()));
+      }
+      for (int i = 0; i < 100; i++) sim.advancePhysics(0.02);
+
+      assertEquals(0, sim.getSleepingBallCount(), "No sleeping when disabled");
+    }
+  }
+
+  @Nested
+  class FrictionAndSpinTransfer {
+    @Test
+    void slidingBallDeceleratesAtMuTimesG() {
+      config.magnusEnabled = false;
+      config.dragEnabled = false; // isolate ground friction from air drag
+      config.sleepingEnabled = false;
+      config.spinTransferEnabled = false;
+      sim.setConfig(config);
+
+      double initialSpeed = 5.0;
+      sim.spawnBall(
+          new Translation3d(8, 4, FuelPhysicsSim.getBallRadius()),
+          new Translation3d(initialSpeed, 0, 0));
+
+      sim.advancePhysics(0.5); // 0.5 seconds
+
+      Translation3d vel = sim.getBallVelocities().get(0);
+      double finalSpeed = Math.abs(vel.getX());
+
+      // Expected deceleration: mu_k * g = 0.3 * 9.81 = 2.943 m/s^2
+      // After 0.5s: v = 5 - 2.943*0.5 = 3.53 m/s
+      double expectedSpeed = initialSpeed - 0.3 * 9.81 * 0.5;
+      assertEquals(
+          expectedSpeed,
+          finalSpeed,
+          expectedSpeed * 0.2,
+          "Ground friction deceleration should match mu*g");
+    }
+
+    @Test
+    void spinTransferOnWallCollision() {
+      config.sleepingEnabled = false;
+      config.magnusEnabled = false;
+      sim.setConfig(config);
+
+      // Ball with no spin hits a wall
+      sim.spawnBall(
+          new Translation3d(FuelPhysicsSim.getBallRadius() + 0.01, 4, 0.3),
+          new Translation3d(-5, 3, 0)); // Oblique hit
+
+      sim.advancePhysics(0.02);
+
+      Translation3d omega = sim.getBallOmegas().get(0);
+      assertTrue(
+          omega.getNorm() > 0.1, "Wall collision should impart spin: omega=" + omega.getNorm());
+    }
+
+    @Test
+    void groundFrictionSlowsSpin() {
+      config.magnusEnabled = false;
+      config.sleepingEnabled = false;
+      config.spinDecayEnabled = false; // test ground friction only
+      sim.setConfig(config);
+
+      // Ball on ground with high spin
+      sim.launchBall(
+          new Translation3d(8, 4, FuelPhysicsSim.getBallRadius()),
+          new Translation3d(0.5, 0, 0),
+          new Translation3d(0, 100, 0)); // High spin
+
+      double initialOmega = sim.getBallOmegas().get(0).getNorm();
+
+      for (int i = 0; i < 100; i++) sim.advancePhysics(0.02);
+
+      double finalOmega = sim.getBallOmegas().get(0).getNorm();
+      assertTrue(
+          finalOmega < initialOmega,
+          "Ground friction should reduce spin: initial=" + initialOmega + " final=" + finalOmega);
+    }
+
+    @Test
+    void noFrictionBallNeverStops() {
+      config.dragEnabled = false;
+      config.frictionEnabled = false;
+      config.sleepingEnabled = false;
+      config.magnusEnabled = false;
+      sim.setConfig(config);
+
+      // Y=1 avoids hub ramp geometry
+      sim.spawnBall(
+          new Translation3d(8, 1, FuelPhysicsSim.getBallRadius()), new Translation3d(3, 0, 0));
+
+      for (int i = 0; i < 500; i++) sim.advancePhysics(0.02);
+
+      Translation3d vel = sim.getBallVelocities().get(0);
+      double speed = Math.sqrt(vel.getX() * vel.getX() + vel.getY() * vel.getY());
+      // Speed decreases from COR on wall bounces, but stays > 1.0
+      assertTrue(speed > 1.0, "Ball should keep moving without friction: speed=" + speed);
+    }
+  }
+
+  @Nested
+  class Performance {
+    @Test
+    void fiftyBallStepUnder2ms() {
+      config.sleepingEnabled = false;
+      sim.setConfig(config);
+
+      for (int i = 0; i < 50; i++) {
+        sim.spawnBall(
+            new Translation3d(2 + (i % 10) * 0.5, 1 + (i / 10) * 0.5, 0.5 + (i % 5) * 0.3),
+            new Translation3d(Math.cos(i * 0.3) * 3, Math.sin(i * 0.3) * 3, 2));
+      }
+
+      // Warmup
+      for (int i = 0; i < 10; i++) sim.advancePhysics(0.02);
+
+      // Measure
+      long start = System.nanoTime();
+      int steps = 100;
+      for (int i = 0; i < steps; i++) sim.advancePhysics(0.02);
+      double meanMs = (System.nanoTime() - start) / 1_000_000.0 / steps;
+
+      assertTrue(meanMs < 5.0, "50-ball step should be under 5ms: " + meanMs + "ms");
+    }
+
+    @Test
+    void fourHundredBallStepUnder10ms() {
+      config.sleepingEnabled = true; // sleeping helps with resting balls
+      sim.setConfig(config);
+
+      for (int i = 0; i < 400; i++) {
+        sim.spawnBall(
+            new Translation3d(
+                1 + (i % 40) * 0.35, 0.5 + (i / 40) * 0.35, FuelPhysicsSim.getBallRadius()));
+      }
+
+      // Let balls settle (most will sleep)
+      for (int i = 0; i < 50; i++) sim.advancePhysics(0.02);
+
+      long start = System.nanoTime();
+      int steps = 50;
+      for (int i = 0; i < steps; i++) sim.advancePhysics(0.02);
+      double meanMs = (System.nanoTime() - start) / 1_000_000.0 / steps;
+
+      assertTrue(meanMs < 15.0, "400-ball step should be under 15ms: " + meanMs + "ms");
+    }
+  }
+
+  @Nested
+  class Determinism {
+    @Test
+    void sameInitialConditionsSameFinalState() {
+      config.deterministic = true;
+      config.deterministicSeed = 123L;
+      sim.setConfig(config);
+
+      sim.launchBall(new Translation3d(8, 4, 1), new Translation3d(5, 2, 8), 2000);
+      sim.launchBall(new Translation3d(6, 3, 0.5), new Translation3d(-3, 1, 4), 1000);
+
+      for (int i = 0; i < 200; i++) sim.advancePhysics(0.02);
+      List<Translation3d> positions1 = sim.getBallPositions();
+
+      // Run again with same setup
+      FuelPhysicsSim sim2 = new FuelPhysicsSim("Test/Det2", config);
+      sim2.enable();
+      sim2.setConfig(config);
+      sim2.launchBall(new Translation3d(8, 4, 1), new Translation3d(5, 2, 8), 2000);
+      sim2.launchBall(new Translation3d(6, 3, 0.5), new Translation3d(-3, 1, 4), 1000);
+
+      for (int i = 0; i < 200; i++) sim2.advancePhysics(0.02);
+      List<Translation3d> positions2 = sim2.getBallPositions();
+
+      assertEquals(positions1.size(), positions2.size(), "Same ball count");
+      for (int i = 0; i < positions1.size(); i++) {
+        assertEquals(
+            positions1.get(i).getX(),
+            positions2.get(i).getX(),
+            1e-9,
+            "X position mismatch at ball " + i);
+        assertEquals(
+            positions1.get(i).getY(),
+            positions2.get(i).getY(),
+            1e-9,
+            "Y position mismatch at ball " + i);
+        assertEquals(
+            positions1.get(i).getZ(),
+            positions2.get(i).getZ(),
+            1e-9,
+            "Z position mismatch at ball " + i);
+      }
+    }
+
+    @Test
+    void deterministicModeProducesReproducibleDispersal() {
+      config.deterministic = true;
+      config.deterministicSeed = 42L;
+      config.sleepingEnabled = false;
+      sim.setConfig(config);
+
+      // Drop ball directly above blue hub center
+      sim.launchBall(new Translation3d(4.5974, 4.035, 5.0), new Translation3d(0, 0, 0), 0);
+
+      // Run until scoring happens
+      for (int i = 0; i < 300; i++) sim.advancePhysics(0.02);
+
+      int scored1 = sim.getTotalScored();
+      List<Translation3d> finalPos1 = sim.getBallPositions();
+
+      // Repeat
+      FuelPhysicsSim sim2 = new FuelPhysicsSim("Test/Det3", config);
+      sim2.enable();
+      sim2.setConfig(config);
+      sim2.launchBall(new Translation3d(4.5974, 4.035, 5.0), new Translation3d(0, 0, 0), 0);
+      for (int i = 0; i < 300; i++) sim2.advancePhysics(0.02);
+
+      assertEquals(scored1, sim2.getTotalScored(), "Same scoring outcome");
+      if (!finalPos1.isEmpty() && !sim2.getBallPositions().isEmpty()) {
+        assertEquals(
+            finalPos1.get(0).getX(),
+            sim2.getBallPositions().get(0).getX(),
+            1e-9,
+            "Same dispersal position");
+      }
+    }
+  }
+
+  @Nested
+  class FeatureFlags {
+    @Test
+    void allFeaturesOffMatchesBaseline() {
+      // With all advanced features off, behavior should be simple Euler + bounce
+      config.magnusEnabled = false;
+      config.frictionEnabled = false;
+      config.spinTransferEnabled = false;
+      config.sleepingEnabled = false;
+      config.ccdEnabled = false;
+      config.velocityDependentCOR = false;
+      config.spinDecayEnabled = false;
+      config.solverIterations = 1;
+      sim.setConfig(config);
+
+      sim.launchBall(new Translation3d(8, 4, 2), new Translation3d(5, 0, 5), 0);
+
+      // Should still work without crashing
+      assertDoesNotThrow(
+          () -> {
             for (int i = 0; i < 100; i++) sim.advancePhysics(0.02);
+          });
 
-            Translation3d pos = sim.getBallPositions().get(0);
-            assertEquals(8.0, pos.getX(), 0.01, "Should not drift in X");
-            assertEquals(4.0, pos.getY(), 0.01, "Should not drift in Y");
-        }
+      assertTrue(sim.getBallCount() > 0, "Ball should still exist");
     }
 
-    @Nested
-    class MagnusAndSpin {
-        @Test
-        void magnusBackspinCurvesUpward() {
-            config.frictionEnabled = false;
-            config.sleepingEnabled = false;
-            config.spinDecayEnabled = false; // keep spin constant for clearer test
-            sim.setConfig(config);
+    @Test
+    void configCopyIsIndependent() {
+      PhysicsConfig original = new PhysicsConfig();
+      original.magnusEnabled = true;
+      PhysicsConfig copy = original.copy();
+      copy.magnusEnabled = false;
+      assertTrue(original.magnusEnabled, "Copy should not affect original");
+    }
+  }
 
-            // Ball with backspin (positive RPM = lift)
-            sim.launchBall(new Translation3d(3, 4, 0.5), new Translation3d(10, 0, 5), 3000);
+  @Nested
+  class HubScoring {
+    @Test
+    void ballScoresThroughHubOpening() {
+      config.sleepingEnabled = false;
+      config.magnusEnabled = false;
+      sim.setConfig(config);
 
-            // Ball without spin
-            FuelPhysicsSim simNoSpin = new FuelPhysicsSim("Test/NoSpin", config);
-            simNoSpin.enable();
-            PhysicsConfig noMagnusCfg = config.copy();
-            noMagnusCfg.magnusEnabled = false;
-            simNoSpin.setConfig(noMagnusCfg);
-            simNoSpin.launchBall(new Translation3d(3, 4, 0.5), new Translation3d(10, 0, 5), 0);
+      // Drop ball from directly above blue hub center so it falls through the opening
+      // Hub at (4.5974, 4.035), entry height at 1.829m
+      sim.launchBall(new Translation3d(4.5974, 4.035, 5.0), new Translation3d(0, 0, 0), 0);
 
-            // Track max height
-            double maxZSpin = 0, maxZNoSpin = 0;
-            for (int i = 0; i < 200; i++) {
-                sim.advancePhysics(0.02);
-                simNoSpin.advancePhysics(0.02);
-                if (sim.getBallCount() > 0)
-                    maxZSpin = Math.max(maxZSpin, sim.getBallPositions().get(0).getZ());
-                if (simNoSpin.getBallCount() > 0)
-                    maxZNoSpin = Math.max(maxZNoSpin, simNoSpin.getBallPositions().get(0).getZ());
-            }
+      for (int i = 0; i < 300; i++) {
+        sim.advancePhysics(0.02);
+      }
 
-            assertTrue(
-                    maxZSpin > maxZNoSpin,
-                    "Backspin should increase max height: spin="
-                            + maxZSpin
-                            + " noSpin="
-                            + maxZNoSpin);
-        }
-
-        @Test
-        void magnusSidespinCurvesSideways() {
-            config.frictionEnabled = false;
-            config.sleepingEnabled = false;
-            config.spinDecayEnabled = false;
-            sim.setConfig(config);
-
-            // Sidespin: omega around Z axis
-            double omegaZ = 300.0; // rad/s (about 2860 RPM around vertical axis)
-            sim.launchBall(
-                    new Translation3d(3, 4, 1),
-                    new Translation3d(10, 0, 3),
-                    new Translation3d(0, 0, omegaZ));
-
-            double maxYDisplacement = 0;
-            for (int i = 0; i < 200; i++) {
-                sim.advancePhysics(0.02);
-                if (sim.getBallCount() > 0) {
-                    double yDisp = Math.abs(sim.getBallPositions().get(0).getY() - 4.0);
-                    maxYDisplacement = Math.max(maxYDisplacement, yDisp);
-                }
-            }
-
-            assertTrue(
-                    maxYDisplacement > 0.05,
-                    "Sidespin should curve ball sideways: maxY=" + maxYDisplacement);
-        }
-
-        @Test
-        void magnusTopspinCurvesDownward() {
-            config.frictionEnabled = false;
-            config.sleepingEnabled = false;
-            config.spinDecayEnabled = false;
-            sim.setConfig(config);
-
-            // Topspin: negative of backspin (positive omega Y = topspin for +X velocity)
-            sim.launchBall(new Translation3d(3, 4, 0.5), new Translation3d(10, 0, 5), -3000);
-
-            FuelPhysicsSim simNoSpin = new FuelPhysicsSim("Test/NoSpin2", config);
-            simNoSpin.enable();
-            PhysicsConfig noMagnusCfg = config.copy();
-            noMagnusCfg.magnusEnabled = false;
-            simNoSpin.setConfig(noMagnusCfg);
-            simNoSpin.launchBall(new Translation3d(3, 4, 0.5), new Translation3d(10, 0, 5), 0);
-
-            // Only track the first arc (stop after apex to avoid ground bounce contamination)
-            double maxZTopSpin = 0, maxZNoSpin = 0;
-            boolean topPassed = false, noPassed = false;
-            double prevZTop = 0, prevZNo = 0;
-            for (int i = 0; i < 200; i++) {
-                sim.advancePhysics(0.02);
-                simNoSpin.advancePhysics(0.02);
-                if (sim.getBallCount() > 0 && !topPassed) {
-                    double z = sim.getBallPositions().get(0).getZ();
-                    if (z < prevZTop && prevZTop > 0.6) topPassed = true;
-                    maxZTopSpin = Math.max(maxZTopSpin, z);
-                    prevZTop = z;
-                }
-                if (simNoSpin.getBallCount() > 0 && !noPassed) {
-                    double z = simNoSpin.getBallPositions().get(0).getZ();
-                    if (z < prevZNo && prevZNo > 0.6) noPassed = true;
-                    maxZNoSpin = Math.max(maxZNoSpin, z);
-                    prevZNo = z;
-                }
-            }
-
-            assertTrue(
-                    maxZTopSpin < maxZNoSpin,
-                    "Topspin should lower apex: topspin=" + maxZTopSpin + " noSpin=" + maxZNoSpin);
-        }
-
-        @Test
-        void spinDecaysExponentially() {
-            config.frictionEnabled = false;
-            config.sleepingEnabled = false;
-            config.spinDecayTau = 1.0; // 1 second for easier testing
-            config.subticks = 10;
-            sim.setConfig(config);
-
-            double initialRPM = 5000;
-            sim.launchBall(new Translation3d(8, 4, 3), new Translation3d(0, 0, 0), initialRPM);
-
-            // Run for tau seconds
-            for (int i = 0; i < 50; i++) sim.advancePhysics(0.02); // 1 second total
-
-            List<Translation3d> omegas = sim.getBallOmegas();
-            double currentOmegaY = Math.abs(omegas.get(0).getY());
-            double initialOmegaY = initialRPM * 2.0 * Math.PI / 60.0;
-            double expectedOmega = initialOmegaY * Math.exp(-1.0); // 37% at t=tau
-
-            assertEquals(
-                    expectedOmega,
-                    currentOmegaY,
-                    expectedOmega * 0.10,
-                    "Spin should be ~37% of initial at t=tau");
-        }
-
-        @Test
-        void noMagnusDisablesCurve() {
-            config.magnusEnabled = false;
-            config.frictionEnabled = false;
-            config.sleepingEnabled = false;
-            sim.setConfig(config);
-
-            sim.launchBall(new Translation3d(3, 4, 1), new Translation3d(10, 0, 5), 5000);
-
-            // Without Magnus, spin should not affect trajectory
-            FuelPhysicsSim simNoSpin = new FuelPhysicsSim("Test/NoSpinRef", config);
-            simNoSpin.enable();
-            simNoSpin.setConfig(config);
-            simNoSpin.launchBall(new Translation3d(3, 4, 1), new Translation3d(10, 0, 5), 0);
-
-            for (int i = 0; i < 100; i++) {
-                sim.advancePhysics(0.02);
-                simNoSpin.advancePhysics(0.02);
-            }
-
-            if (sim.getBallCount() > 0 && simNoSpin.getBallCount() > 0) {
-                Translation3d posSpin = sim.getBallPositions().get(0);
-                Translation3d posNoSpin = simNoSpin.getBallPositions().get(0);
-                // Positions should be very close since Magnus is disabled
-                assertEquals(posNoSpin.getZ(), posSpin.getZ(), 0.1, "No Magnus = same trajectory");
-            }
-        }
+      assertTrue(sim.getTotalScored() > 0, "Ball should have scored in hub");
     }
 
-    @Nested
-    class ConservationLaws {
-        @Test
-        void energyDecreasesMonotonically() {
-            // With real COR values, energy should never increase
-            config.sleepingEnabled = false;
-            config.subticks = 5;
-            sim.setConfig(config);
+    @Test
+    void hubScoreCountIncrements() {
+      config.sleepingEnabled = false;
+      config.magnusEnabled = false;
+      sim.setConfig(config);
 
-            sim.launchBall(new Translation3d(8, 4, 3), new Translation3d(5, 2, 8), 1000);
+      // Drop first ball above hub
+      sim.launchBall(new Translation3d(4.5974, 4.035, 5.0), new Translation3d(0, 0, 0), 0);
 
-            double prevEnergy = sim.getTotalKineticEnergy() + sim.getTotalPotentialEnergy();
-            int violations = 0;
+      for (int i = 0; i < 200; i++) sim.advancePhysics(0.02);
 
-            for (int i = 0; i < 500; i++) {
-                sim.advancePhysics(0.02);
-                double energy = sim.getTotalKineticEnergy() + sim.getTotalPotentialEnergy();
-                if (energy > prevEnergy + 0.01) { // 10mJ tolerance for numerical noise
-                    violations++;
-                }
-                prevEnergy = energy;
-            }
+      int firstScore = sim.getTotalScored();
 
-            // Allow a few violations from numerical noise, but not many
-            assertTrue(
-                    violations < 10, "Energy increased " + violations + " times out of 500 steps");
-        }
+      // Drop second ball
+      sim.launchBall(new Translation3d(4.5974, 4.035, 5.0), new Translation3d(0, 0, 0), 0);
 
-        @Test
-        void momentumConservedInBallBallCollision() {
-            // Two balls colliding in vacuum with no gravity or drag
-            config.magnusEnabled = false;
-            config.frictionEnabled = false;
-            config.sleepingEnabled = false;
-            config.spinTransferEnabled = false;
-            config.subticks = 10;
-            sim.setConfig(config);
+      for (int i = 0; i < 200; i++) sim.advancePhysics(0.02);
 
-            // Two balls approaching each other
-            sim.spawnBall(new Translation3d(7.5, 4, 2), new Translation3d(3, 0, 0));
-            sim.spawnBall(new Translation3d(8.5, 4, 2), new Translation3d(-3, 0, 0));
-
-            Translation3d initialMomentum = sim.getTotalMomentum();
-
-            // Step until collision happens and resolves
-            for (int i = 0; i < 100; i++) sim.advancePhysics(0.02);
-
-            Translation3d finalMomentum = sim.getTotalMomentum();
-
-            // Momentum should be conserved (X components should sum to 0 since equal and opposite)
-            assertEquals(
-                    initialMomentum.getX(), finalMomentum.getX(), 0.01, "X momentum not conserved");
-            assertEquals(
-                    initialMomentum.getY(), finalMomentum.getY(), 0.01, "Y momentum not conserved");
-        }
-
-        @Test
-        void angularMomentumConservedInIsolatedCollision() {
-            // Two spinning balls collide. Total angular momentum should be roughly conserved.
-            config.magnusEnabled = false;
-            config.sleepingEnabled = false;
-            config.subticks = 10;
-            sim.setConfig(config);
-
-            double omega1 = 100.0; // rad/s
-            sim.launchBall(
-                    new Translation3d(7.5, 4, 2),
-                    new Translation3d(3, 0, 0),
-                    new Translation3d(0, omega1, 0));
-            sim.launchBall(
-                    new Translation3d(8.5, 4, 2),
-                    new Translation3d(-3, 0, 0),
-                    new Translation3d(0, -omega1, 0));
-
-            double mass = FuelPhysicsSim.getBallMass();
-            double I = FuelPhysicsSim.getMomentOfInertia();
-
-            // Compute initial total angular momentum about origin
-            // L = r x (m*v) + I*omega for each ball
-            // This is complex, so just check omega conservation
-            List<Translation3d> initialOmegas = sim.getBallOmegas();
-            double initialTotalOmegaY = 0;
-            for (Translation3d o : initialOmegas) initialTotalOmegaY += o.getY();
-
-            for (int i = 0; i < 100; i++) sim.advancePhysics(0.02);
-
-            List<Translation3d> finalOmegas = sim.getBallOmegas();
-            double finalTotalOmegaY = 0;
-            for (Translation3d o : finalOmegas) finalTotalOmegaY += o.getY();
-
-            // Total spin should be roughly conserved (some energy goes to translation)
-            // Use a wider tolerance since spin-transfer mechanics are approximate
-            assertEquals(
-                    initialTotalOmegaY,
-                    finalTotalOmegaY,
-                    Math.abs(initialTotalOmegaY) * 0.5 + 1.0,
-                    "Angular momentum should be approximately conserved");
-        }
+      assertTrue(
+          sim.getTotalScored() >= firstScore, "Score should increment with each scoring ball");
     }
+  }
 
-    @Nested
-    class Collisions {
-        @Test
-        void multiBodyPileSettlesInFiniteIterations() {
-            config.sleepingEnabled = false;
-            config.subticks = 5;
-            sim.setConfig(config);
+  @Nested
+  class DragTests {
+    @Test
+    void dragReducesRange() {
+      config.magnusEnabled = false;
+      config.frictionEnabled = false;
+      config.sleepingEnabled = false;
+      sim.setConfig(config);
 
-            // Stack 5 balls vertically
-            for (int i = 0; i < 5; i++) {
-                sim.spawnBall(
-                        new Translation3d(
-                                8,
-                                4,
-                                FuelPhysicsSim.getBallRadius()
-                                        + i * FuelPhysicsSim.getBallRadius() * 2.5),
-                        new Translation3d(0, 0, -1));
-            }
+      // With drag
+      sim.launchBall(new Translation3d(2, 3, 0.5), new Translation3d(10, 0, 10), 0);
 
-            // Let them settle
-            for (int i = 0; i < 200; i++) sim.advancePhysics(0.02);
+      // Without drag (separate sim, but we test by comparing vacuum analytical)
+      double v = Math.sqrt(10 * 10 + 10 * 10);
+      double theta = Math.atan2(10, 10);
+      double vacuumRange = v * v * Math.sin(2 * theta) / 9.81;
 
-            // All balls should have low velocity
-            for (Translation3d vel : sim.getBallVelocities()) {
-                assertTrue(vel.getNorm() < 0.5, "Ball should have settled: speed=" + vel.getNorm());
-            }
-        }
+      for (int i = 0; i < 300; i++) sim.advancePhysics(0.02);
 
-        @Test
-        void stackedBallsDoNotJitter() {
-            config.sleepingEnabled = false;
-            config.subticks = 5;
-            sim.setConfig(config);
-
-            // Let balls settle first
-            for (int i = 0; i < 3; i++) {
-                sim.spawnBall(
-                        new Translation3d(
-                                8,
-                                4,
-                                FuelPhysicsSim.getBallRadius()
-                                        + i * FuelPhysicsSim.getBallRadius() * 2.2));
-            }
-            for (int i = 0; i < 300; i++) sim.advancePhysics(0.02);
-
-            // Record positions, run 200 more steps, check stability
-            List<Translation3d> posBefore = sim.getBallPositions();
-            for (int i = 0; i < 200; i++) sim.advancePhysics(0.02);
-            List<Translation3d> posAfter = sim.getBallPositions();
-
-            for (int i = 0; i < Math.min(posBefore.size(), posAfter.size()); i++) {
-                double drift = posBefore.get(i).getDistance(posAfter.get(i));
-                assertTrue(drift < 0.05, "Ball " + i + " jittered by " + drift + "m");
-            }
-        }
-
-        @Test
-        void penetrationStaysBelowTolerance() {
-            config.sleepingEnabled = false;
-            sim.setConfig(config);
-
-            // Ball bouncing on ground
-            sim.launchBall(new Translation3d(8, 4, 3), new Translation3d(0, 0, -10), 0);
-
-            double maxPenetration = 0;
-            for (int i = 0; i < 500; i++) {
-                sim.advancePhysics(0.02);
-                if (sim.getBallCount() > 0) {
-                    double z = sim.getBallPositions().get(0).getZ();
-                    double pen = FuelPhysicsSim.getBallRadius() - z;
-                    maxPenetration = Math.max(maxPenetration, pen);
-                }
-            }
-
-            assertTrue(
-                    maxPenetration < 0.005,
-                    "Penetration should stay below 5mm: " + maxPenetration + "m");
-        }
-
-        @Test
-        void wallBounceWithCorrectCOR() {
-            config.magnusEnabled = false;
-            config.frictionEnabled = false;
-            config.sleepingEnabled = false;
-            config.velocityDependentCOR = false;
-            sim.setConfig(config);
-
-            // Ball moving toward X=0 wall
-            double incomingSpeed = 5.0;
-            sim.spawnBall(
-                    new Translation3d(FuelPhysicsSim.getBallRadius() + 0.01, 4, 0.3),
-                    new Translation3d(-incomingSpeed, 0, 0));
-
-            sim.advancePhysics(0.02);
-
-            Translation3d vel = sim.getBallVelocities().get(0);
-            double expectedBounceSpeed = incomingSpeed * FuelPhysicsSim.getFieldCOR();
-            assertEquals(
-                    expectedBounceSpeed,
-                    vel.getX(),
-                    expectedBounceSpeed * 0.15,
-                    "Bounce speed should match COR");
-            assertTrue(vel.getX() > 0, "Ball should bounce away from wall");
-        }
-
-        @Test
-        void ballBallCollisionWorks() {
-            config.magnusEnabled = false;
-            config.frictionEnabled = false;
-            config.sleepingEnabled = false;
-            config.subticks = 10;
-            sim.setConfig(config);
-
-            // Two balls on collision course (at same height, no gravity effect)
-            sim.spawnBall(new Translation3d(7.8, 4, 2), new Translation3d(5, 0, 0));
-            sim.spawnBall(new Translation3d(8.2, 4, 2), new Translation3d(-5, 0, 0));
-
-            // Run until they collide and separate
-            for (int i = 0; i < 50; i++) sim.advancePhysics(0.02);
-
-            List<Translation3d> vels = sim.getBallVelocities();
-            if (vels.size() >= 2) {
-                // After collision, velocities should have reversed direction
-                // (with COR < 1, they'll be slower)
-                assertTrue(vels.get(0).getX() < 0, "Ball A should reverse: " + vels.get(0).getX());
-                assertTrue(vels.get(1).getX() > 0, "Ball B should reverse: " + vels.get(1).getX());
-            }
-        }
-
-        @Test
-        void fastBallDoesNotTunnelThroughWall() {
-            config.ccdEnabled = true;
-            config.sleepingEnabled = false;
-            sim.setConfig(config);
-
-            // Very fast ball aimed at alliance wall
-            sim.spawnBall(new Translation3d(1, 4, 0.3), new Translation3d(-50, 0, 0));
-
-            sim.advancePhysics(0.02);
-
-            // Ball should NOT have gone through the wall
-            Translation3d pos = sim.getBallPositions().get(0);
-            assertTrue(
-                    pos.getX() >= FuelPhysicsSim.getBallRadius() - 0.01,
-                    "Ball tunneled through wall: x=" + pos.getX());
-        }
-
-        @Test
-        void fastBallDoesNotTunnelThroughThinObstacle() {
-            config.ccdEnabled = true;
-            config.sleepingEnabled = false;
-            config.subticks = 1; // Deliberately low to test CCD
-            sim.setConfig(config);
-
-            // Fast ball aimed at a trench pillar (about 0.3m wide)
-            // Trench pillar at approximately X=3.96..4.265
-            sim.spawnBall(new Translation3d(3.5, 1.4, 0.5), new Translation3d(50, 0, 0));
-
-            sim.advancePhysics(0.02);
-
-            // Ball should have been stopped by CCD
-            Translation3d pos = sim.getBallPositions().get(0);
-            // Should not have passed through to X > 4.3
-            // (it might bounce back or stop at the pillar)
-            assertTrue(
-                    pos.getX() < 5.0 || pos.getX() > 4.3,
-                    "CCD should prevent tunneling: x=" + pos.getX());
-        }
-
-        @Test
-        void higherImpactSpeedLowerBounceHeight() {
-            config.velocityDependentCOR = true;
-            config.magnusEnabled = false;
-            config.frictionEnabled = false;
-            config.sleepingEnabled = false;
-            sim.setConfig(config);
-
-            // Slow drop
-            FuelPhysicsSim simSlow = new FuelPhysicsSim("Test/Slow", config);
-            simSlow.enable();
-            simSlow.setConfig(config);
-            simSlow.spawnBall(new Translation3d(8, 3, 1)); // 1m drop
-
-            // Fast drop
-            FuelPhysicsSim simFast = new FuelPhysicsSim("Test/Fast", config);
-            simFast.enable();
-            simFast.setConfig(config);
-            simFast.spawnBall(new Translation3d(8, 5, 5)); // 5m drop
-
-            double maxBounceSlow = 0, maxBounceFast = 0;
-            boolean slowBounced = false, fastBounced = false;
-
-            for (int i = 0; i < 300; i++) {
-                simSlow.advancePhysics(0.02);
-                simFast.advancePhysics(0.02);
-
-                if (simSlow.getBallCount() > 0) {
-                    double z = simSlow.getBallPositions().get(0).getZ();
-                    double vz = simSlow.getBallVelocities().get(0).getZ();
-                    if (slowBounced) maxBounceSlow = Math.max(maxBounceSlow, z);
-                    if (vz > 0 && z < 0.2) slowBounced = true;
-                }
-                if (simFast.getBallCount() > 0) {
-                    double z = simFast.getBallPositions().get(0).getZ();
-                    double vz = simFast.getBallVelocities().get(0).getZ();
-                    if (fastBounced) maxBounceFast = Math.max(maxBounceFast, z);
-                    if (vz > 0 && z < 0.2) fastBounced = true;
-                }
-            }
-
-            if (maxBounceSlow > 0 && maxBounceFast > 0) {
-                // COR ratio: fast should bounce relatively lower than slow
-                double ratioSlow = maxBounceSlow / 1.0;
-                double ratioFast = maxBounceFast / 5.0;
-                assertTrue(
-                        ratioFast < ratioSlow,
-                        "Higher impact should have lower COR ratio: slow="
-                                + ratioSlow
-                                + " fast="
-                                + ratioFast);
-            }
-        }
-
-        @Test
-        void ballGrazingRungDeflectsTangentially() {
-            config.sleepingEnabled = false;
-            config.magnusEnabled = false;
-            sim.setConfig(config);
-
-            // Ball at tower rung height, moving toward it at a tangent
-            // Blue tower rung at X=0, Y~3.6..4.5, Z=0.686
-            sim.spawnBall(new Translation3d(0.3, 3.5, 0.686), new Translation3d(-3, 1, 0));
-
-            for (int i = 0; i < 50; i++) sim.advancePhysics(0.02);
-
-            // Ball should have been deflected (Y component changed)
-            Translation3d vel = sim.getBallVelocities().get(0);
-            assertTrue(vel.getNorm() > 0.1, "Ball should still be moving after rung deflection");
-        }
+      double actualRange = 0;
+      for (Translation3d pos : sim.getBallPositions()) {
+        actualRange = Math.max(actualRange, pos.getX() - 2.0);
+      }
+      // With drag, range should be shorter than vacuum
+      assertTrue(
+          actualRange < vacuumRange,
+          "Drag should reduce range: actual=" + actualRange + " vacuum=" + vacuumRange);
     }
-
-    @Nested
-    class Sleeping {
-        @Test
-        void sleepingBallsReduceComputeTime() {
-            config.sleepingEnabled = true;
-            config.subticks = 5;
-            sim.setConfig(config);
-
-            // Spawn many balls at rest (they should sleep quickly)
-            for (int i = 0; i < 350; i++) {
-                sim.spawnBall(
-                        new Translation3d(
-                                2 + (i % 50) * 0.2,
-                                1 + (i / 50) * 0.2,
-                                FuelPhysicsSim.getBallRadius()));
-            }
-
-            // Let them settle and sleep
-            for (int i = 0; i < 100; i++) sim.advancePhysics(0.02);
-
-            int sleeping = sim.getSleepingBallCount();
-            assertTrue(sleeping > 200, "Most resting balls should be sleeping: " + sleeping);
-
-            // Time a step with mostly sleeping balls
-            long start = System.nanoTime();
-            for (int i = 0; i < 10; i++) sim.advancePhysics(0.02);
-            double elapsedMs = (System.nanoTime() - start) / 1_000_000.0 / 10.0;
-
-            assertTrue(
-                    elapsedMs < 2.0,
-                    "Step with sleeping balls should be fast: " + elapsedMs + "ms");
-        }
-
-        @Test
-        void sleepingBallWakesOnExternalCollision() {
-            config.sleepingEnabled = true;
-            sim.setConfig(config);
-
-            // Spawn ball at rest, let it sleep (Y=1 avoids hub geometry)
-            sim.spawnBall(new Translation3d(8, 1, FuelPhysicsSim.getBallRadius()));
-            for (int i = 0; i < 50; i++) sim.advancePhysics(0.02);
-
-            assertTrue(sim.getSleepingBallCount() > 0, "Ball should be sleeping");
-
-            // Launch a ball at it
-            sim.launchBall(
-                    new Translation3d(7, 1, FuelPhysicsSim.getBallRadius()),
-                    new Translation3d(5, 0, 0),
-                    0);
-
-            // Run until collision
-            for (int i = 0; i < 50; i++) sim.advancePhysics(0.02);
-
-            // The resting ball should have woken up
-            assertEquals(0, sim.getSleepingBallCount(), "Collision should wake sleeping ball");
-        }
-
-        @Test
-        void allBallsEventuallySleep() {
-            config.sleepingEnabled = true;
-            sim.setConfig(config);
-
-            // Spawn 50 balls with small velocities
-            for (int i = 0; i < 50; i++) {
-                sim.spawnBall(
-                        new Translation3d(
-                                3 + (i % 10) * 0.3,
-                                2 + (i / 10) * 0.3,
-                                FuelPhysicsSim.getBallRadius()),
-                        new Translation3d(0.1, 0.05, 0));
-            }
-
-            for (int i = 0; i < 500; i++) sim.advancePhysics(0.02);
-
-            int sleeping = sim.getSleepingBallCount();
-            assertTrue(sleeping >= 25, "Most balls should eventually sleep: " + sleeping + "/50");
-        }
-
-        @Test
-        void noSleepingAllBallsAlwaysActive() {
-            config.sleepingEnabled = false;
-            sim.setConfig(config);
-
-            for (int i = 0; i < 10; i++) {
-                sim.spawnBall(new Translation3d(8, 4, FuelPhysicsSim.getBallRadius()));
-            }
-            for (int i = 0; i < 100; i++) sim.advancePhysics(0.02);
-
-            assertEquals(0, sim.getSleepingBallCount(), "No sleeping when disabled");
-        }
-    }
-
-    @Nested
-    class FrictionAndSpinTransfer {
-        @Test
-        void slidingBallDeceleratesAtMuTimesG() {
-            config.magnusEnabled = false;
-            config.dragEnabled = false; // isolate ground friction from air drag
-            config.sleepingEnabled = false;
-            config.spinTransferEnabled = false;
-            sim.setConfig(config);
-
-            double initialSpeed = 5.0;
-            sim.spawnBall(
-                    new Translation3d(8, 4, FuelPhysicsSim.getBallRadius()),
-                    new Translation3d(initialSpeed, 0, 0));
-
-            sim.advancePhysics(0.5); // 0.5 seconds
-
-            Translation3d vel = sim.getBallVelocities().get(0);
-            double finalSpeed = Math.abs(vel.getX());
-
-            // Expected deceleration: mu_k * g = 0.3 * 9.81 = 2.943 m/s^2
-            // After 0.5s: v = 5 - 2.943*0.5 = 3.53 m/s
-            double expectedSpeed = initialSpeed - 0.3 * 9.81 * 0.5;
-            assertEquals(
-                    expectedSpeed,
-                    finalSpeed,
-                    expectedSpeed * 0.2,
-                    "Ground friction deceleration should match mu*g");
-        }
-
-        @Test
-        void spinTransferOnWallCollision() {
-            config.sleepingEnabled = false;
-            config.magnusEnabled = false;
-            sim.setConfig(config);
-
-            // Ball with no spin hits a wall
-            sim.spawnBall(
-                    new Translation3d(FuelPhysicsSim.getBallRadius() + 0.01, 4, 0.3),
-                    new Translation3d(-5, 3, 0)); // Oblique hit
-
-            sim.advancePhysics(0.02);
-
-            Translation3d omega = sim.getBallOmegas().get(0);
-            assertTrue(
-                    omega.getNorm() > 0.1,
-                    "Wall collision should impart spin: omega=" + omega.getNorm());
-        }
-
-        @Test
-        void groundFrictionSlowsSpin() {
-            config.magnusEnabled = false;
-            config.sleepingEnabled = false;
-            config.spinDecayEnabled = false; // test ground friction only
-            sim.setConfig(config);
-
-            // Ball on ground with high spin
-            sim.launchBall(
-                    new Translation3d(8, 4, FuelPhysicsSim.getBallRadius()),
-                    new Translation3d(0.5, 0, 0),
-                    new Translation3d(0, 100, 0)); // High spin
-
-            double initialOmega = sim.getBallOmegas().get(0).getNorm();
-
-            for (int i = 0; i < 100; i++) sim.advancePhysics(0.02);
-
-            double finalOmega = sim.getBallOmegas().get(0).getNorm();
-            assertTrue(
-                    finalOmega < initialOmega,
-                    "Ground friction should reduce spin: initial="
-                            + initialOmega
-                            + " final="
-                            + finalOmega);
-        }
-
-        @Test
-        void noFrictionBallNeverStops() {
-            config.dragEnabled = false;
-            config.frictionEnabled = false;
-            config.sleepingEnabled = false;
-            config.magnusEnabled = false;
-            sim.setConfig(config);
-
-            // Y=1 avoids hub ramp geometry
-            sim.spawnBall(
-                    new Translation3d(8, 1, FuelPhysicsSim.getBallRadius()),
-                    new Translation3d(3, 0, 0));
-
-            for (int i = 0; i < 500; i++) sim.advancePhysics(0.02);
-
-            Translation3d vel = sim.getBallVelocities().get(0);
-            double speed = Math.sqrt(vel.getX() * vel.getX() + vel.getY() * vel.getY());
-            // Speed decreases from COR on wall bounces, but stays > 1.0
-            assertTrue(speed > 1.0, "Ball should keep moving without friction: speed=" + speed);
-        }
-    }
-
-    @Nested
-    class Performance {
-        @Test
-        void fiftyBallStepUnder2ms() {
-            config.sleepingEnabled = false;
-            sim.setConfig(config);
-
-            for (int i = 0; i < 50; i++) {
-                sim.spawnBall(
-                        new Translation3d(
-                                2 + (i % 10) * 0.5, 1 + (i / 10) * 0.5, 0.5 + (i % 5) * 0.3),
-                        new Translation3d(Math.cos(i * 0.3) * 3, Math.sin(i * 0.3) * 3, 2));
-            }
-
-            // Warmup
-            for (int i = 0; i < 10; i++) sim.advancePhysics(0.02);
-
-            // Measure
-            long start = System.nanoTime();
-            int steps = 100;
-            for (int i = 0; i < steps; i++) sim.advancePhysics(0.02);
-            double meanMs = (System.nanoTime() - start) / 1_000_000.0 / steps;
-
-            assertTrue(meanMs < 5.0, "50-ball step should be under 5ms: " + meanMs + "ms");
-        }
-
-        @Test
-        void fourHundredBallStepUnder10ms() {
-            config.sleepingEnabled = true; // sleeping helps with resting balls
-            sim.setConfig(config);
-
-            for (int i = 0; i < 400; i++) {
-                sim.spawnBall(
-                        new Translation3d(
-                                1 + (i % 40) * 0.35,
-                                0.5 + (i / 40) * 0.35,
-                                FuelPhysicsSim.getBallRadius()));
-            }
-
-            // Let balls settle (most will sleep)
-            for (int i = 0; i < 50; i++) sim.advancePhysics(0.02);
-
-            long start = System.nanoTime();
-            int steps = 50;
-            for (int i = 0; i < steps; i++) sim.advancePhysics(0.02);
-            double meanMs = (System.nanoTime() - start) / 1_000_000.0 / steps;
-
-            assertTrue(meanMs < 15.0, "400-ball step should be under 15ms: " + meanMs + "ms");
-        }
-    }
-
-    @Nested
-    class Determinism {
-        @Test
-        void sameInitialConditionsSameFinalState() {
-            config.deterministic = true;
-            config.deterministicSeed = 123L;
-            sim.setConfig(config);
-
-            sim.launchBall(new Translation3d(8, 4, 1), new Translation3d(5, 2, 8), 2000);
-            sim.launchBall(new Translation3d(6, 3, 0.5), new Translation3d(-3, 1, 4), 1000);
-
-            for (int i = 0; i < 200; i++) sim.advancePhysics(0.02);
-            List<Translation3d> positions1 = sim.getBallPositions();
-
-            // Run again with same setup
-            FuelPhysicsSim sim2 = new FuelPhysicsSim("Test/Det2", config);
-            sim2.enable();
-            sim2.setConfig(config);
-            sim2.launchBall(new Translation3d(8, 4, 1), new Translation3d(5, 2, 8), 2000);
-            sim2.launchBall(new Translation3d(6, 3, 0.5), new Translation3d(-3, 1, 4), 1000);
-
-            for (int i = 0; i < 200; i++) sim2.advancePhysics(0.02);
-            List<Translation3d> positions2 = sim2.getBallPositions();
-
-            assertEquals(positions1.size(), positions2.size(), "Same ball count");
-            for (int i = 0; i < positions1.size(); i++) {
-                assertEquals(
-                        positions1.get(i).getX(),
-                        positions2.get(i).getX(),
-                        1e-9,
-                        "X position mismatch at ball " + i);
-                assertEquals(
-                        positions1.get(i).getY(),
-                        positions2.get(i).getY(),
-                        1e-9,
-                        "Y position mismatch at ball " + i);
-                assertEquals(
-                        positions1.get(i).getZ(),
-                        positions2.get(i).getZ(),
-                        1e-9,
-                        "Z position mismatch at ball " + i);
-            }
-        }
-
-        @Test
-        void deterministicModeProducesReproducibleDispersal() {
-            config.deterministic = true;
-            config.deterministicSeed = 42L;
-            config.sleepingEnabled = false;
-            sim.setConfig(config);
-
-            // Drop ball directly above blue hub center
-            sim.launchBall(new Translation3d(4.5974, 4.035, 5.0), new Translation3d(0, 0, 0), 0);
-
-            // Run until scoring happens
-            for (int i = 0; i < 300; i++) sim.advancePhysics(0.02);
-
-            int scored1 = sim.getTotalScored();
-            List<Translation3d> finalPos1 = sim.getBallPositions();
-
-            // Repeat
-            FuelPhysicsSim sim2 = new FuelPhysicsSim("Test/Det3", config);
-            sim2.enable();
-            sim2.setConfig(config);
-            sim2.launchBall(new Translation3d(4.5974, 4.035, 5.0), new Translation3d(0, 0, 0), 0);
-            for (int i = 0; i < 300; i++) sim2.advancePhysics(0.02);
-
-            assertEquals(scored1, sim2.getTotalScored(), "Same scoring outcome");
-            if (!finalPos1.isEmpty() && !sim2.getBallPositions().isEmpty()) {
-                assertEquals(
-                        finalPos1.get(0).getX(),
-                        sim2.getBallPositions().get(0).getX(),
-                        1e-9,
-                        "Same dispersal position");
-            }
-        }
-    }
-
-    @Nested
-    class FeatureFlags {
-        @Test
-        void allFeaturesOffMatchesBaseline() {
-            // With all advanced features off, behavior should be simple Euler + bounce
-            config.magnusEnabled = false;
-            config.frictionEnabled = false;
-            config.spinTransferEnabled = false;
-            config.sleepingEnabled = false;
-            config.ccdEnabled = false;
-            config.velocityDependentCOR = false;
-            config.spinDecayEnabled = false;
-            config.solverIterations = 1;
-            sim.setConfig(config);
-
-            sim.launchBall(new Translation3d(8, 4, 2), new Translation3d(5, 0, 5), 0);
-
-            // Should still work without crashing
-            assertDoesNotThrow(
-                    () -> {
-                        for (int i = 0; i < 100; i++) sim.advancePhysics(0.02);
-                    });
-
-            assertTrue(sim.getBallCount() > 0, "Ball should still exist");
-        }
-
-        @Test
-        void configCopyIsIndependent() {
-            PhysicsConfig original = new PhysicsConfig();
-            original.magnusEnabled = true;
-            PhysicsConfig copy = original.copy();
-            copy.magnusEnabled = false;
-            assertTrue(original.magnusEnabled, "Copy should not affect original");
-        }
-    }
-
-    @Nested
-    class HubScoring {
-        @Test
-        void ballScoresThroughHubOpening() {
-            config.sleepingEnabled = false;
-            config.magnusEnabled = false;
-            sim.setConfig(config);
-
-            // Drop ball from directly above blue hub center so it falls through the opening
-            // Hub at (4.5974, 4.035), entry height at 1.829m
-            sim.launchBall(new Translation3d(4.5974, 4.035, 5.0), new Translation3d(0, 0, 0), 0);
-
-            for (int i = 0; i < 300; i++) {
-                sim.advancePhysics(0.02);
-            }
-
-            assertTrue(sim.getTotalScored() > 0, "Ball should have scored in hub");
-        }
-
-        @Test
-        void hubScoreCountIncrements() {
-            config.sleepingEnabled = false;
-            config.magnusEnabled = false;
-            sim.setConfig(config);
-
-            // Drop first ball above hub
-            sim.launchBall(new Translation3d(4.5974, 4.035, 5.0), new Translation3d(0, 0, 0), 0);
-
-            for (int i = 0; i < 200; i++) sim.advancePhysics(0.02);
-
-            int firstScore = sim.getTotalScored();
-
-            // Drop second ball
-            sim.launchBall(new Translation3d(4.5974, 4.035, 5.0), new Translation3d(0, 0, 0), 0);
-
-            for (int i = 0; i < 200; i++) sim.advancePhysics(0.02);
-
-            assertTrue(
-                    sim.getTotalScored() >= firstScore,
-                    "Score should increment with each scoring ball");
-        }
-    }
-
-    @Nested
-    class DragTests {
-        @Test
-        void dragReducesRange() {
-            config.magnusEnabled = false;
-            config.frictionEnabled = false;
-            config.sleepingEnabled = false;
-            sim.setConfig(config);
-
-            // With drag
-            sim.launchBall(new Translation3d(2, 3, 0.5), new Translation3d(10, 0, 10), 0);
-
-            // Without drag (separate sim, but we test by comparing vacuum analytical)
-            double v = Math.sqrt(10 * 10 + 10 * 10);
-            double theta = Math.atan2(10, 10);
-            double vacuumRange = v * v * Math.sin(2 * theta) / 9.81;
-
-            for (int i = 0; i < 300; i++) sim.advancePhysics(0.02);
-
-            double actualRange = 0;
-            for (Translation3d pos : sim.getBallPositions()) {
-                actualRange = Math.max(actualRange, pos.getX() - 2.0);
-            }
-            // With drag, range should be shorter than vacuum
-            assertTrue(
-                    actualRange < vacuumRange,
-                    "Drag should reduce range: actual=" + actualRange + " vacuum=" + vacuumRange);
-        }
-    }
+  }
 }

--- a/src/test/java/frc/robot/sim/SimFuelManagerTest.java
+++ b/src/test/java/frc/robot/sim/SimFuelManagerTest.java
@@ -5,7 +5,6 @@ import static org.junit.jupiter.api.Assertions.*;
 import edu.wpi.first.hal.HAL;
 import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.math.geometry.Rotation2d;
-
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -13,89 +12,89 @@ import org.junit.jupiter.api.Test;
 /** Tests for SimFuelManager shot detection and feature flags. */
 class SimFuelManagerTest {
 
-    private SimFuelManager manager;
-    private FuelPhysicsSim sim;
+  private SimFuelManager manager;
+  private FuelPhysicsSim sim;
 
-    @BeforeAll
-    static void initHAL() {
-        HAL.initialize(500, 0);
-    }
+  @BeforeAll
+  static void initHAL() {
+    HAL.initialize(500, 0);
+  }
 
-    @BeforeEach
-    void setUp() {
-        FuelPhysicsSim.PhysicsConfig config = new FuelPhysicsSim.PhysicsConfig();
-        config.deterministic = true;
-        config.deterministicSeed = 42L;
-        sim = new FuelPhysicsSim("Test/FuelManager", config);
-        manager = new SimFuelManager(sim);
-        manager.enable();
-    }
+  @BeforeEach
+  void setUp() {
+    FuelPhysicsSim.PhysicsConfig config = new FuelPhysicsSim.PhysicsConfig();
+    config.deterministic = true;
+    config.deterministicSeed = 42L;
+    sim = new FuelPhysicsSim("Test/FuelManager", config);
+    manager = new SimFuelManager(sim);
+    manager.enable();
+  }
 
-    @Test
-    void shotDetectionCreatesBall() {
-        Pose2d pose = new Pose2d(8, 4, Rotation2d.kZero);
-        // Rising edge: false -> true
-        manager.update(false, pose, 0, 3000);
-        assertEquals(0, sim.getBallCount(), "No ball before rising edge");
+  @Test
+  void shotDetectionCreatesBall() {
+    Pose2d pose = new Pose2d(8, 4, Rotation2d.kZero);
+    // Rising edge: false -> true
+    manager.update(false, pose, 0, 3000);
+    assertEquals(0, sim.getBallCount(), "No ball before rising edge");
 
-        manager.update(true, pose, 0, 3000);
-        assertEquals(1, sim.getBallCount(), "Ball should spawn on rising edge");
-    }
+    manager.update(true, pose, 0, 3000);
+    assertEquals(1, sim.getBallCount(), "Ball should spawn on rising edge");
+  }
 
-    @Test
-    void noShotOnSustainedHigh() {
-        Pose2d pose = new Pose2d(8, 4, Rotation2d.kZero);
-        manager.update(true, pose, 0, 3000); // First rising edge
-        assertEquals(1, sim.getBallCount());
+  @Test
+  void noShotOnSustainedHigh() {
+    Pose2d pose = new Pose2d(8, 4, Rotation2d.kZero);
+    manager.update(true, pose, 0, 3000); // First rising edge
+    assertEquals(1, sim.getBallCount());
 
-        manager.update(true, pose, 0, 3000); // Still high, no new edge
-        assertEquals(1, sim.getBallCount(), "No new ball without rising edge");
-    }
+    manager.update(true, pose, 0, 3000); // Still high, no new edge
+    assertEquals(1, sim.getBallCount(), "No new ball without rising edge");
+  }
 
-    @Test
-    void lowRPMRejectsShotCreation() {
-        Pose2d pose = new Pose2d(8, 4, Rotation2d.kZero);
-        manager.update(false, pose, 0, 50); // Low RPM
-        manager.update(true, pose, 0, 50); // Rising edge but RPM too low
-        assertEquals(0, sim.getBallCount(), "Should not spawn ball with RPM <= 100");
-    }
+  @Test
+  void lowRPMRejectsShotCreation() {
+    Pose2d pose = new Pose2d(8, 4, Rotation2d.kZero);
+    manager.update(false, pose, 0, 50); // Low RPM
+    manager.update(true, pose, 0, 50); // Rising edge but RPM too low
+    assertEquals(0, sim.getBallCount(), "Should not spawn ball with RPM <= 100");
+  }
 
-    @Test
-    void disabledSkipsPhysics() {
-        // The enabled TunableNumber defaults to 1, so normally it runs.
-        // We test that calling update still works (no crash).
-        Pose2d pose = new Pose2d(8, 4, Rotation2d.kZero);
-        assertDoesNotThrow(() -> manager.update(false, pose, 0, 3000));
-    }
+  @Test
+  void disabledSkipsPhysics() {
+    // The enabled TunableNumber defaults to 1, so normally it runs.
+    // We test that calling update still works (no crash).
+    Pose2d pose = new Pose2d(8, 4, Rotation2d.kZero);
+    assertDoesNotThrow(() -> manager.update(false, pose, 0, 3000));
+  }
 
-    @Test
-    void risingEdgeTrigger() {
-        Pose2d pose = new Pose2d(8, 4, Rotation2d.kZero);
-        // false -> true -> false -> true should create 2 balls
-        manager.update(false, pose, 0, 3000);
-        manager.update(true, pose, 0, 3000); // ball 1
-        manager.update(false, pose, 0, 3000);
-        manager.update(true, pose, 0, 3000); // ball 2
+  @Test
+  void risingEdgeTrigger() {
+    Pose2d pose = new Pose2d(8, 4, Rotation2d.kZero);
+    // false -> true -> false -> true should create 2 balls
+    manager.update(false, pose, 0, 3000);
+    manager.update(true, pose, 0, 3000); // ball 1
+    manager.update(false, pose, 0, 3000);
+    manager.update(true, pose, 0, 3000); // ball 2
 
-        assertEquals(2, sim.getBallCount(), "Two rising edges should create two balls");
-    }
+    assertEquals(2, sim.getBallCount(), "Two rising edges should create two balls");
+  }
 
-    @Test
-    void placeFieldBallsDelegates() {
-        manager.placeFieldBalls();
-        assertTrue(sim.getBallCount() > 100, "placeFieldBalls should spawn many balls");
-    }
+  @Test
+  void placeFieldBallsDelegates() {
+    manager.placeFieldBalls();
+    assertTrue(sim.getBallCount() > 100, "placeFieldBalls should spawn many balls");
+  }
 
-    @Test
-    void getSim() {
-        assertSame(sim, manager.getSim(), "getSim() should return underlying sim");
-    }
+  @Test
+  void getSim() {
+    assertSame(sim, manager.getSim(), "getSim() should return underlying sim");
+  }
 
-    @Test
-    void startAndStop() {
-        manager.disable();
-        assertFalse(sim.isRunning());
-        manager.enable();
-        assertTrue(sim.isRunning());
-    }
+  @Test
+  void startAndStop() {
+    manager.disable();
+    assertFalse(sim.isRunning());
+    manager.enable();
+    assertTrue(sim.isRunning());
+  }
 }


### PR DESCRIPTION
Issue #96

Adds a full ball physics sim that runs during simulateJava. You can drive around, intake balls, shoot them, and watch them fly through the air and score in hubs in AdvantageScope. Good for driver practice and testing commands without the robot.

New files:
  - FuelPhysicsSim.java: the actual physics engine. Handles drag, Magnus spin, wall bounces, hub scoring, intake pickup. MIT licensed so other teams can use it too
  - SimFuelManager.java: connects shot detection and intake to the physics engine
  - 3 test files (64 tests covering all the physics)

Changes to existing files:
  - SimDeviceManager: added wasShotFiredThisCycle() and getShooterRPM() so the physics sim knows when a shot happens
  - Robot.java: wires everything up in simulationInit/simulationPeriodic
  - Constants.java: added ProjectileSimConstants and ShotCalculatorConstants for launcher geometry
  - SafeLog.java: added Pose2d[] overload for ball trail visualization

  Ball positions show up in AdvantageScope Field3d at Sim/FuelPositions/Fuels. Connect to localhost:5810 to see them.

