### PR TITLE
scoring readiness pipeline

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -11,7 +11,6 @@ import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.math.geometry.Translation2d;
 import edu.wpi.first.math.geometry.Translation3d;
 import edu.wpi.first.math.util.Units;
-
 import swervelib.math.Matter;
 
 /**
@@ -24,398 +23,398 @@ import swervelib.math.Matter;
  */
 public final class Constants {
 
-    /**
-     * Master tuning mode switch. - true: Values read from dashboard (practice/testing) - false:
-     * Values locked to defaults (competition)
-     *
-     * <p>IMPORTANT: Set to FALSE before competition deployment!
+  /**
+   * Master tuning mode switch. - true: Values read from dashboard (practice/testing) - false:
+   * Values locked to defaults (competition)
+   *
+   * <p>IMPORTANT: Set to FALSE before competition deployment!
+   */
+  public static final boolean TUNING_MODE = true;
+
+  public static final double ROBOT_MASS = (148 - 20.3) * 0.453592; // 32lbs * kg per pound
+  public static final double LOOP_TIME = 0.13; // s, 20ms + 110ms sprk max velocity lag
+  public static final double MAX_SPEED = Units.feetToMeters(14.5);
+  // Maximum speed of the robot in meters per second, used to limit acceleration.
+  public static final Matter CHASSIS =
+      new Matter(new Translation3d(0, 0, Units.inchesToMeters(8)), ROBOT_MASS);
+
+  public static final class DrivebaseConstants {
+
+    // Hold time on motor brakes when disabled
+    public static final double WHEEL_LOCK_TIME = 10; // seconds
+  }
+
+  public static final class FieldConstants {
+    public static final AprilTagFieldLayout FIELD_LAYOUT =
+        AprilTagFieldLayout.loadField(AprilTagFields.k2026RebuiltAndymark);
+
+    public static final double DistanceToHub = 0.4;
+  }
+
+  public static class OperatorConstants {
+
+    // Joystick Deadband
+    public static final double DEADBAND = 0.1;
+    public static final double LEFT_Y_DEADBAND = 0.1;
+    public static final double RIGHT_X_DEADBAND = 0.1;
+    public static final double TURN_CONSTANT = 6;
+  }
+
+  public static final class HubScoringConstants {
+
+    // Hub positions on field
+    public static final Translation2d BLUE_HUB_CENTER = new Translation2d(4.625594, 4.0);
+    public static final Translation2d RED_HUB_CENTER = new Translation2d(11.901424, 4.0);
+
+    // Scoring parameters
+    public static final double SCORING_DISTANCE = 2; // meters from hub center
+    public static final double MAX_ARC_SPEED = 2.0; // max speed while driving along arc (m/s)
+
+    // Valid scoring arc definition
+    public static final Rotation2d BLUE_SCORING_SIDE = Rotation2d.fromDegrees(180); // Faces +X
+    public static final Rotation2d RED_SCORING_SIDE = Rotation2d.fromDegrees(0); // Faces -X
+    public static final double SCORING_ARC_WIDTH_DEGREES =
+        90; // 180 = semicircle, 90 = quarter circle
+
+    // Tolerances
+    public static final double POSITION_TOLERANCE = 0.05; // meters
+    public static final double ANGLE_TOLERANCE = 2.0; // degrees
+  }
+
+  public static class PhotonvisionConstants {
+
+    /*
+    deploy order for Json files of swerve modules
+    frontleft,
+    frontright,
+    backleft,
+    backright
      */
-    public static final boolean TUNING_MODE = true;
+  }
 
-    public static final double ROBOT_MASS = (148 - 20.3) * 0.453592; // 32lbs * kg per pound
-    public static final double LOOP_TIME = 0.13; // s, 20ms + 110ms sprk max velocity lag
-    public static final double MAX_SPEED = Units.feetToMeters(14.5);
-    // Maximum speed of the robot in meters per second, used to limit acceleration.
-    public static final Matter CHASSIS =
-            new Matter(new Translation3d(0, 0, Units.inchesToMeters(8)), ROBOT_MASS);
+  public static final class CANDeviceIDs {
+    public static final int kIndexerID = 50;
+    public static final int kShooterID = 52;
+    public static final int kIntakePivotID = 56;
+    public static final int kIntakeRollerID = 55;
+    public static final int kHangerID = 60;
+    public static final int kAgitatorID = 54;
+  }
 
-    public static final class DrivebaseConstants {
+  public static final class MotorConstants {
+    public static final double DESIRED_SHOOTER_RPM = 3730;
+    public static final double DESIRED_INDEXER_RPM = 7833; // 8.4 * 3730/4
+    public static final double OUT_INTAKE_POS = 38.24;
+    public static final double IN_INTAKE_POS = 11.6;
+    public static final double DESIRED_INTAKE_RPM = 0;
+    public static final double UP_HANGER_POS = 0;
+    public static final double DOWN_HANGER_POS = 0;
+    public static final double DESIRED_AGITATOR_SPEED = .5;
+  }
 
-        // Hold time on motor brakes when disabled
-        public static final double WHEEL_LOCK_TIME = 10; // seconds
+  public static final class IntakeRollerConstants {
+    public static final double P = 1.0;
+    public static final double I = 0.0;
+    public static final double D = 0.0;
+    public static final double MinOutput = -1.0;
+    public static final double MaxOutput = 1.0;
+    public static final double FF = 0.0;
+    public static final double Iz = 0.0;
+  }
+
+  public static final class IntakePivotConstants {
+    public static final double P = 1.0;
+    public static final double I = 0.0;
+    public static final double D = 0.2;
+    public static final double MinOutput = -1.0;
+    public static final double MaxOutput = 1.0;
+    public static final double FF = 0.0;
+    public static final double Iz = 0.0;
+  }
+
+  public static final class ShooterConstants {
+    // Velocity PID tuning (from Kfir2026)
+    public static final double P = 0.00011;
+    public static final double I = 0.0;
+    public static final double D = 0.0;
+    public static final double FF = 0.000172;
+    public static final double MinOutput = -1.0;
+    public static final double MaxOutput = 1.0;
+    public static final double Iz = 0.0;
+
+    // Tuning targets
+    public static final double TARGET_RPM = 3730;
+    public static final double TARGET_FIRE_RATE_PER_SEC = 2.5;
+    public static final double TARGET_RECOVERY_MS = 150.0;
+
+    // Telemetry constants
+    public static final double SPEED_TOLERANCE_RPM = 50.0;
+    public static final double VELOCITY_CONVERSION = 1.0;
+    public static final double SHOT_DETECTION_DROP_RPM = 200.0;
+    public static final double SHOT_DETECTION_MIN_RPM = 1000.0;
+    public static final double TEMP_WARNING_CELSIUS = 65.0;
+  }
+
+  public static final class IndexerConstants {
+    // Velocity PID (from Alden)
+    public static final double P = 0.000;
+    public static final double I = 0.0;
+    public static final double D = 0.00;
+    public static final double MinOutput = -1.0;
+    public static final double MaxOutput = 1.0;
+    public static final double FF = 0.0004;
+    public static final double Iz = 0.0;
+
+    // Telemetry constants
+    public static final double TARGET_SPEED = 7833;
+    public static final double JAM_CURRENT_THRESHOLD_AMPS = 35.0;
+    public static final double JAM_TIME_THRESHOLD_SECONDS = 0.3;
+  }
+
+  public static final class AgitatorConstants {
+    public static final double P = 0.000;
+    public static final double I = 0.0;
+    public static final double D = 0.0;
+    public static final double MinOutput = -1.0;
+    public static final double MaxOutput = 1.0;
+    public static final double FF = 0.0002;
+    public static final double Iz = 0.0;
+
+    public static final double TARGET_RPM = 2000;
+    public static final double JAM_CURRENT_THRESHOLD_AMPS = 25.0;
+    public static final double JAM_TIME_THRESHOLD_SECONDS = 0.3;
+  }
+
+  public static final class HopperConstants {
+    public static final int LOW_BALL_THRESHOLD = 3;
+    public static final double DETECTION_CONFIDENCE_THRESHOLD = 0.8;
+  }
+
+  public static final class HangerConstants {
+    public static final double P = 1.0;
+    public static final double I = 0.0;
+    public static final double D = 0.0;
+    public static final double MinOutput = -1.0;
+    public static final double MaxOutput = 1.0;
+    public static final double FF = 0.0;
+    public static final double Iz = 0.0;
+    public static final double POSITION_TOLERANCE = 0.1;
+  }
+
+  public static final class BatteryThresholds {
+    public static final double CRITICAL_V = 10.0;
+    public static final double WARNING_V = 11.5;
+    public static final double PRE_MATCH_WARN_V = 12.3;
+    public static final double PRE_MATCH_FAIL_V = 12.0;
+  }
+
+  /** CAN bus disconnect debounce and scoring readiness stabilization */
+  public static final class DeviceHealthConstants {
+    // Motor must report disconnected for this long before we flag it (filters CAN glitches)
+    public static final double DISCONNECT_DEBOUNCE_SEC = 0.5;
+    // ReadyToShoot stays true through brief velocity dips during sustained fire
+    public static final double READY_TO_SHOOT_DEBOUNCE_SEC = 0.15;
+
+    // Per-component falling-edge debounce for the 8-condition ReadyToShoot composite.
+    // Each condition holds true independently after its raw input drops, so a single-frame
+    // glitch on one sensor doesn't kill the whole composite.
+    public static final double SHOOTER_READY_DEBOUNCE_SEC = 0.08;
+    public static final double INDEXER_CLEAR_DEBOUNCE_SEC = 0.05;
+    public static final double VISION_LOCKED_DEBOUNCE_SEC = 0.10;
+    public static final double SHOT_CONFIDENT_DEBOUNCE_SEC = 0.08;
+    // hasBall and fireAuthorized: no debounce (instant response)
+  }
+
+  /**
+   * Pre-deploy and pre-merge safety gates. Run via Gradle tasks:
+   *
+   * <ul>
+   *   <li>{@code ./gradlew checkDeploy} blocks deploy when TUNING_MODE is on
+   *   <li>{@code ./gradlew checkCompetition} stricter gate for match day
+   * </ul>
+   *
+   * Skip with {@code ./gradlew deploy -x checkDeploy} if you really need tuning on the robot.
+   */
+  public static final class DeploySafetyCheck {
+    /** Returns false if TUNING_MODE is on (unsafe for competition deploy). */
+    public static boolean isSafeForDeploy() {
+      return !TUNING_MODE;
     }
 
-    public static final class FieldConstants {
-        public static final AprilTagFieldLayout FIELD_LAYOUT =
-                AprilTagFieldLayout.loadField(AprilTagFields.k2026RebuiltAndymark);
-
-        public static final double DistanceToHub = 0.4;
+    // back left left 11.54, 11.54, 45 degrees 15 desgrees
+    /** Gradle entry point: exits 1 if deploy is unsafe. */
+    public static void main(String... args) {
+      if (!isSafeForDeploy()) {
+        System.err.println("DEPLOY BLOCKED: TUNING_MODE = true");
+        System.err.println("Set Constants.TUNING_MODE = false before deploying to robot.");
+        System.err.println("Override: ./gradlew deploy -x checkDeploy");
+        System.exit(1);
+      }
+      System.out.println("Deploy safety check passed.");
     }
+  }
 
-    public static class OperatorConstants {
+  public static final class LEDConstants {
+    public static final int PWM_PORT = 0;
+    public static final int STRIP_LENGTH = 19;
+    public static final double DIM_DISABLED = 0.15;
+  }
 
-        // Joystick Deadband
-        public static final double DEADBAND = 0.1;
-        public static final double LEFT_Y_DEADBAND = 0.1;
-        public static final double RIGHT_X_DEADBAND = 0.1;
-        public static final double TURN_CONSTANT = 6;
+  /**
+   * PDH channel map. Maps physical PDH channel (0-23) to a human-readable circuit name. Update this
+   * when wiring changes. Channels without a label are logged as "Ch{N}".
+   */
+  public static final class PDHChannelMap {
+    public static final int NUM_CHANNELS = 24;
+
+    // Channel labels: index = PDH channel number, value = circuit name
+    // Update these to match your actual wiring harness
+    private static final String[] LABELS = {
+      "FrontLeftDrive", // 0
+      "FrontLeftTurn", // 1
+      "FrontRightDrive", // 2
+      "FrontRightTurn", // 3
+      "BackLeftDrive", // 4
+      "BackLeftTurn", // 5
+      "BackRightDrive", // 6
+      "BackRightTurn", // 7
+      "Shooter", // 8
+      "Indexer", // 9
+      "Agitator", // 10
+      "Intake", // 11
+      "IntakeActuator", // 12
+      "Hanger", // 13
+      "Ch14", // 14 - unused/unknown
+      "Ch15", // 15 - unused/unknown
+      "Ch16", // 16 - unused/unknown
+      "Ch17", // 17 - unused/unknown
+      "Ch18", // 18 - unused/unknown
+      "Ch19", // 19 - unused/unknown
+      "Radio", // 20
+      "RoboRIO", // 21
+      "Ch22", // 22 - unused/unknown
+      "Ch23", // 23 - unused/unknown
+    };
+
+    /** Alert when any single channel exceeds this current (amps). */
+    public static final double CHANNEL_OVERCURRENT_AMPS = 40.0;
+
+    public static String getLabel(int channel) {
+      if (channel >= 0 && channel < LABELS.length) {
+        return LABELS[channel];
+      }
+      return "Ch" + channel;
     }
+  }
 
-    public static final class HubScoringConstants {
+  /** Jam protection: 3-layer debounce + auto-reverse + disable after max attempts */
+  public static final class JamProtectionConstants {
+    // Intake jam protection
+    public static final double INTAKE_JAM_CURRENT_AMPS = 25.0;
+    public static final double INTAKE_JAM_VELOCITY_RPM = 100.0;
+    public static final double INTAKE_STARTUP_IGNORE_SEC = 0.5;
+    public static final double INTAKE_JAM_CONFIRM_SEC = 0.3;
+    public static final double INTAKE_REVERSE_SEC = 0.4;
+    public static final double INTAKE_COOLDOWN_SEC = 0.15;
+    public static final double INTAKE_REVERSE_POWER = -0.4;
+    public static final int INTAKE_MAX_ATTEMPTS = 3;
 
-        // Hub positions on field
-        public static final Translation2d BLUE_HUB_CENTER = new Translation2d(4.625594, 4.0);
-        public static final Translation2d RED_HUB_CENTER = new Translation2d(11.901424, 4.0);
+    // Indexer jam protection (raised confirm + velocity to avoid false triggers during ball
+    // passage)
+    public static final double INDEXER_JAM_CURRENT_AMPS = 25.0;
+    public static final double INDEXER_JAM_VELOCITY_RPM = 200.0;
+    public static final double INDEXER_STARTUP_IGNORE_SEC = 0.5;
+    public static final double INDEXER_JAM_CONFIRM_SEC = 0.5;
+    public static final double INDEXER_REVERSE_SEC = 0.3;
+    public static final double INDEXER_COOLDOWN_SEC = 0.15;
+    public static final double INDEXER_REVERSE_POWER = -0.3;
+    public static final int INDEXER_MAX_ATTEMPTS = 3;
 
-        // Scoring parameters
-        public static final double SCORING_DISTANCE = 2; // meters from hub center
-        public static final double MAX_ARC_SPEED = 2.0; // max speed while driving along arc (m/s)
+    // Agitator jam protection (raised current threshold, needs real stall current measurement)
+    public static final double AGITATOR_JAM_CURRENT_AMPS = 20.0;
+    public static final double AGITATOR_JAM_VELOCITY_RPM = 100.0;
+    public static final double AGITATOR_STARTUP_IGNORE_SEC = 0.5;
+    public static final double AGITATOR_JAM_CONFIRM_SEC = 0.3;
+    public static final double AGITATOR_REVERSE_SEC = 0.4;
+    public static final double AGITATOR_COOLDOWN_SEC = 0.15;
+    public static final double AGITATOR_REVERSE_POWER = -0.3;
+    public static final int AGITATOR_MAX_ATTEMPTS = 3;
+  }
 
-        // Valid scoring arc definition
-        public static final Rotation2d BLUE_SCORING_SIDE = Rotation2d.fromDegrees(180); // Faces +X
-        public static final Rotation2d RED_SCORING_SIDE = Rotation2d.fromDegrees(0); // Faces -X
-        public static final double SCORING_ARC_WIDTH_DEGREES =
-                90; // 180 = semicircle, 90 = quarter circle
+  /** Stall = high current + low velocity for debounce time */
+  public static final class StallDetectionConstants {
+    // Shooter stall thresholds
+    public static final double SHOOTER_STALL_CURRENT_AMPS = 50.0;
+    public static final double SHOOTER_STALL_VELOCITY_RPM = 100.0;
+    public static final double SHOOTER_STALL_DEBOUNCE_MS = 250.0;
 
-        // Tolerances
-        public static final double POSITION_TOLERANCE = 0.05; // meters
-        public static final double ANGLE_TOLERANCE = 2.0; // degrees
-    }
+    // Indexer stall thresholds
+    public static final double INDEXER_STALL_CURRENT_AMPS = 15.0;
+    public static final double INDEXER_STALL_VELOCITY_RPM = 50.0;
+    public static final double INDEXER_STALL_DEBOUNCE_MS = 200.0;
 
-    public static class PhotonvisionConstants {
+    // Intake stall thresholds
+    public static final double INTAKE_STALL_CURRENT_AMPS = 20.0;
+    public static final double INTAKE_STALL_VELOCITY_RPM = 100.0;
+    public static final double INTAKE_STALL_DEBOUNCE_MS = 200.0;
+  }
 
-        /*
-        deploy order for Json files of swerve modules
-        frontleft,
-        frontright,
-        backleft,
-        backright
-         */
-    }
+  public static final class HubTimingConstants {
+    // Fuel processing at the hub (measured from field tour videos + Week 0)
+    public static final double FUEL_COUNT_DELAY_MIN_SEC = 1.0;
+    public static final double FUEL_COUNT_DELAY_MAX_SEC = 2.0;
+    // Hub counts fuel for 3 seconds after active window ends (game manual)
+    public static final double FUEL_COUNT_EXTENSION_SEC = 3.0;
+    // Margin buffer: shot must land this far inside window for FIRE_AUTHORIZED
+    public static final double FIRE_SAFE_MARGIN_SEC = 0.5;
+    // How early before active window to trigger PRE_SPIN
+    public static final double PRE_SPIN_WINDOW_SEC = 3.0;
+    // Extra margin when schedule confidence is FALLBACK (50/50 guess)
+    public static final double FALLBACK_MARGIN_EXTRA_SEC = 1.0;
+    // How often GAME_DATA_MISSING alert repeats during transition
+    public static final double GAME_DATA_ALERT_INTERVAL_SEC = 2.0;
 
-    public static final class CANDeviceIDs {
-        public static final int kIndexerID = 50;
-        public static final int kShooterID = 52;
-        public static final int kIntakePivotID = 56;
-        public static final int kIntakeRollerID = 55;
-        public static final int kHangerID = 60;
-        public static final int kAgitatorID = 54;
-    }
+    // Hub shift schedule: elapsed seconds from teleop start
+    // Game Manual Section 6.4: 10s transition, 4x25s shifts, 30s endgame = 140s total
+    public static final double TRANSITION_END = 10.0;
+    public static final double SHIFT1_END = 35.0;
+    public static final double SHIFT2_END = 60.0;
+    public static final double SHIFT3_END = 85.0;
+    public static final double SHIFT4_END = 110.0;
+    public static final double ENDGAME_END = 140.0;
 
-    public static final class MotorConstants {
-        public static final double DESIRED_SHOOTER_RPM = 3730;
-        public static final double DESIRED_INDEXER_RPM = 7833; // 8.4 * 3730/4
-        public static final double OUT_INTAKE_POS = 38.24;
-        public static final double IN_INTAKE_POS = 11.6;
-        public static final double DESIRED_INTAKE_RPM = 0;
-        public static final double UP_HANGER_POS = 0;
-        public static final double DOWN_HANGER_POS = 0;
-        public static final double DESIRED_AGITATOR_SPEED = .5;
-    }
+    public static final double AUTO_DURATION = 20.0;
+  }
 
-    public static final class IntakeRollerConstants {
-        public static final double P = 1.0;
-        public static final double I = 0.0;
-        public static final double D = 0.0;
-        public static final double MinOutput = -1.0;
-        public static final double MaxOutput = 1.0;
-        public static final double FF = 0.0;
-        public static final double Iz = 0.0;
-    }
+  public static final class SpatialLaunchConstants {
+    // Closer than this and the ball trajectory is nearly vertical
+    public static final double MIN_LAUNCH_DISTANCE_M = 1.0;
 
-    public static final class IntakePivotConstants {
-        public static final double P = 1.0;
-        public static final double I = 0.0;
-        public static final double D = 0.2;
-        public static final double MinOutput = -1.0;
-        public static final double MaxOutput = 1.0;
-        public static final double FF = 0.0;
-        public static final double Iz = 0.0;
-    }
+    // Ball radius used to expand obstacle AABBs (a near-miss is still a miss)
+    public static final double BALL_RADIUS_M = 0.075;
 
-    public static final class ShooterConstants {
-        // Velocity PID tuning (from Kfir2026)
-        public static final double P = 0.00011;
-        public static final double I = 0.0;
-        public static final double D = 0.0;
-        public static final double FF = 0.000172;
-        public static final double MinOutput = -1.0;
-        public static final double MaxOutput = 1.0;
-        public static final double Iz = 0.0;
+    // Trench pillar AABBs from game manual section 5 field drawings.
+    // Each row: {minX, minY, maxX, maxY}. Pillars are ~0.305m square, 1.346m tall.
+    public static final double[][] TRENCH_PILLARS = {
+      {3.960, 1.265, 4.265, 1.570},
+      {3.960, 6.177, 4.265, 6.482},
+      {12.276, 1.265, 12.581, 1.570},
+      {12.276, 6.177, 12.581, 6.482},
+    };
 
-        // Tuning targets
-        public static final double TARGET_RPM = 3730;
-        public static final double TARGET_FIRE_RATE_PER_SEC = 2.5;
-        public static final double TARGET_RECOVERY_MS = 150.0;
+    // Trench ceiling exclusion zones: shooting from under here hits the ceiling.
+    // XY rectangles from field geometry (trench ceiling AABBs projected to 2D).
+    public static final double[][] TRENCH_EXCLUSION_ZONES = {
+      {3.960, 1.570, 5.180, 3.730},
+      {3.960, 4.320, 5.180, 6.170},
+      {11.361, 1.570, 12.581, 3.730},
+      {11.361, 4.320, 12.581, 6.170},
+    };
 
-        // Telemetry constants
-        public static final double SPEED_TOLERANCE_RPM = 50.0;
-        public static final double VELOCITY_CONVERSION = 1.0;
-        public static final double SHOT_DETECTION_DROP_RPM = 200.0;
-        public static final double SHOT_DETECTION_MIN_RPM = 1000.0;
-        public static final double TEMP_WARNING_CELSIUS = 65.0;
-    }
+    // Time for the robot to react before entering a no-shoot zone (seconds)
+    public static final double RETRACTION_TIME_SEC = 0.25;
 
-    public static final class IndexerConstants {
-        // Velocity PID (from Alden)
-        public static final double P = 0.000;
-        public static final double I = 0.0;
-        public static final double D = 0.00;
-        public static final double MinOutput = -1.0;
-        public static final double MaxOutput = 1.0;
-        public static final double FF = 0.0004;
-        public static final double Iz = 0.0;
-
-        // Telemetry constants
-        public static final double TARGET_SPEED = 7833;
-        public static final double JAM_CURRENT_THRESHOLD_AMPS = 35.0;
-        public static final double JAM_TIME_THRESHOLD_SECONDS = 0.3;
-    }
-
-    public static final class AgitatorConstants {
-        public static final double P = 0.000;
-        public static final double I = 0.0;
-        public static final double D = 0.0;
-        public static final double MinOutput = -1.0;
-        public static final double MaxOutput = 1.0;
-        public static final double FF = 0.0002;
-        public static final double Iz = 0.0;
-
-        public static final double TARGET_RPM = 2000;
-        public static final double JAM_CURRENT_THRESHOLD_AMPS = 25.0;
-        public static final double JAM_TIME_THRESHOLD_SECONDS = 0.3;
-    }
-
-    public static final class HopperConstants {
-        public static final int LOW_BALL_THRESHOLD = 3;
-        public static final double DETECTION_CONFIDENCE_THRESHOLD = 0.8;
-    }
-
-    public static final class HangerConstants {
-        public static final double P = 1.0;
-        public static final double I = 0.0;
-        public static final double D = 0.0;
-        public static final double MinOutput = -1.0;
-        public static final double MaxOutput = 1.0;
-        public static final double FF = 0.0;
-        public static final double Iz = 0.0;
-        public static final double POSITION_TOLERANCE = 0.1;
-    }
-
-    public static final class BatteryThresholds {
-        public static final double CRITICAL_V = 10.0;
-        public static final double WARNING_V = 11.5;
-        public static final double PRE_MATCH_WARN_V = 12.3;
-        public static final double PRE_MATCH_FAIL_V = 12.0;
-    }
-
-    /** CAN bus disconnect debounce and scoring readiness stabilization */
-    public static final class DeviceHealthConstants {
-        // Motor must report disconnected for this long before we flag it (filters CAN glitches)
-        public static final double DISCONNECT_DEBOUNCE_SEC = 0.5;
-        // ReadyToShoot stays true through brief velocity dips during sustained fire
-        public static final double READY_TO_SHOOT_DEBOUNCE_SEC = 0.15;
-
-        // Per-component falling-edge debounce for the 8-condition ReadyToShoot composite.
-        // Each condition holds true independently after its raw input drops, so a single-frame
-        // glitch on one sensor doesn't kill the whole composite.
-        public static final double SHOOTER_READY_DEBOUNCE_SEC = 0.08;
-        public static final double INDEXER_CLEAR_DEBOUNCE_SEC = 0.05;
-        public static final double VISION_LOCKED_DEBOUNCE_SEC = 0.10;
-        public static final double SHOT_CONFIDENT_DEBOUNCE_SEC = 0.08;
-        // hasBall and fireAuthorized: no debounce (instant response)
-    }
-
-    /**
-     * Pre-deploy and pre-merge safety gates. Run via Gradle tasks:
-     *
-     * <ul>
-     *   <li>{@code ./gradlew checkDeploy} blocks deploy when TUNING_MODE is on
-     *   <li>{@code ./gradlew checkCompetition} stricter gate for match day
-     * </ul>
-     *
-     * Skip with {@code ./gradlew deploy -x checkDeploy} if you really need tuning on the robot.
-     */
-    public static final class DeploySafetyCheck {
-        /** Returns false if TUNING_MODE is on (unsafe for competition deploy). */
-        public static boolean isSafeForDeploy() {
-            return !TUNING_MODE;
-        }
-
-        // back left left 11.54, 11.54, 45 degrees 15 desgrees
-        /** Gradle entry point: exits 1 if deploy is unsafe. */
-        public static void main(String... args) {
-            if (!isSafeForDeploy()) {
-                System.err.println("DEPLOY BLOCKED: TUNING_MODE = true");
-                System.err.println("Set Constants.TUNING_MODE = false before deploying to robot.");
-                System.err.println("Override: ./gradlew deploy -x checkDeploy");
-                System.exit(1);
-            }
-            System.out.println("Deploy safety check passed.");
-        }
-    }
-
-    public static final class LEDConstants {
-        public static final int PWM_PORT = 0;
-        public static final int STRIP_LENGTH = 19;
-        public static final double DIM_DISABLED = 0.15;
-    }
-
-    /**
-     * PDH channel map. Maps physical PDH channel (0-23) to a human-readable circuit name. Update
-     * this when wiring changes. Channels without a label are logged as "Ch{N}".
-     */
-    public static final class PDHChannelMap {
-        public static final int NUM_CHANNELS = 24;
-
-        // Channel labels: index = PDH channel number, value = circuit name
-        // Update these to match your actual wiring harness
-        private static final String[] LABELS = {
-            "FrontLeftDrive", // 0
-            "FrontLeftTurn", // 1
-            "FrontRightDrive", // 2
-            "FrontRightTurn", // 3
-            "BackLeftDrive", // 4
-            "BackLeftTurn", // 5
-            "BackRightDrive", // 6
-            "BackRightTurn", // 7
-            "Shooter", // 8
-            "Indexer", // 9
-            "Agitator", // 10
-            "Intake", // 11
-            "IntakeActuator", // 12
-            "Hanger", // 13
-            "Ch14", // 14 - unused/unknown
-            "Ch15", // 15 - unused/unknown
-            "Ch16", // 16 - unused/unknown
-            "Ch17", // 17 - unused/unknown
-            "Ch18", // 18 - unused/unknown
-            "Ch19", // 19 - unused/unknown
-            "Radio", // 20
-            "RoboRIO", // 21
-            "Ch22", // 22 - unused/unknown
-            "Ch23", // 23 - unused/unknown
-        };
-
-        /** Alert when any single channel exceeds this current (amps). */
-        public static final double CHANNEL_OVERCURRENT_AMPS = 40.0;
-
-        public static String getLabel(int channel) {
-            if (channel >= 0 && channel < LABELS.length) {
-                return LABELS[channel];
-            }
-            return "Ch" + channel;
-        }
-    }
-
-    /** Jam protection: 3-layer debounce + auto-reverse + disable after max attempts */
-    public static final class JamProtectionConstants {
-        // Intake jam protection
-        public static final double INTAKE_JAM_CURRENT_AMPS = 25.0;
-        public static final double INTAKE_JAM_VELOCITY_RPM = 100.0;
-        public static final double INTAKE_STARTUP_IGNORE_SEC = 0.5;
-        public static final double INTAKE_JAM_CONFIRM_SEC = 0.3;
-        public static final double INTAKE_REVERSE_SEC = 0.4;
-        public static final double INTAKE_COOLDOWN_SEC = 0.15;
-        public static final double INTAKE_REVERSE_POWER = -0.4;
-        public static final int INTAKE_MAX_ATTEMPTS = 3;
-
-        // Indexer jam protection (raised confirm + velocity to avoid false triggers during ball
-        // passage)
-        public static final double INDEXER_JAM_CURRENT_AMPS = 25.0;
-        public static final double INDEXER_JAM_VELOCITY_RPM = 200.0;
-        public static final double INDEXER_STARTUP_IGNORE_SEC = 0.5;
-        public static final double INDEXER_JAM_CONFIRM_SEC = 0.5;
-        public static final double INDEXER_REVERSE_SEC = 0.3;
-        public static final double INDEXER_COOLDOWN_SEC = 0.15;
-        public static final double INDEXER_REVERSE_POWER = -0.3;
-        public static final int INDEXER_MAX_ATTEMPTS = 3;
-
-        // Agitator jam protection (raised current threshold, needs real stall current measurement)
-        public static final double AGITATOR_JAM_CURRENT_AMPS = 20.0;
-        public static final double AGITATOR_JAM_VELOCITY_RPM = 100.0;
-        public static final double AGITATOR_STARTUP_IGNORE_SEC = 0.5;
-        public static final double AGITATOR_JAM_CONFIRM_SEC = 0.3;
-        public static final double AGITATOR_REVERSE_SEC = 0.4;
-        public static final double AGITATOR_COOLDOWN_SEC = 0.15;
-        public static final double AGITATOR_REVERSE_POWER = -0.3;
-        public static final int AGITATOR_MAX_ATTEMPTS = 3;
-    }
-
-    /** Stall = high current + low velocity for debounce time */
-    public static final class StallDetectionConstants {
-        // Shooter stall thresholds
-        public static final double SHOOTER_STALL_CURRENT_AMPS = 50.0;
-        public static final double SHOOTER_STALL_VELOCITY_RPM = 100.0;
-        public static final double SHOOTER_STALL_DEBOUNCE_MS = 250.0;
-
-        // Indexer stall thresholds
-        public static final double INDEXER_STALL_CURRENT_AMPS = 15.0;
-        public static final double INDEXER_STALL_VELOCITY_RPM = 50.0;
-        public static final double INDEXER_STALL_DEBOUNCE_MS = 200.0;
-
-        // Intake stall thresholds
-        public static final double INTAKE_STALL_CURRENT_AMPS = 20.0;
-        public static final double INTAKE_STALL_VELOCITY_RPM = 100.0;
-        public static final double INTAKE_STALL_DEBOUNCE_MS = 200.0;
-    }
-
-    public static final class HubTimingConstants {
-        // Fuel processing at the hub (measured from field tour videos + Week 0)
-        public static final double FUEL_COUNT_DELAY_MIN_SEC = 1.0;
-        public static final double FUEL_COUNT_DELAY_MAX_SEC = 2.0;
-        // Hub counts fuel for 3 seconds after active window ends (game manual)
-        public static final double FUEL_COUNT_EXTENSION_SEC = 3.0;
-        // Margin buffer: shot must land this far inside window for FIRE_AUTHORIZED
-        public static final double FIRE_SAFE_MARGIN_SEC = 0.5;
-        // How early before active window to trigger PRE_SPIN
-        public static final double PRE_SPIN_WINDOW_SEC = 3.0;
-        // Extra margin when schedule confidence is FALLBACK (50/50 guess)
-        public static final double FALLBACK_MARGIN_EXTRA_SEC = 1.0;
-        // How often GAME_DATA_MISSING alert repeats during transition
-        public static final double GAME_DATA_ALERT_INTERVAL_SEC = 2.0;
-
-        // Hub shift schedule: elapsed seconds from teleop start
-        // Game Manual Section 6.4: 10s transition, 4x25s shifts, 30s endgame = 140s total
-        public static final double TRANSITION_END = 10.0;
-        public static final double SHIFT1_END = 35.0;
-        public static final double SHIFT2_END = 60.0;
-        public static final double SHIFT3_END = 85.0;
-        public static final double SHIFT4_END = 110.0;
-        public static final double ENDGAME_END = 140.0;
-
-        public static final double AUTO_DURATION = 20.0;
-    }
-
-    public static final class SpatialLaunchConstants {
-        // Closer than this and the ball trajectory is nearly vertical
-        public static final double MIN_LAUNCH_DISTANCE_M = 1.0;
-
-        // Ball radius used to expand obstacle AABBs (a near-miss is still a miss)
-        public static final double BALL_RADIUS_M = 0.075;
-
-        // Trench pillar AABBs from game manual section 5 field drawings.
-        // Each row: {minX, minY, maxX, maxY}. Pillars are ~0.305m square, 1.346m tall.
-        public static final double[][] TRENCH_PILLARS = {
-            {3.960, 1.265, 4.265, 1.570},
-            {3.960, 6.177, 4.265, 6.482},
-            {12.276, 1.265, 12.581, 1.570},
-            {12.276, 6.177, 12.581, 6.482},
-        };
-
-        // Trench ceiling exclusion zones: shooting from under here hits the ceiling.
-        // XY rectangles from field geometry (trench ceiling AABBs projected to 2D).
-        public static final double[][] TRENCH_EXCLUSION_ZONES = {
-            {3.960, 1.570, 5.180, 3.730},
-            {3.960, 4.320, 5.180, 6.170},
-            {11.361, 1.570, 12.581, 3.730},
-            {11.361, 4.320, 12.581, 6.170},
-        };
-
-        // Time for the robot to react before entering a no-shoot zone (seconds)
-        public static final double RETRACTION_TIME_SEC = 0.25;
-
-        // Heading tolerance for ReadyToShoot (degrees)
-        public static final double HEADING_TOLERANCE_DEG = 5.0;
-    }
+    // Heading tolerance for ReadyToShoot (degrees)
+    public static final double HEADING_TOLERANCE_DEG = 5.0;
+  }
 }

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -8,7 +8,6 @@ import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj.Timer;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.CommandScheduler;
-
 import frc.robot.sim.SimDeviceManager;
 import frc.robot.sim.SimScenarioRunner;
 import frc.robot.telemetry.TelemetryManager;
@@ -26,7 +25,6 @@ import frc.robot.util.PostMatchSummary;
 import frc.robot.util.PreMatchDiagnostics;
 import frc.robot.util.PredictiveAlerts;
 import frc.robot.util.ScoringReadiness;
-
 import org.littletonrobotics.junction.LoggedRobot;
 import org.littletonrobotics.junction.Logger;
 import org.littletonrobotics.junction.networktables.NT4Publisher;
@@ -40,390 +38,386 @@ import org.littletonrobotics.junction.wpilog.WPILOGWriter;
  */
 public class Robot extends LoggedRobot {
 
-    private static Robot instance;
-    private Command m_autonomousCommand;
-    private RobotContainer m_robotContainer;
+  private static Robot instance;
+  private Command m_autonomousCommand;
+  private RobotContainer m_robotContainer;
 
-    private Timer disabledTimer;
-    private SimScenarioRunner simScenarioRunner;
-    private SimDeviceManager simDeviceManager;
+  private Timer disabledTimer;
+  private SimScenarioRunner simScenarioRunner;
+  private SimDeviceManager simDeviceManager;
 
-    // Diagnostics
-    private boolean hasRunDiagnostics = false;
+  // Diagnostics
+  private boolean hasRunDiagnostics = false;
 
-    // Logging status
-    private boolean loggingAvailable = false;
+  // Logging status
+  private boolean loggingAvailable = false;
 
-    public Robot() {
-        instance = this;
-    }
+  public Robot() {
+    instance = this;
+  }
 
-    public static Robot getInstance() {
-        return instance;
-    }
+  public static Robot getInstance() {
+    return instance;
+  }
 
-    private void installExceptionHandler() {
-        Thread.setDefaultUncaughtExceptionHandler(
-                (thread, exception) -> {
-                    try {
-                        DiagnosticContext.captureException(thread, exception);
-                    } catch (Throwable t) {
-                    }
+  private void installExceptionHandler() {
+    Thread.setDefaultUncaughtExceptionHandler(
+        (thread, exception) -> {
+          try {
+            DiagnosticContext.captureException(thread, exception);
+          } catch (Throwable t) {
+          }
 
-                    if (exception instanceof RuntimeException) {
-                        throw (RuntimeException) exception;
-                    } else if (exception instanceof Error) {
-                        throw (Error) exception;
-                    } else {
-                        throw new RuntimeException(exception);
-                    }
-                });
-    }
+          if (exception instanceof RuntimeException) {
+            throw (RuntimeException) exception;
+          } else if (exception instanceof Error) {
+            throw (Error) exception;
+          } else {
+            throw new RuntimeException(exception);
+          }
+        });
+  }
 
-    /** Configure AdvantageKit logging. Failures are swallowed so the robot keeps running. */
-    private void configureLogging() {
+  /** Configure AdvantageKit logging. Failures are swallowed so the robot keeps running. */
+  private void configureLogging() {
+    try {
+      Logger.recordMetadata("ProjectName", BuildConstants.MAVEN_NAME);
+      Logger.recordMetadata("BuildDate", BuildConstants.BUILD_DATE);
+      Logger.recordMetadata("GitSHA", BuildConstants.GIT_SHA);
+      Logger.recordMetadata("GitBranch", BuildConstants.GIT_BRANCH);
+      Logger.recordMetadata("GitDirty", BuildConstants.DIRTY == 1 ? "true" : "false");
+
+      if (isReal()) {
+        // USB logging, skip if USB not mounted
         try {
-            Logger.recordMetadata("ProjectName", BuildConstants.MAVEN_NAME);
-            Logger.recordMetadata("BuildDate", BuildConstants.BUILD_DATE);
-            Logger.recordMetadata("GitSHA", BuildConstants.GIT_SHA);
-            Logger.recordMetadata("GitBranch", BuildConstants.GIT_BRANCH);
-            Logger.recordMetadata("GitDirty", BuildConstants.DIRTY == 1 ? "true" : "false");
-
-            if (isReal()) {
-                // USB logging, skip if USB not mounted
-                try {
-                    Logger.addDataReceiver(new WPILOGWriter());
-                } catch (Throwable t) {
-                    DriverStation.reportWarning(
-                            "USB logging unavailable: " + t.getMessage(), false);
-                }
-
-                // NT logging - also optional
-                try {
-                    Logger.addDataReceiver(new NT4Publisher());
-                } catch (Throwable t) {
-                    DriverStation.reportWarning("NT logging unavailable: " + t.getMessage(), false);
-                }
-            } else {
-                // Simulation - less critical but still wrap
-                try {
-                    Logger.addDataReceiver(new WPILOGWriter("logs"));
-                    Logger.addDataReceiver(new NT4Publisher());
-                } catch (Throwable t) {
-                    // Simulation logging failed - continue anyway
-                }
-            }
-
-            Logger.start();
-            loggingAvailable = true;
+          Logger.addDataReceiver(new WPILOGWriter());
         } catch (Throwable t) {
-            // Entire logging system failed - robot still runs
-            DriverStation.reportError(
-                    "Logging system failed to initialize: " + t.getMessage(), false);
-            loggingAvailable = false;
+          DriverStation.reportWarning("USB logging unavailable: " + t.getMessage(), false);
         }
-    }
 
-    /** Crash-barrier wrapper: runs action, logs to Health/CrashBarrier/{name} on failure. */
-    private void safeCall(String name, Runnable action) {
+        // NT logging - also optional
         try {
-            action.run();
+          Logger.addDataReceiver(new NT4Publisher());
         } catch (Throwable t) {
-            safeLog("Health/CrashBarrier/" + name, true);
-            safeLog("Health/CrashBarrier/LastError", t.getClass().getSimpleName());
+          DriverStation.reportWarning("NT logging unavailable: " + t.getMessage(), false);
         }
-    }
-
-    /** Check critical telemetry values for NaN/Infinity corruption. */
-    private void checkNaNInfinity() {
-        TelemetryManager tm = TelemetryManager.getInstance();
-        checkValue("Shooter/VelocityRPM", tm.getShooterVelocityRPM());
-        checkValue("Shooter/Temperature", tm.getShooterTemperature());
-        checkValue("Health/LoopTimeMs", tm.getLoopTimeMs());
-    }
-
-    private void checkValue(String name, double value) {
-        if (Double.isNaN(value) || Double.isInfinite(value)) {
-            safeLog("Health/NaN/" + name, true);
-        }
-    }
-
-    /** Safe logging helper that cannot throw */
-    private void safeLog(String key, boolean value) {
+      } else {
+        // Simulation - less critical but still wrap
         try {
-            Logger.recordOutput(key, value);
+          Logger.addDataReceiver(new WPILOGWriter("logs"));
+          Logger.addDataReceiver(new NT4Publisher());
         } catch (Throwable t) {
-            // Ignore - logging failure shouldn't crash robot
+          // Simulation logging failed - continue anyway
         }
+      }
+
+      Logger.start();
+      loggingAvailable = true;
+    } catch (Throwable t) {
+      // Entire logging system failed - robot still runs
+      DriverStation.reportError("Logging system failed to initialize: " + t.getMessage(), false);
+      loggingAvailable = false;
+    }
+  }
+
+  /** Crash-barrier wrapper: runs action, logs to Health/CrashBarrier/{name} on failure. */
+  private void safeCall(String name, Runnable action) {
+    try {
+      action.run();
+    } catch (Throwable t) {
+      safeLog("Health/CrashBarrier/" + name, true);
+      safeLog("Health/CrashBarrier/LastError", t.getClass().getSimpleName());
+    }
+  }
+
+  /** Check critical telemetry values for NaN/Infinity corruption. */
+  private void checkNaNInfinity() {
+    TelemetryManager tm = TelemetryManager.getInstance();
+    checkValue("Shooter/VelocityRPM", tm.getShooterVelocityRPM());
+    checkValue("Shooter/Temperature", tm.getShooterTemperature());
+    checkValue("Health/LoopTimeMs", tm.getLoopTimeMs());
+  }
+
+  private void checkValue(String name, double value) {
+    if (Double.isNaN(value) || Double.isInfinite(value)) {
+      safeLog("Health/NaN/" + name, true);
+    }
+  }
+
+  /** Safe logging helper that cannot throw */
+  private void safeLog(String key, boolean value) {
+    try {
+      Logger.recordOutput(key, value);
+    } catch (Throwable t) {
+      // Ignore - logging failure shouldn't crash robot
+    }
+  }
+
+  /** Safe logging helper that cannot throw */
+  private void safeLog(String key, String value) {
+    try {
+      Logger.recordOutput(key, value);
+    } catch (Throwable t) {
+      // Ignore - logging failure shouldn't crash robot
+    }
+  }
+
+  @Override
+  public void robotInit() {
+    installExceptionHandler();
+    configureLogging();
+
+    m_robotContainer = RobotContainer.getInstance();
+
+    // Create a timer to disable motor brake a few seconds after disable. This will
+    // let the robot stop immediately when disabled, but then also let it be pushed more
+    disabledTimer = new Timer();
+
+    if (isSimulation()) {
+      DriverStation.silenceJoystickConnectionWarning(true);
     }
 
-    /** Safe logging helper that cannot throw */
-    private void safeLog(String key, String value) {
-        try {
-            Logger.recordOutput(key, value);
-        } catch (Throwable t) {
-            // Ignore - logging failure shouldn't crash robot
-        }
+    // Send test notification to Elastic Dashboard (protected)
+    try {
+      ElasticUtil.sendInfo("Robot", "Code initialized successfully");
+    } catch (Throwable t) {
+      // Dashboard notification failed - not critical
+    }
+  }
+
+  @Override
+  public void robotPeriodic() {
+    safeCall("Tracer", () -> LoggedTracer.reset());
+
+    safeCall("CommandScheduler", () -> CommandScheduler.getInstance().run());
+    safeCall("Tracer", () -> LoggedTracer.record("CommandsMs"));
+
+    // Hub shift + fire authorization run before telemetry so ScoringTelemetry reads fresh state
+    safeCall("HubShift", () -> HubShiftEngine.getInstance().update(0));
+    safeCall(
+        "FireAuth",
+        () -> {
+          HubShiftEngine engine = HubShiftEngine.getInstance();
+          FireAuthorization.getInstance()
+              .update(
+                  engine.getShiftedInfo(),
+                  0,
+                  engine.getConfidence(),
+                  engine.isHubTrackingEnabled());
+        });
+
+    safeCall("Telemetry", () -> TelemetryManager.getInstance().updateAll());
+    safeCall("NaNGuard", () -> checkNaNInfinity());
+    safeCall("Tracer", () -> LoggedTracer.record("TelemetryMs"));
+
+    safeCall(
+        "ChannelCoordinator",
+        () -> {
+          ChannelCoordinator.getInstance().update();
+          ChannelCoordinator.getInstance().log();
+        });
+
+    safeCall("DriverFeedback", () -> DriverFeedback.getInstance().update());
+    safeCall("LEDStatus", () -> LEDStatusDisplay.getInstance().update());
+
+    safeCall(
+        "Alerts",
+        () -> {
+          AlertManager.getInstance().checkAll();
+          AlertManager.getInstance().checkLoopTime(TelemetryManager.getInstance().getLoopTimeMs());
+          AlertManager.getInstance().logActiveAlerts();
+        });
+
+    safeCall(
+        "Predictive",
+        () -> {
+          PredictiveAlerts.getInstance().update();
+          PredictiveAlerts.getInstance().log();
+        });
+
+    safeCall(
+        "PostMatch",
+        () -> {
+          if (DriverStation.isEnabled()) {
+            PostMatchSummary.getInstance()
+                .updateTracking(TelemetryManager.getInstance().getLoopTimeMs());
+          }
+        });
+
+    safeCall("Tracer", () -> LoggedTracer.record("AlertsMs"));
+  }
+
+  @Override
+  public void disabledInit() {
+    try {
+      m_robotContainer.setMotorBrake(true);
+    } catch (Throwable t) {
+      safeLog("Health/CrashBarrier/DisabledInit", true);
+    }
+    disabledTimer.reset();
+    disabledTimer.start();
+
+    try {
+      EventMarker.modeChange("DISABLED");
+    } catch (Throwable t) {
+      // Event marker failure not critical
     }
 
-    @Override
-    public void robotInit() {
-        installExceptionHandler();
-        configureLogging();
-
-        m_robotContainer = RobotContainer.getInstance();
-
-        // Create a timer to disable motor brake a few seconds after disable. This will
-        // let the robot stop immediately when disabled, but then also let it be pushed more
-        disabledTimer = new Timer();
-
-        if (isSimulation()) {
-            DriverStation.silenceJoystickConnectionWarning(true);
-        }
-
-        // Send test notification to Elastic Dashboard (protected)
-        try {
-            ElasticUtil.sendInfo("Robot", "Code initialized successfully");
-        } catch (Throwable t) {
-            // Dashboard notification failed - not critical
-        }
+    try {
+      DriverFeedback.getInstance().stopAll();
+    } catch (Throwable t) {
+      // Not critical
     }
 
-    @Override
-    public void robotPeriodic() {
-        safeCall("Tracer", () -> LoggedTracer.reset());
-
-        safeCall("CommandScheduler", () -> CommandScheduler.getInstance().run());
-        safeCall("Tracer", () -> LoggedTracer.record("CommandsMs"));
-
-        // Hub shift + fire authorization run before telemetry so ScoringTelemetry reads fresh state
-        safeCall("HubShift", () -> HubShiftEngine.getInstance().update(0));
-        safeCall(
-                "FireAuth",
-                () -> {
-                    HubShiftEngine engine = HubShiftEngine.getInstance();
-                    FireAuthorization.getInstance()
-                            .update(
-                                    engine.getShiftedInfo(),
-                                    0,
-                                    engine.getConfidence(),
-                                    engine.isHubTrackingEnabled());
-                });
-
-        safeCall("Telemetry", () -> TelemetryManager.getInstance().updateAll());
-        safeCall("NaNGuard", () -> checkNaNInfinity());
-        safeCall("Tracer", () -> LoggedTracer.record("TelemetryMs"));
-
-        safeCall(
-                "ChannelCoordinator",
-                () -> {
-                    ChannelCoordinator.getInstance().update();
-                    ChannelCoordinator.getInstance().log();
-                });
-
-        safeCall("DriverFeedback", () -> DriverFeedback.getInstance().update());
-        safeCall("LEDStatus", () -> LEDStatusDisplay.getInstance().update());
-
-        safeCall(
-                "Alerts",
-                () -> {
-                    AlertManager.getInstance().checkAll();
-                    AlertManager.getInstance()
-                            .checkLoopTime(TelemetryManager.getInstance().getLoopTimeMs());
-                    AlertManager.getInstance().logActiveAlerts();
-                });
-
-        safeCall(
-                "Predictive",
-                () -> {
-                    PredictiveAlerts.getInstance().update();
-                    PredictiveAlerts.getInstance().log();
-                });
-
-        safeCall(
-                "PostMatch",
-                () -> {
-                    if (DriverStation.isEnabled()) {
-                        PostMatchSummary.getInstance()
-                                .updateTracking(TelemetryManager.getInstance().getLoopTimeMs());
-                    }
-                });
-
-        safeCall("Tracer", () -> LoggedTracer.record("AlertsMs"));
+    // Generate post-match summary if we were tracking
+    try {
+      PostMatchSummary.getInstance().generateSummary();
+    } catch (Throwable t) {
+      safeLog("Health/CrashBarrier/PostMatchSummary", true);
     }
 
-    @Override
-    public void disabledInit() {
-        try {
-            m_robotContainer.setMotorBrake(true);
-        } catch (Throwable t) {
-            safeLog("Health/CrashBarrier/DisabledInit", true);
-        }
+    hasRunDiagnostics = false;
+  }
+
+  @Override
+  public void disabledPeriodic() {
+    try {
+      if (disabledTimer.hasElapsed(Constants.DrivebaseConstants.WHEEL_LOCK_TIME)) {
+        m_robotContainer.setMotorBrake(false);
+        disabledTimer.stop();
         disabledTimer.reset();
-        disabledTimer.start();
-
-        try {
-            EventMarker.modeChange("DISABLED");
-        } catch (Throwable t) {
-            // Event marker failure not critical
-        }
-
-        try {
-            DriverFeedback.getInstance().stopAll();
-        } catch (Throwable t) {
-            // Not critical
-        }
-
-        // Generate post-match summary if we were tracking
-        try {
-            PostMatchSummary.getInstance().generateSummary();
-        } catch (Throwable t) {
-            safeLog("Health/CrashBarrier/PostMatchSummary", true);
-        }
-
-        hasRunDiagnostics = false;
+      }
+    } catch (Throwable t) {
+      safeLog("Health/CrashBarrier/DisabledPeriodic", true);
     }
 
-    @Override
-    public void disabledPeriodic() {
-        try {
-            if (disabledTimer.hasElapsed(Constants.DrivebaseConstants.WHEEL_LOCK_TIME)) {
-                m_robotContainer.setMotorBrake(false);
-                disabledTimer.stop();
-                disabledTimer.reset();
-            }
-        } catch (Throwable t) {
-            safeLog("Health/CrashBarrier/DisabledPeriodic", true);
-        }
-
-        // Run safe diagnostics once after 0.5s delay (let readings stabilize)
-        if (!hasRunDiagnostics && disabledTimer.hasElapsed(0.5)) {
-            try {
-                PreMatchDiagnostics.getInstance().runSafeChecks();
-            } catch (Throwable t) {
-                safeLog("Health/CrashBarrier/Diagnostics", true);
-                DriverStation.reportWarning(
-                        "Pre-match diagnostics failed: " + t.getMessage(), false);
-            }
-            hasRunDiagnostics = true;
-        }
-
-        // Manual safe trigger from dashboard (sensor-only, works while disabled)
-        try {
-            if (PreMatchDiagnostics.getInstance().checkAndClearSafeTrigger()
-                    && !PreMatchDiagnostics.getInstance().isRunning()) {
-                PreMatchDiagnostics.getInstance().runSafeChecks();
-            }
-        } catch (Throwable t) {
-            safeLog("Health/CrashBarrier/DiagnosticsTrigger", true);
-        }
-
-        // Full trigger pressed while disabled - warn user
-        try {
-            if (PreMatchDiagnostics.getInstance().checkAndClearFullTrigger()) {
-                safeLog("Diagnostics/FullCheckBlocked", true);
-                // Notification sent by PreMatchDiagnostics.runFullChecks() when it rejects
-            }
-        } catch (Throwable t) {
-            // Ignore
-        }
+    // Run safe diagnostics once after 0.5s delay (let readings stabilize)
+    if (!hasRunDiagnostics && disabledTimer.hasElapsed(0.5)) {
+      try {
+        PreMatchDiagnostics.getInstance().runSafeChecks();
+      } catch (Throwable t) {
+        safeLog("Health/CrashBarrier/Diagnostics", true);
+        DriverStation.reportWarning("Pre-match diagnostics failed: " + t.getMessage(), false);
+      }
+      hasRunDiagnostics = true;
     }
 
-    @Override
-    public void autonomousInit() {
-        // Mode init is called by IterativeRobotBase.loopFunc() with NO try-catch.
-        // An unhandled exception here kills the robot program permanently.
-        m_robotContainer.setMotorBrake(true);
-        m_autonomousCommand = m_robotContainer.getAutonomousCommand();
-
-        try {
-            EventMarker.reset();
-            EventMarker.modeChange("AUTONOMOUS");
-            PostMatchSummary.getInstance().startTracking();
-        } catch (Throwable t) {
-            safeLog("Health/CrashBarrier/AutonomousInit", true);
-        }
-
-        if (m_autonomousCommand != null) {
-            CommandScheduler.getInstance().schedule(m_autonomousCommand);
-            try {
-                String autoName = m_autonomousCommand.getName();
-                EventMarker.autoStart(autoName);
-            } catch (Throwable t) {
-                safeLog("Health/CrashBarrier/AutonomousInit", true);
-            }
-        }
+    // Manual safe trigger from dashboard (sensor-only, works while disabled)
+    try {
+      if (PreMatchDiagnostics.getInstance().checkAndClearSafeTrigger()
+          && !PreMatchDiagnostics.getInstance().isRunning()) {
+        PreMatchDiagnostics.getInstance().runSafeChecks();
+      }
+    } catch (Throwable t) {
+      safeLog("Health/CrashBarrier/DiagnosticsTrigger", true);
     }
 
-    @Override
-    public void autonomousPeriodic() {}
+    // Full trigger pressed while disabled - warn user
+    try {
+      if (PreMatchDiagnostics.getInstance().checkAndClearFullTrigger()) {
+        safeLog("Diagnostics/FullCheckBlocked", true);
+        // Notification sent by PreMatchDiagnostics.runFullChecks() when it rejects
+      }
+    } catch (Throwable t) {
+      // Ignore
+    }
+  }
 
-    @Override
-    public void teleopInit() {
-        // cancelAll() is critical (stops auto commands). Telemetry helpers are not.
-        CommandScheduler.getInstance().cancelAll();
+  @Override
+  public void autonomousInit() {
+    // Mode init is called by IterativeRobotBase.loopFunc() with NO try-catch.
+    // An unhandled exception here kills the robot program permanently.
+    m_robotContainer.setMotorBrake(true);
+    m_autonomousCommand = m_robotContainer.getAutonomousCommand();
 
-        try {
-            EventMarker.modeChange("TELEOP");
-            PostMatchSummary.getInstance().startTracking();
-        } catch (Throwable t) {
-            safeLog("Health/CrashBarrier/TeleopInit", true);
-        }
-
-        // Reset scoring state for the new teleop period
-        safeCall(
-                "ScoringReset",
-                () -> {
-                    ScoringReadiness.getInstance().reset();
-                    HubShiftEngine.getInstance().initializeTeleop();
-                });
+    try {
+      EventMarker.reset();
+      EventMarker.modeChange("AUTONOMOUS");
+      PostMatchSummary.getInstance().startTracking();
+    } catch (Throwable t) {
+      safeLog("Health/CrashBarrier/AutonomousInit", true);
     }
 
-    @Override
-    public void teleopPeriodic() {}
+    if (m_autonomousCommand != null) {
+      CommandScheduler.getInstance().schedule(m_autonomousCommand);
+      try {
+        String autoName = m_autonomousCommand.getName();
+        EventMarker.autoStart(autoName);
+      } catch (Throwable t) {
+        safeLog("Health/CrashBarrier/AutonomousInit", true);
+      }
+    }
+  }
 
-    @Override
-    public void testInit() {
-        CommandScheduler.getInstance().cancelAll();
-        try {
-            EventMarker.modeChange("TEST");
-        } catch (Throwable t) {
-            safeLog("Health/CrashBarrier/TestInit", true);
-        }
+  @Override
+  public void autonomousPeriodic() {}
+
+  @Override
+  public void teleopInit() {
+    // cancelAll() is critical (stops auto commands). Telemetry helpers are not.
+    CommandScheduler.getInstance().cancelAll();
+
+    try {
+      EventMarker.modeChange("TELEOP");
+      PostMatchSummary.getInstance().startTracking();
+    } catch (Throwable t) {
+      safeLog("Health/CrashBarrier/TeleopInit", true);
     }
 
-    @Override
-    public void testPeriodic() {
-        // Full diagnostic trigger (actuator tests) - only works in test mode
-        try {
-            if (PreMatchDiagnostics.getInstance().checkAndClearFullTrigger()
-                    && !PreMatchDiagnostics.getInstance().isRunning()) {
-                PreMatchDiagnostics.getInstance().runFullChecks();
-            }
-            // Safe checks can also run in test mode
-            if (PreMatchDiagnostics.getInstance().checkAndClearSafeTrigger()
-                    && !PreMatchDiagnostics.getInstance().isRunning()) {
-                PreMatchDiagnostics.getInstance().runSafeChecks();
-            }
-        } catch (Throwable t) {
-            safeLog("Health/CrashBarrier/DiagnosticsTest", true);
-        }
-    }
+    // Reset scoring state for the new teleop period
+    safeCall(
+        "ScoringReset",
+        () -> {
+          ScoringReadiness.getInstance().reset();
+          HubShiftEngine.getInstance().initializeTeleop();
+        });
+  }
 
-    @Override
-    public void simulationInit() {
-        simDeviceManager = new SimDeviceManager();
-        simDeviceManager.init();
-        simScenarioRunner = new SimScenarioRunner();
-    }
+  @Override
+  public void teleopPeriodic() {}
 
-    @Override
-    public void simulationPeriodic() {
-        if (simDeviceManager != null) {
-            simDeviceManager.update();
-        }
-        if (simScenarioRunner != null) {
-            simScenarioRunner.update();
-        }
+  @Override
+  public void testInit() {
+    CommandScheduler.getInstance().cancelAll();
+    try {
+      EventMarker.modeChange("TEST");
+    } catch (Throwable t) {
+      safeLog("Health/CrashBarrier/TestInit", true);
     }
+  }
+
+  @Override
+  public void testPeriodic() {
+    // Full diagnostic trigger (actuator tests) - only works in test mode
+    try {
+      if (PreMatchDiagnostics.getInstance().checkAndClearFullTrigger()
+          && !PreMatchDiagnostics.getInstance().isRunning()) {
+        PreMatchDiagnostics.getInstance().runFullChecks();
+      }
+      // Safe checks can also run in test mode
+      if (PreMatchDiagnostics.getInstance().checkAndClearSafeTrigger()
+          && !PreMatchDiagnostics.getInstance().isRunning()) {
+        PreMatchDiagnostics.getInstance().runSafeChecks();
+      }
+    } catch (Throwable t) {
+      safeLog("Health/CrashBarrier/DiagnosticsTest", true);
+    }
+  }
+
+  @Override
+  public void simulationInit() {
+    simDeviceManager = new SimDeviceManager();
+    simDeviceManager.init();
+    simScenarioRunner = new SimScenarioRunner();
+  }
+
+  @Override
+  public void simulationPeriodic() {
+    if (simDeviceManager != null) {
+      simDeviceManager.update();
+    }
+    if (simScenarioRunner != null) {
+      simScenarioRunner.update();
+    }
+  }
 }

--- a/src/main/java/frc/robot/telemetry/MatchStatsTelemetry.java
+++ b/src/main/java/frc/robot/telemetry/MatchStatsTelemetry.java
@@ -2,237 +2,236 @@ package frc.robot.telemetry;
 
 import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj.Timer;
-
 import frc.robot.util.FireAuthorization;
 
 /** Tracks shots per phase, time allocation, and hub-shift scoring efficiency. */
 public class MatchStatsTelemetry implements SubsystemTelemetry {
-    private final ShooterTelemetry shooterTelemetry;
-    private final VisionTelemetry visionTelemetry;
-    private final ScoringTelemetry scoringTelemetry; // nullable
+  private final ShooterTelemetry shooterTelemetry;
+  private final VisionTelemetry visionTelemetry;
+  private final ScoringTelemetry scoringTelemetry; // nullable
 
-    private boolean wasEnabled = false;
-    private double matchStartTime = 0;
-    private double endgameStartTime = 0;
-    private boolean inEndgame = false;
+  private boolean wasEnabled = false;
+  private double matchStartTime = 0;
+  private double endgameStartTime = 0;
+  private boolean inEndgame = false;
 
-    private int autoShots = 0;
-    private int teleopShots = 0;
-    private int endgameShots = 0;
-    private int lastTotalShots = 0;
+  private int autoShots = 0;
+  private int teleopShots = 0;
+  private int endgameShots = 0;
+  private int lastTotalShots = 0;
 
-    private double timeShootingMs = 0;
-    private double timeAimingMs = 0;
-    private double timeIdleMs = 0;
+  private double timeShootingMs = 0;
+  private double timeAimingMs = 0;
+  private double timeIdleMs = 0;
 
-    private double shooterUptimeMs = 0;
-    private double visionLockTimeMs = 0;
+  private double shooterUptimeMs = 0;
+  private double visionLockTimeMs = 0;
 
-    private int shotsShift1 = 0;
-    private int shotsShift2 = 0;
-    private int shotsShift3 = 0;
-    private int shotsShift4 = 0;
-    private int shotsShiftEndgame = 0;
+  private int shotsShift1 = 0;
+  private int shotsShift2 = 0;
+  private int shotsShift3 = 0;
+  private int shotsShift4 = 0;
+  private int shotsShiftEndgame = 0;
 
-    private int activeHubShots = 0;
-    private int inactiveHubShots = 0;
+  private int activeHubShots = 0;
+  private int inactiveHubShots = 0;
 
-    private double activeHubTimeMs = 0;
-    private double firingDuringActiveMs = 0;
+  private double activeHubTimeMs = 0;
+  private double firingDuringActiveMs = 0;
 
-    private int shotsWasted = 0;
-    private int marginalShots = 0;
-    private int preSpinEvents = 0;
-    private boolean prevPreSpin = false;
+  private int shotsWasted = 0;
+  private int marginalShots = 0;
+  private int preSpinEvents = 0;
+  private boolean prevPreSpin = false;
 
-    private double lastUpdateTime = 0;
+  private double lastUpdateTime = 0;
 
-    public MatchStatsTelemetry(
-            ShooterTelemetry shooter, VisionTelemetry vision, ScoringTelemetry scoring) {
-        this.shooterTelemetry = shooter;
-        this.visionTelemetry = vision;
-        this.scoringTelemetry = scoring;
+  public MatchStatsTelemetry(
+      ShooterTelemetry shooter, VisionTelemetry vision, ScoringTelemetry scoring) {
+    this.shooterTelemetry = shooter;
+    this.visionTelemetry = vision;
+    this.scoringTelemetry = scoring;
+  }
+
+  @Override
+  public void update() {
+    double now = Timer.getFPGATimestamp();
+
+    double dt = (lastUpdateTime > 0) ? (now - lastUpdateTime) : 0.02;
+    lastUpdateTime = now;
+
+    boolean currentlyEnabled = DriverStation.isEnabled();
+
+    if (!wasEnabled && currentlyEnabled) {
+      matchStartTime = now;
+      inEndgame = false;
+    }
+    wasEnabled = currentlyEnabled;
+
+    if (!currentlyEnabled) {
+      return;
     }
 
-    @Override
-    public void update() {
-        double now = Timer.getFPGATimestamp();
+    if (DriverStation.isTeleop() && !inEndgame) {
+      double matchTime = DriverStation.getMatchTime();
+      if (matchTime <= 30 && matchTime > 0) {
+        endgameStartTime = now;
+        inEndgame = true;
+      }
+    }
 
-        double dt = (lastUpdateTime > 0) ? (now - lastUpdateTime) : 0.02;
-        lastUpdateTime = now;
+    int currentTotalShots = shooterTelemetry.getTotalShots();
+    int newShots = currentTotalShots - lastTotalShots;
+    if (newShots > 0) {
+      if (DriverStation.isAutonomous()) {
+        autoShots += newShots;
+      } else if (inEndgame) {
+        endgameShots += newShots;
+      } else {
+        teleopShots += newShots;
+      }
 
-        boolean currentlyEnabled = DriverStation.isEnabled();
-
-        if (!wasEnabled && currentlyEnabled) {
-            matchStartTime = now;
-            inEndgame = false;
+      if (scoringTelemetry != null) {
+        int shift = scoringTelemetry.getHubShiftNumber();
+        boolean hubActive = scoringTelemetry.isHubActive();
+        switch (shift) {
+          case 1 -> shotsShift1 += newShots;
+          case 2 -> shotsShift2 += newShots;
+          case 3 -> shotsShift3 += newShots;
+          case 4 -> shotsShift4 += newShots;
+          case 0 -> shotsShiftEndgame += newShots;
+          default -> {}
         }
-        wasEnabled = currentlyEnabled;
-
-        if (!currentlyEnabled) {
-            return;
-        }
-
-        if (DriverStation.isTeleop() && !inEndgame) {
-            double matchTime = DriverStation.getMatchTime();
-            if (matchTime <= 30 && matchTime > 0) {
-                endgameStartTime = now;
-                inEndgame = true;
-            }
-        }
-
-        int currentTotalShots = shooterTelemetry.getTotalShots();
-        int newShots = currentTotalShots - lastTotalShots;
-        if (newShots > 0) {
-            if (DriverStation.isAutonomous()) {
-                autoShots += newShots;
-            } else if (inEndgame) {
-                endgameShots += newShots;
-            } else {
-                teleopShots += newShots;
-            }
-
-            if (scoringTelemetry != null) {
-                int shift = scoringTelemetry.getHubShiftNumber();
-                boolean hubActive = scoringTelemetry.isHubActive();
-                switch (shift) {
-                    case 1 -> shotsShift1 += newShots;
-                    case 2 -> shotsShift2 += newShots;
-                    case 3 -> shotsShift3 += newShots;
-                    case 4 -> shotsShift4 += newShots;
-                    case 0 -> shotsShiftEndgame += newShots;
-                    default -> {}
-                }
-                if (hubActive) activeHubShots += newShots;
-                else inactiveHubShots += newShots;
-
-                try {
-                    FireAuthorization fa = FireAuthorization.getInstance();
-                    FireAuthorization.AuthorizationLevel authLevel = fa.getLevel();
-                    if (authLevel == FireAuthorization.AuthorizationLevel.FIRE_MARGINAL) {
-                        marginalShots += newShots;
-                    }
-                    if (!hubActive) {
-                        shotsWasted += newShots;
-                    }
-                } catch (Throwable t) {
-                    // fire auth not available, skip analytics
-                }
-            }
-        }
-        lastTotalShots = currentTotalShots;
+        if (hubActive) activeHubShots += newShots;
+        else inactiveHubShots += newShots;
 
         try {
-            boolean preSpin = FireAuthorization.getInstance().isPreSpin();
-            if (preSpin && !prevPreSpin) preSpinEvents++;
-            prevPreSpin = preSpin;
+          FireAuthorization fa = FireAuthorization.getInstance();
+          FireAuthorization.AuthorizationLevel authLevel = fa.getLevel();
+          if (authLevel == FireAuthorization.AuthorizationLevel.FIRE_MARGINAL) {
+            marginalShots += newShots;
+          }
+          if (!hubActive) {
+            shotsWasted += newShots;
+          }
         } catch (Throwable t) {
-            // fire auth not available
+          // fire auth not available, skip analytics
         }
+      }
+    }
+    lastTotalShots = currentTotalShots;
 
+    try {
+      boolean preSpin = FireAuthorization.getInstance().isPreSpin();
+      if (preSpin && !prevPreSpin) preSpinEvents++;
+      prevPreSpin = preSpin;
+    } catch (Throwable t) {
+      // fire auth not available
+    }
+
+    if (shooterTelemetry.isAtSpeed()) {
+      shooterUptimeMs += dt * 1000;
+    }
+
+    if (visionTelemetry.isLockedOnTarget()) {
+      visionLockTimeMs += dt * 1000;
+    }
+
+    double dtMs = dt * 1000;
+    if (shooterTelemetry.isAtSpeed()) {
+      timeShootingMs += dtMs;
+    } else if (shooterTelemetry.isSpinningUp()) {
+      timeAimingMs += dtMs;
+    } else {
+      timeIdleMs += dtMs;
+    }
+
+    if (scoringTelemetry != null && DriverStation.isTeleop()) {
+      if (scoringTelemetry.isHubActive()) {
+        activeHubTimeMs += dtMs;
         if (shooterTelemetry.isAtSpeed()) {
-            shooterUptimeMs += dt * 1000;
+          firingDuringActiveMs += dtMs;
         }
+      }
+    }
+  }
 
-        if (visionTelemetry.isLockedOnTarget()) {
-            visionLockTimeMs += dt * 1000;
-        }
+  @Override
+  public void log() {
+    int totalShots = autoShots + teleopShots + endgameShots;
+    SafeLog.put("MatchStats/AutoShots", autoShots);
+    SafeLog.put("MatchStats/TeleopShots", teleopShots);
+    SafeLog.put("MatchStats/EndgameShots", endgameShots);
+    SafeLog.put("MatchStats/TotalShots", totalShots);
 
-        double dtMs = dt * 1000;
-        if (shooterTelemetry.isAtSpeed()) {
-            timeShootingMs += dtMs;
-        } else if (shooterTelemetry.isSpinningUp()) {
-            timeAimingMs += dtMs;
-        } else {
-            timeIdleMs += dtMs;
-        }
-
-        if (scoringTelemetry != null && DriverStation.isTeleop()) {
-            if (scoringTelemetry.isHubActive()) {
-                activeHubTimeMs += dtMs;
-                if (shooterTelemetry.isAtSpeed()) {
-                    firingDuringActiveMs += dtMs;
-                }
-            }
-        }
+    double totalTime = timeShootingMs + timeAimingMs + timeIdleMs;
+    if (totalTime > 0) {
+      SafeLog.put("MatchStats/Time/ShootingPct", timeShootingMs / totalTime * 100);
+      SafeLog.put("MatchStats/Time/AimingPct", timeAimingMs / totalTime * 100);
+      SafeLog.put("MatchStats/Time/IdlePct", timeIdleMs / totalTime * 100);
+    } else {
+      SafeLog.put("MatchStats/Time/ShootingPct", 0.0);
+      SafeLog.put("MatchStats/Time/AimingPct", 0.0);
+      SafeLog.put("MatchStats/Time/IdlePct", 0.0);
     }
 
-    @Override
-    public void log() {
-        int totalShots = autoShots + teleopShots + endgameShots;
-        SafeLog.put("MatchStats/AutoShots", autoShots);
-        SafeLog.put("MatchStats/TeleopShots", teleopShots);
-        SafeLog.put("MatchStats/EndgameShots", endgameShots);
-        SafeLog.put("MatchStats/TotalShots", totalShots);
+    SafeLog.put("MatchStats/ShooterUptimeMs", shooterUptimeMs);
+    SafeLog.put("MatchStats/VisionLockTimeMs", visionLockTimeMs);
 
-        double totalTime = timeShootingMs + timeAimingMs + timeIdleMs;
-        if (totalTime > 0) {
-            SafeLog.put("MatchStats/Time/ShootingPct", timeShootingMs / totalTime * 100);
-            SafeLog.put("MatchStats/Time/AimingPct", timeAimingMs / totalTime * 100);
-            SafeLog.put("MatchStats/Time/IdlePct", timeIdleMs / totalTime * 100);
-        } else {
-            SafeLog.put("MatchStats/Time/ShootingPct", 0.0);
-            SafeLog.put("MatchStats/Time/AimingPct", 0.0);
-            SafeLog.put("MatchStats/Time/IdlePct", 0.0);
-        }
-
-        SafeLog.put("MatchStats/ShooterUptimeMs", shooterUptimeMs);
-        SafeLog.put("MatchStats/VisionLockTimeMs", visionLockTimeMs);
-
-        double matchDurationMin = (Timer.getFPGATimestamp() - matchStartTime) / 60.0;
-        if (matchDurationMin > 0.05) {
-            SafeLog.put("MatchStats/ShotsPerMinute", totalShots / matchDurationMin);
-        } else {
-            SafeLog.put("MatchStats/ShotsPerMinute", 0.0);
-        }
-
-        SafeLog.put("MatchStats/ShotsInShift/1", shotsShift1);
-        SafeLog.put("MatchStats/ShotsInShift/2", shotsShift2);
-        SafeLog.put("MatchStats/ShotsInShift/3", shotsShift3);
-        SafeLog.put("MatchStats/ShotsInShift/4", shotsShift4);
-        SafeLog.put("MatchStats/ShotsInShift/Endgame", shotsShiftEndgame);
-        SafeLog.put("MatchStats/ActiveHubShots", activeHubShots);
-        SafeLog.put("MatchStats/InactiveHubShots", inactiveHubShots);
-        double hubUtil = activeHubTimeMs > 0 ? (firingDuringActiveMs / activeHubTimeMs) * 100 : 0;
-        SafeLog.put("MatchStats/HubUtilization", hubUtil);
-
-        SafeLog.put("MatchStats/ShotsWasted", shotsWasted);
-        SafeLog.put("MatchStats/MarginalShots", marginalShots);
-        SafeLog.put("MatchStats/PreSpinEvents", preSpinEvents);
+    double matchDurationMin = (Timer.getFPGATimestamp() - matchStartTime) / 60.0;
+    if (matchDurationMin > 0.05) {
+      SafeLog.put("MatchStats/ShotsPerMinute", totalShots / matchDurationMin);
+    } else {
+      SafeLog.put("MatchStats/ShotsPerMinute", 0.0);
     }
 
-    @Override
-    public String getName() {
-        return "MatchStats";
-    }
+    SafeLog.put("MatchStats/ShotsInShift/1", shotsShift1);
+    SafeLog.put("MatchStats/ShotsInShift/2", shotsShift2);
+    SafeLog.put("MatchStats/ShotsInShift/3", shotsShift3);
+    SafeLog.put("MatchStats/ShotsInShift/4", shotsShift4);
+    SafeLog.put("MatchStats/ShotsInShift/Endgame", shotsShiftEndgame);
+    SafeLog.put("MatchStats/ActiveHubShots", activeHubShots);
+    SafeLog.put("MatchStats/InactiveHubShots", inactiveHubShots);
+    double hubUtil = activeHubTimeMs > 0 ? (firingDuringActiveMs / activeHubTimeMs) * 100 : 0;
+    SafeLog.put("MatchStats/HubUtilization", hubUtil);
 
-    public void reset() {
-        autoShots = 0;
-        teleopShots = 0;
-        endgameShots = 0;
-        lastTotalShots = 0;
-        timeShootingMs = 0;
-        timeAimingMs = 0;
-        timeIdleMs = 0;
-        shooterUptimeMs = 0;
-        visionLockTimeMs = 0;
-        matchStartTime = 0;
-        endgameStartTime = 0;
-        inEndgame = false;
-        wasEnabled = false;
-        shotsShift1 = 0;
-        shotsShift2 = 0;
-        shotsShift3 = 0;
-        shotsShift4 = 0;
-        shotsShiftEndgame = 0;
-        activeHubShots = 0;
-        inactiveHubShots = 0;
-        activeHubTimeMs = 0;
-        firingDuringActiveMs = 0;
-        shotsWasted = 0;
-        marginalShots = 0;
-        preSpinEvents = 0;
-        prevPreSpin = false;
-        lastUpdateTime = 0;
-    }
+    SafeLog.put("MatchStats/ShotsWasted", shotsWasted);
+    SafeLog.put("MatchStats/MarginalShots", marginalShots);
+    SafeLog.put("MatchStats/PreSpinEvents", preSpinEvents);
+  }
+
+  @Override
+  public String getName() {
+    return "MatchStats";
+  }
+
+  public void reset() {
+    autoShots = 0;
+    teleopShots = 0;
+    endgameShots = 0;
+    lastTotalShots = 0;
+    timeShootingMs = 0;
+    timeAimingMs = 0;
+    timeIdleMs = 0;
+    shooterUptimeMs = 0;
+    visionLockTimeMs = 0;
+    matchStartTime = 0;
+    endgameStartTime = 0;
+    inEndgame = false;
+    wasEnabled = false;
+    shotsShift1 = 0;
+    shotsShift2 = 0;
+    shotsShift3 = 0;
+    shotsShift4 = 0;
+    shotsShiftEndgame = 0;
+    activeHubShots = 0;
+    inactiveHubShots = 0;
+    activeHubTimeMs = 0;
+    firingDuringActiveMs = 0;
+    shotsWasted = 0;
+    marginalShots = 0;
+    preSpinEvents = 0;
+    prevPreSpin = false;
+    lastUpdateTime = 0;
+  }
 }

--- a/src/main/java/frc/robot/telemetry/ScoringTelemetry.java
+++ b/src/main/java/frc/robot/telemetry/ScoringTelemetry.java
@@ -4,142 +4,141 @@ import frc.robot.util.ScoringReadiness;
 import frc.robot.util.SpatialLaunchValidator;
 
 /**
- * Wires subsystem telemetry into ScoringReadiness and logs the composite.
- * update() must run before log() so logged values reflect the current cycle.
+ * Wires subsystem telemetry into ScoringReadiness and logs the composite. update() must run before
+ * log() so logged values reflect the current cycle.
  */
 public class ScoringTelemetry implements SubsystemTelemetry {
-    private final ShooterTelemetry shooterTelemetry;
-    private final IndexerTelemetry indexerTelemetry;
-    private final VisionTelemetry visionTelemetry;
+  private final ShooterTelemetry shooterTelemetry;
+  private final IndexerTelemetry indexerTelemetry;
+  private final VisionTelemetry visionTelemetry;
 
-    private boolean scoringAvailable = false;
+  private boolean scoringAvailable = false;
 
-    public ScoringTelemetry(
-            ShooterTelemetry shooterTelemetry,
-            IndexerTelemetry indexerTelemetry,
-            VisionTelemetry visionTelemetry) {
-        this.shooterTelemetry = shooterTelemetry;
-        this.indexerTelemetry = indexerTelemetry;
-        this.visionTelemetry = visionTelemetry;
+  public ScoringTelemetry(
+      ShooterTelemetry shooterTelemetry,
+      IndexerTelemetry indexerTelemetry,
+      VisionTelemetry visionTelemetry) {
+    this.shooterTelemetry = shooterTelemetry;
+    this.indexerTelemetry = indexerTelemetry;
+    this.visionTelemetry = visionTelemetry;
+  }
+
+  @Override
+  public void update() {
+    try {
+      if (shooterTelemetry == null || indexerTelemetry == null || visionTelemetry == null) {
+        scoringAvailable = false;
+        ScoringReadiness.getInstance().reset();
+        return;
+      }
+      scoringAvailable = true;
+
+      ScoringReadiness sr = ScoringReadiness.getInstance();
+
+      // pass-through until ShotCalculator is wired on the SOTM branch
+      double confidence = 100;
+
+      sr.setInputs(
+          shooterTelemetry.isAtSpeed(),
+          !indexerTelemetry.isJamDetected(),
+          visionTelemetry.isLockedOnTarget(),
+          true, // stub: assume ball present until hopper sensor is wired
+          confidence);
+
+      // Stub: heading error = 0 until ShotCalculator has aim direction wired in
+      double headingError = 0;
+      boolean inExclusionZone = false;
+      try {
+        var pose = frc.robot.RobotContainer.getInstance().getSwerveSubsystem().getPose();
+        inExclusionZone = SpatialLaunchValidator.isInExclusionZone(pose.getX(), pose.getY());
+      } catch (Throwable t) {
+        // pose not available yet, fail-open
+      }
+      sr.setHeadingAndZone(headingError, inExclusionZone);
+
+      sr.update();
+    } catch (Throwable t) {
+      scoringAvailable = false;
+      ScoringReadiness.getInstance().reset();
     }
+  }
 
-    @Override
-    public void update() {
-        try {
-            if (shooterTelemetry == null || indexerTelemetry == null || visionTelemetry == null) {
-                scoringAvailable = false;
-                ScoringReadiness.getInstance().reset();
-                return;
-            }
-            scoringAvailable = true;
+  @Override
+  public void log() {
+    ScoringReadiness sr = ScoringReadiness.getInstance();
 
-            ScoringReadiness sr = ScoringReadiness.getInstance();
+    SafeLog.put("Scoring/Available", scoringAvailable);
+    SafeLog.put("Scoring/ReadyToShoot", sr.isReadyToShoot());
+    SafeLog.put("Scoring/Conditions/ShooterReady", sr.isShooterReady());
+    SafeLog.put("Scoring/Conditions/IndexerClear", sr.isIndexerClear());
+    SafeLog.put("Scoring/Conditions/VisionLocked", sr.isVisionLocked());
+    SafeLog.put("Scoring/Conditions/HasBall", sr.isHasBall());
+    SafeLog.put("Scoring/Conditions/HubActive", sr.isHubActive());
+    SafeLog.put("Scoring/Conditions/FireAuthorized", sr.isFireAuthorized());
+    SafeLog.put("Scoring/Conditions/ShotConfident", sr.isShotConfident());
+    SafeLog.put("Scoring/HeadingOnTarget", sr.isHeadingOnTarget());
+    SafeLog.put("Scoring/HeadingErrorDeg", sr.getHeadingErrorDeg());
+    SafeLog.put("Scoring/InExclusionZone", sr.isInExclusionZone());
 
-            // pass-through until ShotCalculator is wired on the SOTM branch
-            double confidence = 100;
+    // debounced values show what the composite actually uses after per-component smoothing
+    SafeLog.put("Scoring/Debounced/ShooterReady", sr.isDebouncedShooterReady());
+    SafeLog.put("Scoring/Debounced/IndexerClear", sr.isDebouncedIndexerClear());
+    SafeLog.put("Scoring/Debounced/VisionLocked", sr.isDebouncedVisionLocked());
+    SafeLog.put("Scoring/Debounced/ShotConfident", sr.isDebouncedShotConfident());
 
-            sr.setInputs(
-                    shooterTelemetry.isAtSpeed(),
-                    !indexerTelemetry.isJamDetected(),
-                    visionTelemetry.isLockedOnTarget(),
-                    true, // stub: assume ball present until hopper sensor is wired
-                    confidence);
+    SafeLog.put("Scoring/BallisticWindowRemainingSec", sr.getBallisticWindowRemainingSec());
+    SafeLog.put("Scoring/TimeSinceReadyMs", sr.getTimeSinceReadyMs());
+    SafeLog.put("Scoring/HubShiftNumber", sr.getHubShiftNumber());
+    SafeLog.put("Scoring/TimeToNextShiftSec", sr.getTimeToNextShiftSec());
+    SafeLog.put("Scoring/Conditions/WonAuto", sr.isWonAuto());
+    SafeLog.put("Scoring/Conditions/WonAutoFromFMS", sr.isWonAutoFromFMS());
 
-            // Stub: heading error = 0 until ShotCalculator has aim direction wired in
-            double headingError = 0;
-            boolean inExclusionZone = false;
-            try {
-                var pose = frc.robot.RobotContainer.getInstance().getSwerveSubsystem().getPose();
-                inExclusionZone =
-                        SpatialLaunchValidator.isInExclusionZone(pose.getX(), pose.getY());
-            } catch (Throwable t) {
-                // pose not available yet, fail-open
-            }
-            sr.setHeadingAndZone(headingError, inExclusionZone);
+    SafeLog.put("Scoring/ReadyStateChanged", sr.isReadyStateChanged());
+    SafeLog.put("Scoring/ReadyLostReason", sr.getReadyLostReason());
+  }
 
-            sr.update();
-        } catch (Throwable t) {
-            scoringAvailable = false;
-            ScoringReadiness.getInstance().reset();
-        }
-    }
+  @Override
+  public String getName() {
+    return "Scoring";
+  }
 
-    @Override
-    public void log() {
-        ScoringReadiness sr = ScoringReadiness.getInstance();
+  public boolean isReadyToShoot() {
+    return ScoringReadiness.getInstance().isReadyToShoot();
+  }
 
-        SafeLog.put("Scoring/Available", scoringAvailable);
-        SafeLog.put("Scoring/ReadyToShoot", sr.isReadyToShoot());
-        SafeLog.put("Scoring/Conditions/ShooterReady", sr.isShooterReady());
-        SafeLog.put("Scoring/Conditions/IndexerClear", sr.isIndexerClear());
-        SafeLog.put("Scoring/Conditions/VisionLocked", sr.isVisionLocked());
-        SafeLog.put("Scoring/Conditions/HasBall", sr.isHasBall());
-        SafeLog.put("Scoring/Conditions/HubActive", sr.isHubActive());
-        SafeLog.put("Scoring/Conditions/FireAuthorized", sr.isFireAuthorized());
-        SafeLog.put("Scoring/Conditions/ShotConfident", sr.isShotConfident());
-        SafeLog.put("Scoring/HeadingOnTarget", sr.isHeadingOnTarget());
-        SafeLog.put("Scoring/HeadingErrorDeg", sr.getHeadingErrorDeg());
-        SafeLog.put("Scoring/InExclusionZone", sr.isInExclusionZone());
+  public int getHubShiftNumber() {
+    return ScoringReadiness.getInstance().getHubShiftNumber();
+  }
 
-        // debounced values show what the composite actually uses after per-component smoothing
-        SafeLog.put("Scoring/Debounced/ShooterReady", sr.isDebouncedShooterReady());
-        SafeLog.put("Scoring/Debounced/IndexerClear", sr.isDebouncedIndexerClear());
-        SafeLog.put("Scoring/Debounced/VisionLocked", sr.isDebouncedVisionLocked());
-        SafeLog.put("Scoring/Debounced/ShotConfident", sr.isDebouncedShotConfident());
+  public boolean isHubActive() {
+    return ScoringReadiness.getInstance().isHubActive();
+  }
 
-        SafeLog.put("Scoring/BallisticWindowRemainingSec", sr.getBallisticWindowRemainingSec());
-        SafeLog.put("Scoring/TimeSinceReadyMs", sr.getTimeSinceReadyMs());
-        SafeLog.put("Scoring/HubShiftNumber", sr.getHubShiftNumber());
-        SafeLog.put("Scoring/TimeToNextShiftSec", sr.getTimeToNextShiftSec());
-        SafeLog.put("Scoring/Conditions/WonAuto", sr.isWonAuto());
-        SafeLog.put("Scoring/Conditions/WonAutoFromFMS", sr.isWonAutoFromFMS());
+  public boolean isFireAuthorized() {
+    return ScoringReadiness.getInstance().isFireAuthorized();
+  }
 
-        SafeLog.put("Scoring/ReadyStateChanged", sr.isReadyStateChanged());
-        SafeLog.put("Scoring/ReadyLostReason", sr.getReadyLostReason());
-    }
+  public double getTimeToNextShiftSec() {
+    return ScoringReadiness.getInstance().getTimeToNextShiftSec();
+  }
 
-    @Override
-    public String getName() {
-        return "Scoring";
-    }
+  public double getBallisticWindowRemainingSec() {
+    return ScoringReadiness.getInstance().getBallisticWindowRemainingSec();
+  }
 
-    public boolean isReadyToShoot() {
-        return ScoringReadiness.getInstance().isReadyToShoot();
-    }
+  public boolean isReadyStateChanged() {
+    return ScoringReadiness.getInstance().isReadyStateChanged();
+  }
 
-    public int getHubShiftNumber() {
-        return ScoringReadiness.getInstance().getHubShiftNumber();
-    }
+  public String getReadyLostReason() {
+    return ScoringReadiness.getInstance().getReadyLostReason();
+  }
 
-    public boolean isHubActive() {
-        return ScoringReadiness.getInstance().isHubActive();
-    }
+  public String getFireAuthLevel() {
+    return ScoringReadiness.getInstance().getFireAuthLevel();
+  }
 
-    public boolean isFireAuthorized() {
-        return ScoringReadiness.getInstance().isFireAuthorized();
-    }
-
-    public double getTimeToNextShiftSec() {
-        return ScoringReadiness.getInstance().getTimeToNextShiftSec();
-    }
-
-    public double getBallisticWindowRemainingSec() {
-        return ScoringReadiness.getInstance().getBallisticWindowRemainingSec();
-    }
-
-    public boolean isReadyStateChanged() {
-        return ScoringReadiness.getInstance().isReadyStateChanged();
-    }
-
-    public String getReadyLostReason() {
-        return ScoringReadiness.getInstance().getReadyLostReason();
-    }
-
-    public String getFireAuthLevel() {
-        return ScoringReadiness.getInstance().getFireAuthLevel();
-    }
-
-    public boolean isWonAuto() {
-        return ScoringReadiness.getInstance().isWonAuto();
-    }
+  public boolean isWonAuto() {
+    return ScoringReadiness.getInstance().isWonAuto();
+  }
 }

--- a/src/main/java/frc/robot/util/FireAuthorization.java
+++ b/src/main/java/frc/robot/util/FireAuthorization.java
@@ -6,142 +6,140 @@ import frc.robot.util.HubShiftEngine.ScheduleConfidence;
 import frc.robot.util.HubShiftEngine.ShiftInfo;
 
 /**
- * 5-level fire authorization based on whether a shot would land while the hub is counting.
- * Compares projectile landing time against the hub's scoring window each cycle.
+ * 5-level fire authorization based on whether a shot would land while the hub is counting. Compares
+ * projectile landing time against the hub's scoring window each cycle.
  */
 public class FireAuthorization {
-    private static FireAuthorization instance;
+  private static FireAuthorization instance;
 
-    public enum AuthorizationLevel {
-        FIRE_AUTHORIZED,
-        FIRE_MARGINAL,
-        PRE_SPIN,
-        HOLD_TIMING,
-        HOLD_INACTIVE
+  public enum AuthorizationLevel {
+    FIRE_AUTHORIZED,
+    FIRE_MARGINAL,
+    PRE_SPIN,
+    HOLD_TIMING,
+    HOLD_INACTIVE
+  }
+
+  private final TunableNumber safeMargin =
+      new TunableNumber("FireAuth/SafeMarginSec", HubTimingConstants.FIRE_SAFE_MARGIN_SEC);
+  private final TunableNumber preSpinWindow =
+      new TunableNumber("FireAuth/PreSpinWindowSec", HubTimingConstants.PRE_SPIN_WINDOW_SEC);
+  private final TunableNumber fallbackMarginExtra =
+      new TunableNumber(
+          "FireAuth/FallbackExtraMarginSec", HubTimingConstants.FALLBACK_MARGIN_EXTRA_SEC);
+
+  // fail-open default: a robot that won't fire is worse than one that fires at a bad time
+  private AuthorizationLevel level = AuthorizationLevel.FIRE_AUTHORIZED;
+  private double margin = 0;
+  private double ballLandingTime = 0;
+  private double windowRemaining = 0;
+  private boolean authorized = true;
+  private boolean spatiallyBlocked = false;
+
+  private FireAuthorization() {}
+
+  public static FireAuthorization getInstance() {
+    if (instance == null) {
+      instance = new FireAuthorization();
+    }
+    return instance;
+  }
+
+  /** Call every robotPeriodic() after HubShiftEngine.update(). */
+  public void update(
+      ShiftInfo shiftedInfo,
+      double currentTOF,
+      ScheduleConfidence confidence,
+      boolean hubTrackingEnabled) {
+
+    if (!hubTrackingEnabled) {
+      level = AuthorizationLevel.FIRE_AUTHORIZED;
+      margin = Double.MAX_VALUE;
+      ballLandingTime = 0;
+      windowRemaining = Double.MAX_VALUE;
+      authorized = true;
+      logTelemetry();
+      return;
     }
 
-    private final TunableNumber safeMargin =
-            new TunableNumber("FireAuth/SafeMarginSec", HubTimingConstants.FIRE_SAFE_MARGIN_SEC);
-    private final TunableNumber preSpinWindow =
-            new TunableNumber("FireAuth/PreSpinWindowSec", HubTimingConstants.PRE_SPIN_WINDOW_SEC);
-    private final TunableNumber fallbackMarginExtra =
-            new TunableNumber(
-                    "FireAuth/FallbackExtraMarginSec",
-                    HubTimingConstants.FALLBACK_MARGIN_EXTRA_SEC);
+    // Spatial exclusion (trench ceilings) is handled by the !inExclusionZone gate
+    // in ScoringReadiness. FireAuthorization focuses on timing only.
+    spatiallyBlocked = false;
 
-    // fail-open default: a robot that won't fire is worse than one that fires at a bad time
-    private AuthorizationLevel level = AuthorizationLevel.FIRE_AUTHORIZED;
-    private double margin = 0;
-    private double ballLandingTime = 0;
-    private double windowRemaining = 0;
-    private boolean authorized = true;
-    private boolean spatiallyBlocked = false;
+    HubShiftEngine engine = HubShiftEngine.getInstance();
+    double fuelDelay = (engine.getFuelCountDelayMin() + engine.getFuelCountDelayMax()) / 2.0;
+    double extension = engine.getFuelCountExtension();
 
-    private FireAuthorization() {}
+    ballLandingTime = currentTOF + fuelDelay;
 
-    public static FireAuthorization getInstance() {
-        if (instance == null) {
-            instance = new FireAuthorization();
-        }
-        return instance;
+    double effectiveSafeMargin = safeMargin.get();
+    if (confidence == ScheduleConfidence.FALLBACK) {
+      effectiveSafeMargin += fallbackMarginExtra.get();
     }
 
-    /** Call every robotPeriodic() after HubShiftEngine.update(). */
-    public void update(
-            ShiftInfo shiftedInfo,
-            double currentTOF,
-            ScheduleConfidence confidence,
-            boolean hubTrackingEnabled) {
+    if (shiftedInfo.hubActive()) {
+      windowRemaining = shiftedInfo.timeUntilDeactivation();
+      margin = windowRemaining - ballLandingTime;
 
-        if (!hubTrackingEnabled) {
-            level = AuthorizationLevel.FIRE_AUTHORIZED;
-            margin = Double.MAX_VALUE;
-            ballLandingTime = 0;
-            windowRemaining = Double.MAX_VALUE;
-            authorized = true;
-            logTelemetry();
-            return;
-        }
+      if (margin >= effectiveSafeMargin) {
+        level = AuthorizationLevel.FIRE_AUTHORIZED;
+      } else if (margin > -extension) {
+        level = AuthorizationLevel.FIRE_MARGINAL;
+      } else {
+        level = AuthorizationLevel.HOLD_TIMING;
+      }
+    } else {
+      windowRemaining = 0;
+      double timeToActive = shiftedInfo.timeToNextActive();
+      margin = -(timeToActive);
 
-        // Spatial exclusion (trench ceilings) is handled by the !inExclusionZone gate
-        // in ScoringReadiness. FireAuthorization focuses on timing only.
-        spatiallyBlocked = false;
-
-        HubShiftEngine engine = HubShiftEngine.getInstance();
-        double fuelDelay = (engine.getFuelCountDelayMin() + engine.getFuelCountDelayMax()) / 2.0;
-        double extension = engine.getFuelCountExtension();
-
-        ballLandingTime = currentTOF + fuelDelay;
-
-        double effectiveSafeMargin = safeMargin.get();
-        if (confidence == ScheduleConfidence.FALLBACK) {
-            effectiveSafeMargin += fallbackMarginExtra.get();
-        }
-
-        if (shiftedInfo.hubActive()) {
-            windowRemaining = shiftedInfo.timeUntilDeactivation();
-            margin = windowRemaining - ballLandingTime;
-
-            if (margin >= effectiveSafeMargin) {
-                level = AuthorizationLevel.FIRE_AUTHORIZED;
-            } else if (margin > -extension) {
-                level = AuthorizationLevel.FIRE_MARGINAL;
-            } else {
-                level = AuthorizationLevel.HOLD_TIMING;
-            }
-        } else {
-            windowRemaining = 0;
-            double timeToActive = shiftedInfo.timeToNextActive();
-            margin = -(timeToActive);
-
-            if (timeToActive > 0 && timeToActive <= preSpinWindow.get()) {
-                level = AuthorizationLevel.PRE_SPIN;
-            } else {
-                level = AuthorizationLevel.HOLD_INACTIVE;
-            }
-        }
-
-        authorized =
-                (level == AuthorizationLevel.FIRE_AUTHORIZED
-                        || level == AuthorizationLevel.FIRE_MARGINAL);
-
-        logTelemetry();
+      if (timeToActive > 0 && timeToActive <= preSpinWindow.get()) {
+        level = AuthorizationLevel.PRE_SPIN;
+      } else {
+        level = AuthorizationLevel.HOLD_INACTIVE;
+      }
     }
 
-    private void logTelemetry() {
-        SafeLog.put("Scoring/FireAuth/Level", level.name());
-        SafeLog.put("Scoring/FireAuth/Margin", margin);
-        SafeLog.put("Scoring/FireAuth/BallLandingTime", ballLandingTime);
-        SafeLog.put("Scoring/FireAuth/WindowRemaining", windowRemaining);
-        SafeLog.put("Scoring/FireAuth/Authorized", authorized);
-        SafeLog.put("Scoring/FireAuth/SpatiallyBlocked", spatiallyBlocked);
-    }
+    authorized =
+        (level == AuthorizationLevel.FIRE_AUTHORIZED || level == AuthorizationLevel.FIRE_MARGINAL);
 
-    public AuthorizationLevel getLevel() {
-        return level;
-    }
+    logTelemetry();
+  }
 
-    public double getMargin() {
-        return margin;
-    }
+  private void logTelemetry() {
+    SafeLog.put("Scoring/FireAuth/Level", level.name());
+    SafeLog.put("Scoring/FireAuth/Margin", margin);
+    SafeLog.put("Scoring/FireAuth/BallLandingTime", ballLandingTime);
+    SafeLog.put("Scoring/FireAuth/WindowRemaining", windowRemaining);
+    SafeLog.put("Scoring/FireAuth/Authorized", authorized);
+    SafeLog.put("Scoring/FireAuth/SpatiallyBlocked", spatiallyBlocked);
+  }
 
-    public double getBallLandingTime() {
-        return ballLandingTime;
-    }
+  public AuthorizationLevel getLevel() {
+    return level;
+  }
 
-    public double getWindowRemaining() {
-        return windowRemaining;
-    }
+  public double getMargin() {
+    return margin;
+  }
 
-    public boolean isAuthorized() {
-        return authorized;
-    }
+  public double getBallLandingTime() {
+    return ballLandingTime;
+  }
 
-    public boolean isPreSpin() {
-        return level == AuthorizationLevel.PRE_SPIN;
-    }
+  public double getWindowRemaining() {
+    return windowRemaining;
+  }
 
-    static void resetInstance() {
-        instance = null;
-    }
+  public boolean isAuthorized() {
+    return authorized;
+  }
+
+  public boolean isPreSpin() {
+    return level == AuthorizationLevel.PRE_SPIN;
+  }
+
+  static void resetInstance() {
+    instance = null;
+  }
 }

--- a/src/main/java/frc/robot/util/HubShiftEngine.java
+++ b/src/main/java/frc/robot/util/HubShiftEngine.java
@@ -3,371 +3,361 @@ package frc.robot.util;
 import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj.Timer;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
-
 import frc.robot.Constants.HubTimingConstants;
 import frc.robot.telemetry.SafeLog;
 
 /**
- * Hub shift timing with TOF-compensated boundaries. Tracks which alliance owns the hub
- * across 4 shifts + endgame, with auto-winner detection and copilot override.
+ * Hub shift timing with TOF-compensated boundaries. Tracks which alliance owns the hub across 4
+ * shifts + endgame, with auto-winner detection and copilot override.
  */
 public class HubShiftEngine {
-    private static HubShiftEngine instance;
+  private static HubShiftEngine instance;
 
-    public enum ShiftPhase {
-        DISABLED,
-        AUTO,
-        TRANSITION,
-        SHIFT1,
-        SHIFT2,
-        SHIFT3,
-        SHIFT4,
-        ENDGAME
+  public enum ShiftPhase {
+    DISABLED,
+    AUTO,
+    TRANSITION,
+    SHIFT1,
+    SHIFT2,
+    SHIFT3,
+    SHIFT4,
+    ENDGAME
+  }
+
+  public enum ScheduleConfidence {
+    HIGH,
+    LOW,
+    FALLBACK
+  }
+
+  public record ShiftInfo(
+      ShiftPhase phase,
+      boolean hubActive,
+      double elapsedInPhase,
+      double remainingInState,
+      double timeToNextActive,
+      double timeUntilDeactivation) {}
+
+  // shift boundaries: elapsed seconds from teleop start
+  private static final double[] PHASE_STARTS = {
+    0.0,
+    HubTimingConstants.TRANSITION_END,
+    HubTimingConstants.SHIFT1_END,
+    HubTimingConstants.SHIFT2_END,
+    HubTimingConstants.SHIFT3_END,
+    HubTimingConstants.SHIFT4_END
+  };
+  private static final double[] PHASE_ENDS = {
+    HubTimingConstants.TRANSITION_END,
+    HubTimingConstants.SHIFT1_END,
+    HubTimingConstants.SHIFT2_END,
+    HubTimingConstants.SHIFT3_END,
+    HubTimingConstants.SHIFT4_END,
+    HubTimingConstants.ENDGAME_END
+  };
+  private static final ShiftPhase[] PHASES = {
+    ShiftPhase.TRANSITION,
+    ShiftPhase.SHIFT1,
+    ShiftPhase.SHIFT2,
+    ShiftPhase.SHIFT3,
+    ShiftPhase.SHIFT4,
+    ShiftPhase.ENDGAME
+  };
+
+  // active schedule lookup: [transition, shift1, shift2, shift3, shift4, endgame]
+  // won auto = our hub was active first, so it goes inactive in shift1
+  private static final boolean[] WON_SCHEDULE = {true, false, true, false, true, true};
+  private static final boolean[] LOST_SCHEDULE = {true, true, false, true, false, true};
+
+  private final Timer teleopTimer = new Timer();
+  private boolean teleopStarted = false;
+
+  // auto-winner state
+  private boolean wonAuto = false;
+  private boolean wonAutoFromFMS = false;
+  private boolean wonAutoOverrideSet = false;
+  private boolean wonAutoOverrideValue = false;
+  private ScheduleConfidence confidence = ScheduleConfidence.FALLBACK;
+  private boolean scheduleLocked = false;
+
+  private final TunableNumber hubTrackingEnabled =
+      new TunableNumber("HubShift/TrackingEnabled", 1.0);
+  private final TunableNumber featureEnabled = new TunableNumber("HubShift/FireAuthEnabled", 1.0);
+
+  private final TunableNumber fuelCountDelayMin =
+      new TunableNumber("HubShift/FuelDelayMinSec", HubTimingConstants.FUEL_COUNT_DELAY_MIN_SEC);
+  private final TunableNumber fuelCountDelayMax =
+      new TunableNumber("HubShift/FuelDelayMaxSec", HubTimingConstants.FUEL_COUNT_DELAY_MAX_SEC);
+  private final TunableNumber fuelCountExtension =
+      new TunableNumber("HubShift/FuelExtensionSec", HubTimingConstants.FUEL_COUNT_EXTENSION_SEC);
+
+  private ShiftInfo officialInfo;
+  private ShiftInfo shiftedInfo;
+  private double currentTOF = 0;
+  private boolean gameDataMissing = false;
+
+  private HubShiftEngine() {
+    officialInfo = new ShiftInfo(ShiftPhase.DISABLED, true, 0, 0, 0, 0);
+    shiftedInfo = officialInfo;
+  }
+
+  public static HubShiftEngine getInstance() {
+    if (instance == null) {
+      instance = new HubShiftEngine();
+    }
+    return instance;
+  }
+
+  /** Call from Robot.teleopInit(). */
+  public void initializeTeleop() {
+    teleopTimer.restart();
+    teleopStarted = true;
+    scheduleLocked = false;
+    parseAutoWinner();
+  }
+
+  /** Call every robotPeriodic(). Pass current TOF from ShotCalculator (0 if not available). */
+  public void update(double shotTOF) {
+    currentTOF = Math.max(0, shotTOF);
+
+    if (!teleopStarted || !DriverStation.isTeleop()) {
+      officialInfo =
+          new ShiftInfo(
+              DriverStation.isAutonomous() ? ShiftPhase.AUTO : ShiftPhase.DISABLED,
+              true,
+              0,
+              0,
+              0,
+              Double.MAX_VALUE);
+      shiftedInfo = officialInfo;
+      gameDataMissing = false;
+      return;
     }
 
-    public enum ScheduleConfidence {
-        HIGH,
-        LOW,
-        FALLBACK
+    if (!scheduleLocked) {
+      parseAutoWinner();
     }
 
-    public record ShiftInfo(
-            ShiftPhase phase,
-            boolean hubActive,
-            double elapsedInPhase,
-            double remainingInState,
-            double timeToNextActive,
-            double timeUntilDeactivation) {}
+    double elapsed = teleopTimer.get();
+    boolean[] schedule = wonAuto ? WON_SCHEDULE : LOST_SCHEDULE;
 
-    // shift boundaries: elapsed seconds from teleop start
-    private static final double[] PHASE_STARTS = {
-        0.0,
-        HubTimingConstants.TRANSITION_END,
-        HubTimingConstants.SHIFT1_END,
-        HubTimingConstants.SHIFT2_END,
-        HubTimingConstants.SHIFT3_END,
-        HubTimingConstants.SHIFT4_END
-    };
-    private static final double[] PHASE_ENDS = {
-        HubTimingConstants.TRANSITION_END,
-        HubTimingConstants.SHIFT1_END,
-        HubTimingConstants.SHIFT2_END,
-        HubTimingConstants.SHIFT3_END,
-        HubTimingConstants.SHIFT4_END,
-        HubTimingConstants.ENDGAME_END
-    };
-    private static final ShiftPhase[] PHASES = {
-        ShiftPhase.TRANSITION,
-        ShiftPhase.SHIFT1,
-        ShiftPhase.SHIFT2,
-        ShiftPhase.SHIFT3,
-        ShiftPhase.SHIFT4,
-        ShiftPhase.ENDGAME
-    };
+    officialInfo = computeShiftInfo(schedule, PHASE_STARTS, PHASE_ENDS, elapsed);
 
-    // active schedule lookup: [transition, shift1, shift2, shift3, shift4, endgame]
-    // won auto = our hub was active first, so it goes inactive in shift1
-    private static final boolean[] WON_SCHEDULE = {true, false, true, false, true, true};
-    private static final boolean[] LOST_SCHEDULE = {true, true, false, true, false, true};
-
-    private final Timer teleopTimer = new Timer();
-    private boolean teleopStarted = false;
-
-    // auto-winner state
-    private boolean wonAuto = false;
-    private boolean wonAutoFromFMS = false;
-    private boolean wonAutoOverrideSet = false;
-    private boolean wonAutoOverrideValue = false;
-    private ScheduleConfidence confidence = ScheduleConfidence.FALLBACK;
-    private boolean scheduleLocked = false;
-
-    private final TunableNumber hubTrackingEnabled =
-            new TunableNumber("HubShift/TrackingEnabled", 1.0);
-    private final TunableNumber featureEnabled = new TunableNumber("HubShift/FireAuthEnabled", 1.0);
-
-    private final TunableNumber fuelCountDelayMin =
-            new TunableNumber(
-                    "HubShift/FuelDelayMinSec", HubTimingConstants.FUEL_COUNT_DELAY_MIN_SEC);
-    private final TunableNumber fuelCountDelayMax =
-            new TunableNumber(
-                    "HubShift/FuelDelayMaxSec", HubTimingConstants.FUEL_COUNT_DELAY_MAX_SEC);
-    private final TunableNumber fuelCountExtension =
-            new TunableNumber(
-                    "HubShift/FuelExtensionSec", HubTimingConstants.FUEL_COUNT_EXTENSION_SEC);
-
-    private ShiftInfo officialInfo;
-    private ShiftInfo shiftedInfo;
-    private double currentTOF = 0;
-    private boolean gameDataMissing = false;
-
-    private HubShiftEngine() {
-        officialInfo = new ShiftInfo(ShiftPhase.DISABLED, true, 0, 0, 0, 0);
-        shiftedInfo = officialInfo;
+    if (isFeatureEnabled() && currentTOF > 0) {
+      double approachingOffset = -(currentTOF + fuelCountDelayMin.get());
+      double endingOffset = fuelCountExtension.get() - (currentTOF + fuelCountDelayMax.get());
+      double[] shiftedStarts =
+          computeShiftedBoundaries(PHASE_STARTS, schedule, approachingOffset, endingOffset);
+      double[] shiftedEnds =
+          computeShiftedBoundaries(PHASE_ENDS, schedule, approachingOffset, endingOffset);
+      shiftedInfo = computeShiftInfo(schedule, shiftedStarts, shiftedEnds, elapsed);
+    } else {
+      shiftedInfo = officialInfo;
     }
 
-    public static HubShiftEngine getInstance() {
-        if (instance == null) {
-            instance = new HubShiftEngine();
-        }
-        return instance;
+    gameDataMissing =
+        DriverStation.isFMSAttached()
+            && !wonAutoFromFMS
+            && !wonAutoOverrideSet
+            && elapsed < HubTimingConstants.TRANSITION_END;
+
+    logTelemetry();
+  }
+
+  private void parseAutoWinner() {
+    if (wonAutoOverrideSet) {
+      wonAuto = wonAutoOverrideValue;
+      wonAutoFromFMS = false;
+      confidence = ScheduleConfidence.LOW;
+      scheduleLocked = true;
+      return;
     }
 
-    /** Call from Robot.teleopInit(). */
-    public void initializeTeleop() {
-        teleopTimer.restart();
-        teleopStarted = true;
-        scheduleLocked = false;
-        parseAutoWinner();
-    }
-
-    /** Call every robotPeriodic(). Pass current TOF from ShotCalculator (0 if not available). */
-    public void update(double shotTOF) {
-        currentTOF = Math.max(0, shotTOF);
-
-        if (!teleopStarted || !DriverStation.isTeleop()) {
-            officialInfo =
-                    new ShiftInfo(
-                            DriverStation.isAutonomous() ? ShiftPhase.AUTO : ShiftPhase.DISABLED,
-                            true,
-                            0,
-                            0,
-                            0,
-                            Double.MAX_VALUE);
-            shiftedInfo = officialInfo;
-            gameDataMissing = false;
-            return;
-        }
-
-        if (!scheduleLocked) {
-            parseAutoWinner();
-        }
-
-        double elapsed = teleopTimer.get();
-        boolean[] schedule = wonAuto ? WON_SCHEDULE : LOST_SCHEDULE;
-
-        officialInfo = computeShiftInfo(schedule, PHASE_STARTS, PHASE_ENDS, elapsed);
-
-        if (isFeatureEnabled() && currentTOF > 0) {
-            double approachingOffset = -(currentTOF + fuelCountDelayMin.get());
-            double endingOffset = fuelCountExtension.get() - (currentTOF + fuelCountDelayMax.get());
-            double[] shiftedStarts =
-                    computeShiftedBoundaries(
-                            PHASE_STARTS, schedule, approachingOffset, endingOffset);
-            double[] shiftedEnds =
-                    computeShiftedBoundaries(PHASE_ENDS, schedule, approachingOffset, endingOffset);
-            shiftedInfo = computeShiftInfo(schedule, shiftedStarts, shiftedEnds, elapsed);
-        } else {
-            shiftedInfo = officialInfo;
-        }
-
-        gameDataMissing =
-                DriverStation.isFMSAttached()
-                        && !wonAutoFromFMS
-                        && !wonAutoOverrideSet
-                        && elapsed < HubTimingConstants.TRANSITION_END;
-
-        logTelemetry();
-    }
-
-    private void parseAutoWinner() {
-        if (wonAutoOverrideSet) {
-            wonAuto = wonAutoOverrideValue;
-            wonAutoFromFMS = false;
-            confidence = ScheduleConfidence.LOW;
-            scheduleLocked = true;
-            return;
-        }
-
-        String message = DriverStation.getGameSpecificMessage();
-        if (message != null && !message.isEmpty()) {
-            char winner = message.charAt(0);
-            var ourAlliance = DriverStation.getAlliance();
-            if (ourAlliance.isPresent()) {
-                boolean redWon = (winner == 'R');
-                boolean weAreRed = (ourAlliance.get() == DriverStation.Alliance.Red);
-                wonAuto = (redWon == weAreRed);
-                wonAutoFromFMS = true;
-                confidence = ScheduleConfidence.HIGH;
-                scheduleLocked = true;
-                return;
-            }
-        }
-
-        if (!DriverStation.isFMSAttached()) {
-            wonAuto = SmartDashboard.getBoolean("WonAuto", false);
-            wonAutoFromFMS = false;
-            confidence = ScheduleConfidence.LOW;
-            return;
-        }
-
-        wonAuto = false;
-        wonAutoFromFMS = false;
-        confidence = ScheduleConfidence.FALLBACK;
-    }
-
-    private ShiftInfo computeShiftInfo(
-            boolean[] schedule, double[] starts, double[] ends, double elapsed) {
-        int phaseIndex = -1;
-        for (int i = 0; i < starts.length; i++) {
-            if (elapsed >= starts[i] && elapsed < ends[i]) {
-                phaseIndex = i;
-                break;
-            }
-        }
-        if (phaseIndex < 0) {
-            phaseIndex = starts.length - 1;
-        }
-
-        ShiftPhase phase = PHASES[phaseIndex];
-        boolean hubActive = isHubTrackingEnabled() ? schedule[phaseIndex] : true;
-        double elapsedInPhase = elapsed - starts[phaseIndex];
-        double remainingInPhase = ends[phaseIndex] - elapsed;
-
-        // merge consecutive same-state windows for remaining time
-        double remainingInState = remainingInPhase;
-        if (phaseIndex < ends.length - 1 && schedule[phaseIndex] == schedule[phaseIndex + 1]) {
-            remainingInState = ends[phaseIndex + 1] - elapsed;
-        }
-
-        double timeToNextActive = 0;
-        if (!hubActive) {
-            for (int i = phaseIndex + 1; i < schedule.length; i++) {
-                if (schedule[i]) {
-                    timeToNextActive = starts[i] - elapsed;
-                    break;
-                }
-            }
-        }
-
-        double timeUntilDeactivation = Double.MAX_VALUE;
-        if (hubActive) {
-            for (int i = phaseIndex; i < schedule.length; i++) {
-                if (!schedule[i] || i == schedule.length - 1) {
-                    timeUntilDeactivation =
-                            (i < schedule.length && !schedule[i])
-                                    ? starts[i] - elapsed
-                                    : ends[i] - elapsed;
-                    break;
-                }
-            }
-        }
-
-        return new ShiftInfo(
-                phase,
-                hubActive,
-                elapsedInPhase,
-                remainingInState,
-                timeToNextActive,
-                timeUntilDeactivation);
-    }
-
-    /**
-     * Shifts boundaries based on whether the transition is into or out of an active window. At
-     * inactive->active transitions the boundary shifts earlier so the robot fires before the
-     * official start. At active->inactive transitions the boundary shifts by the ending offset.
-     */
-    private double[] computeShiftedBoundaries(
-            double[] boundaries,
-            boolean[] schedule,
-            double approachingOffset,
-            double endingOffset) {
-        double[] shifted = new double[boundaries.length];
-        shifted[0] = boundaries[0];
-
-        for (int i = 1; i < boundaries.length; i++) {
-            boolean prevActive = schedule[Math.min(i - 1, schedule.length - 1)];
-            boolean nextActive = schedule[Math.min(i, schedule.length - 1)];
-
-            if (!prevActive && nextActive) {
-                shifted[i] = boundaries[i] + approachingOffset;
-            } else if (prevActive && !nextActive) {
-                shifted[i] = boundaries[i] + endingOffset;
-            } else {
-                shifted[i] = boundaries[i];
-            }
-        }
-        return shifted;
-    }
-
-    private void logTelemetry() {
-        SafeLog.put("Scoring/HubShift/Phase", officialInfo.phase().name());
-        SafeLog.put("Scoring/HubShift/OfficialActive", officialInfo.hubActive());
-        SafeLog.put("Scoring/HubShift/ShiftedActive", shiftedInfo.hubActive());
-        SafeLog.put("Scoring/HubShift/ElapsedInPhase", officialInfo.elapsedInPhase());
-        SafeLog.put("Scoring/HubShift/RemainingInState", officialInfo.remainingInState());
-        SafeLog.put("Scoring/HubShift/TimeToNextActive", officialInfo.timeToNextActive());
-        SafeLog.put("Scoring/HubShift/TimeUntilDeactivation", officialInfo.timeUntilDeactivation());
-        SafeLog.put("Scoring/HubShift/WonAuto", wonAuto);
-        SafeLog.put("Scoring/HubShift/WonAutoFromFMS", wonAutoFromFMS);
-        SafeLog.put("Scoring/HubShift/ScheduleConfidence", confidence.name());
-        SafeLog.put("Scoring/HubShift/GameDataMissing", gameDataMissing);
-        SafeLog.put("Scoring/HubShift/TrackingEnabled", isHubTrackingEnabled());
-        SafeLog.put("Scoring/HubShift/CurrentTOF", currentTOF);
-    }
-
-    public ShiftInfo getOfficialInfo() {
-        return officialInfo;
-    }
-
-    public ShiftInfo getShiftedInfo() {
-        return shiftedInfo;
-    }
-
-    public ScheduleConfidence getConfidence() {
-        return confidence;
-    }
-
-    public boolean isGameDataMissing() {
-        return gameDataMissing;
-    }
-
-    public boolean isHubTrackingEnabled() {
-        return hubTrackingEnabled.get() >= 0.5;
-    }
-
-    public boolean isFeatureEnabled() {
-        return featureEnabled.get() >= 0.5;
-    }
-
-    public boolean isWonAuto() {
-        return wonAuto;
-    }
-
-    public boolean isWonAutoFromFMS() {
-        return wonAutoFromFMS;
-    }
-
-    /** Copilot sets this via dashboard or button press to override auto-winner detection. */
-    public void setWonAutoOverride(boolean won) {
-        wonAutoOverrideSet = true;
-        wonAutoOverrideValue = won;
-        wonAuto = won;
-        confidence = ScheduleConfidence.LOW;
+    String message = DriverStation.getGameSpecificMessage();
+    if (message != null && !message.isEmpty()) {
+      char winner = message.charAt(0);
+      var ourAlliance = DriverStation.getAlliance();
+      if (ourAlliance.isPresent()) {
+        boolean redWon = (winner == 'R');
+        boolean weAreRed = (ourAlliance.get() == DriverStation.Alliance.Red);
+        wonAuto = (redWon == weAreRed);
+        wonAutoFromFMS = true;
+        confidence = ScheduleConfidence.HIGH;
         scheduleLocked = true;
+        return;
+      }
     }
 
-    public void clearWonAutoOverride() {
-        wonAutoOverrideSet = false;
-        scheduleLocked = false;
+    if (!DriverStation.isFMSAttached()) {
+      wonAuto = SmartDashboard.getBoolean("WonAuto", false);
+      wonAutoFromFMS = false;
+      confidence = ScheduleConfidence.LOW;
+      return;
     }
 
-    public double getTeleopElapsed() {
-        return teleopStarted ? teleopTimer.get() : 0;
+    wonAuto = false;
+    wonAutoFromFMS = false;
+    confidence = ScheduleConfidence.FALLBACK;
+  }
+
+  private ShiftInfo computeShiftInfo(
+      boolean[] schedule, double[] starts, double[] ends, double elapsed) {
+    int phaseIndex = -1;
+    for (int i = 0; i < starts.length; i++) {
+      if (elapsed >= starts[i] && elapsed < ends[i]) {
+        phaseIndex = i;
+        break;
+      }
+    }
+    if (phaseIndex < 0) {
+      phaseIndex = starts.length - 1;
     }
 
-    public double getFuelCountDelayMin() {
-        return fuelCountDelayMin.get();
+    ShiftPhase phase = PHASES[phaseIndex];
+    boolean hubActive = isHubTrackingEnabled() ? schedule[phaseIndex] : true;
+    double elapsedInPhase = elapsed - starts[phaseIndex];
+    double remainingInPhase = ends[phaseIndex] - elapsed;
+
+    // merge consecutive same-state windows for remaining time
+    double remainingInState = remainingInPhase;
+    if (phaseIndex < ends.length - 1 && schedule[phaseIndex] == schedule[phaseIndex + 1]) {
+      remainingInState = ends[phaseIndex + 1] - elapsed;
     }
 
-    public double getFuelCountDelayMax() {
-        return fuelCountDelayMax.get();
+    double timeToNextActive = 0;
+    if (!hubActive) {
+      for (int i = phaseIndex + 1; i < schedule.length; i++) {
+        if (schedule[i]) {
+          timeToNextActive = starts[i] - elapsed;
+          break;
+        }
+      }
     }
 
-    public double getFuelCountExtension() {
-        return fuelCountExtension.get();
+    double timeUntilDeactivation = Double.MAX_VALUE;
+    if (hubActive) {
+      for (int i = phaseIndex; i < schedule.length; i++) {
+        if (!schedule[i] || i == schedule.length - 1) {
+          timeUntilDeactivation =
+              (i < schedule.length && !schedule[i]) ? starts[i] - elapsed : ends[i] - elapsed;
+          break;
+        }
+      }
     }
 
-    static void resetInstance() {
-        instance = null;
+    return new ShiftInfo(
+        phase,
+        hubActive,
+        elapsedInPhase,
+        remainingInState,
+        timeToNextActive,
+        timeUntilDeactivation);
+  }
+
+  /**
+   * Shifts boundaries based on whether the transition is into or out of an active window. At
+   * inactive->active transitions the boundary shifts earlier so the robot fires before the official
+   * start. At active->inactive transitions the boundary shifts by the ending offset.
+   */
+  private double[] computeShiftedBoundaries(
+      double[] boundaries, boolean[] schedule, double approachingOffset, double endingOffset) {
+    double[] shifted = new double[boundaries.length];
+    shifted[0] = boundaries[0];
+
+    for (int i = 1; i < boundaries.length; i++) {
+      boolean prevActive = schedule[Math.min(i - 1, schedule.length - 1)];
+      boolean nextActive = schedule[Math.min(i, schedule.length - 1)];
+
+      if (!prevActive && nextActive) {
+        shifted[i] = boundaries[i] + approachingOffset;
+      } else if (prevActive && !nextActive) {
+        shifted[i] = boundaries[i] + endingOffset;
+      } else {
+        shifted[i] = boundaries[i];
+      }
     }
+    return shifted;
+  }
+
+  private void logTelemetry() {
+    SafeLog.put("Scoring/HubShift/Phase", officialInfo.phase().name());
+    SafeLog.put("Scoring/HubShift/OfficialActive", officialInfo.hubActive());
+    SafeLog.put("Scoring/HubShift/ShiftedActive", shiftedInfo.hubActive());
+    SafeLog.put("Scoring/HubShift/ElapsedInPhase", officialInfo.elapsedInPhase());
+    SafeLog.put("Scoring/HubShift/RemainingInState", officialInfo.remainingInState());
+    SafeLog.put("Scoring/HubShift/TimeToNextActive", officialInfo.timeToNextActive());
+    SafeLog.put("Scoring/HubShift/TimeUntilDeactivation", officialInfo.timeUntilDeactivation());
+    SafeLog.put("Scoring/HubShift/WonAuto", wonAuto);
+    SafeLog.put("Scoring/HubShift/WonAutoFromFMS", wonAutoFromFMS);
+    SafeLog.put("Scoring/HubShift/ScheduleConfidence", confidence.name());
+    SafeLog.put("Scoring/HubShift/GameDataMissing", gameDataMissing);
+    SafeLog.put("Scoring/HubShift/TrackingEnabled", isHubTrackingEnabled());
+    SafeLog.put("Scoring/HubShift/CurrentTOF", currentTOF);
+  }
+
+  public ShiftInfo getOfficialInfo() {
+    return officialInfo;
+  }
+
+  public ShiftInfo getShiftedInfo() {
+    return shiftedInfo;
+  }
+
+  public ScheduleConfidence getConfidence() {
+    return confidence;
+  }
+
+  public boolean isGameDataMissing() {
+    return gameDataMissing;
+  }
+
+  public boolean isHubTrackingEnabled() {
+    return hubTrackingEnabled.get() >= 0.5;
+  }
+
+  public boolean isFeatureEnabled() {
+    return featureEnabled.get() >= 0.5;
+  }
+
+  public boolean isWonAuto() {
+    return wonAuto;
+  }
+
+  public boolean isWonAutoFromFMS() {
+    return wonAutoFromFMS;
+  }
+
+  /** Copilot sets this via dashboard or button press to override auto-winner detection. */
+  public void setWonAutoOverride(boolean won) {
+    wonAutoOverrideSet = true;
+    wonAutoOverrideValue = won;
+    wonAuto = won;
+    confidence = ScheduleConfidence.LOW;
+    scheduleLocked = true;
+  }
+
+  public void clearWonAutoOverride() {
+    wonAutoOverrideSet = false;
+    scheduleLocked = false;
+  }
+
+  public double getTeleopElapsed() {
+    return teleopStarted ? teleopTimer.get() : 0;
+  }
+
+  public double getFuelCountDelayMin() {
+    return fuelCountDelayMin.get();
+  }
+
+  public double getFuelCountDelayMax() {
+    return fuelCountDelayMax.get();
+  }
+
+  public double getFuelCountExtension() {
+    return fuelCountExtension.get();
+  }
+
+  static void resetInstance() {
+    instance = null;
+  }
 }

--- a/src/main/java/frc/robot/util/ScoringReadiness.java
+++ b/src/main/java/frc/robot/util/ScoringReadiness.java
@@ -1,408 +1,407 @@
 package frc.robot.util;
 
 import edu.wpi.first.wpilibj.Timer;
-
 import frc.robot.Constants.DeviceHealthConstants;
 import frc.robot.Constants.SpatialLaunchConstants;
 
 /**
  * 8-condition ReadyToShoot composite with per-component debounce and heading hysteresis.
  *
- * <p>Each flickery condition gets its own falling-edge debounce so a brief dip on one doesn't
- * reset the hold window for another. hasBall and fireAuthorized respond instantly because you
- * never want to fire without a ball or authorization.
+ * <p>Each flickery condition gets its own falling-edge debounce so a brief dip on one doesn't reset
+ * the hold window for another. hasBall and fireAuthorized respond instantly because you never want
+ * to fire without a ball or authorization.
  */
 public class ScoringReadiness {
-    private static ScoringReadiness instance;
+  private static ScoringReadiness instance;
 
-    private static final TunableNumber headingToleranceDeg =
-            new TunableNumber(
-                    "Scoring/HeadingToleranceDeg", SpatialLaunchConstants.HEADING_TOLERANCE_DEG);
+  private static final TunableNumber headingToleranceDeg =
+      new TunableNumber(
+          "Scoring/HeadingToleranceDeg", SpatialLaunchConstants.HEADING_TOLERANCE_DEG);
 
-    // once heading reaches tolerance, require 4x the error before declaring off-target.
-    // prevents the "almost ready, not ready, almost ready" flicker during SOTM when
-    // heading oscillates near the tolerance edge.
-    private static final double HEADING_HYSTERESIS_FACTOR = 4.0;
+  // once heading reaches tolerance, require 4x the error before declaring off-target.
+  // prevents the "almost ready, not ready, almost ready" flicker during SOTM when
+  // heading oscillates near the tolerance edge.
+  private static final double HEADING_HYSTERESIS_FACTOR = 4.0;
 
-    private boolean shooterReady = false;
-    private boolean indexerClear = true;
-    private boolean visionLocked = false;
-    private boolean hasBall = true;
-    private double shotConfidence = 0;
-    private double headingErrorDeg = 0;
-    private boolean headingOnTarget = false;
-    private boolean stickyHeadingOnTarget = false;
-    private boolean inExclusionZone = false;
+  private boolean shooterReady = false;
+  private boolean indexerClear = true;
+  private boolean visionLocked = false;
+  private boolean hasBall = true;
+  private double shotConfidence = 0;
+  private double headingErrorDeg = 0;
+  private boolean headingOnTarget = false;
+  private boolean stickyHeadingOnTarget = false;
+  private boolean inExclusionZone = false;
 
-    private final FallingDebounce shooterDebounce =
-            new FallingDebounce(DeviceHealthConstants.SHOOTER_READY_DEBOUNCE_SEC);
-    private final FallingDebounce indexerDebounce =
-            new FallingDebounce(DeviceHealthConstants.INDEXER_CLEAR_DEBOUNCE_SEC);
-    private final FallingDebounce visionDebounce =
-            new FallingDebounce(DeviceHealthConstants.VISION_LOCKED_DEBOUNCE_SEC);
-    private final FallingDebounce confidenceDebounce =
-            new FallingDebounce(DeviceHealthConstants.SHOT_CONFIDENT_DEBOUNCE_SEC);
+  private final FallingDebounce shooterDebounce =
+      new FallingDebounce(DeviceHealthConstants.SHOOTER_READY_DEBOUNCE_SEC);
+  private final FallingDebounce indexerDebounce =
+      new FallingDebounce(DeviceHealthConstants.INDEXER_CLEAR_DEBOUNCE_SEC);
+  private final FallingDebounce visionDebounce =
+      new FallingDebounce(DeviceHealthConstants.VISION_LOCKED_DEBOUNCE_SEC);
+  private final FallingDebounce confidenceDebounce =
+      new FallingDebounce(DeviceHealthConstants.SHOT_CONFIDENT_DEBOUNCE_SEC);
 
-    private boolean debouncedShooterReady = false;
-    private boolean debouncedIndexerClear = false;
-    private boolean debouncedVisionLocked = false;
-    private boolean debouncedShotConfident = false;
+  private boolean debouncedShooterReady = false;
+  private boolean debouncedIndexerClear = false;
+  private boolean debouncedVisionLocked = false;
+  private boolean debouncedShotConfident = false;
 
-    private boolean hubActive = true;
-    private boolean readyToShoot = false;
-    private int hubShiftNumber = 0;
-    private double timeToNextShiftSec = 0;
-    private boolean wonAuto = false;
-    private boolean wonAutoFromFMS = false;
+  private boolean hubActive = true;
+  private boolean readyToShoot = false;
+  private int hubShiftNumber = 0;
+  private double timeToNextShiftSec = 0;
+  private boolean wonAuto = false;
+  private boolean wonAutoFromFMS = false;
 
-    private boolean previousReadyToShoot = false;
-    private boolean readyStateChanged = false;
-    private String readyLostReason = "";
+  private boolean previousReadyToShoot = false;
+  private boolean readyStateChanged = false;
+  private String readyLostReason = "";
 
-    private double readySinceTimestamp = 0;
-    private double timeSinceReadyMs = 0;
-    private boolean wasReady = false;
+  private double readySinceTimestamp = 0;
+  private double timeSinceReadyMs = 0;
+  private boolean wasReady = false;
 
-    public static ScoringReadiness getInstance() {
-        if (instance == null) {
-            instance = new ScoringReadiness();
-        }
-        return instance;
+  public static ScoringReadiness getInstance() {
+    if (instance == null) {
+      instance = new ScoringReadiness();
     }
+    return instance;
+  }
 
-    private ScoringReadiness() {}
+  private ScoringReadiness() {}
 
-    /** Set raw inputs. Call from ScoringTelemetry.update() before update(). */
-    public void setInputs(
-            boolean shooterReady,
-            boolean indexerClear,
-            boolean visionLocked,
-            boolean hasBall,
-            double shotConfidence) {
-        this.shooterReady = shooterReady;
-        this.indexerClear = indexerClear;
-        this.visionLocked = visionLocked;
-        this.hasBall = hasBall;
-        this.shotConfidence = shotConfidence;
-    }
+  /** Set raw inputs. Call from ScoringTelemetry.update() before update(). */
+  public void setInputs(
+      boolean shooterReady,
+      boolean indexerClear,
+      boolean visionLocked,
+      boolean hasBall,
+      double shotConfidence) {
+    this.shooterReady = shooterReady;
+    this.indexerClear = indexerClear;
+    this.visionLocked = visionLocked;
+    this.hasBall = hasBall;
+    this.shotConfidence = shotConfidence;
+  }
 
-    /** Set heading error and exclusion zone. Call after setInputs(). */
-    public void setHeadingAndZone(double headingErrorDeg, boolean inExclusionZone) {
-        this.headingErrorDeg = headingErrorDeg;
-        this.inExclusionZone = inExclusionZone;
+  /** Set heading error and exclusion zone. Call after setInputs(). */
+  public void setHeadingAndZone(double headingErrorDeg, boolean inExclusionZone) {
+    this.headingErrorDeg = headingErrorDeg;
+    this.inExclusionZone = inExclusionZone;
 
-        double tol = headingToleranceDeg.get();
-        double absError = Math.abs(headingErrorDeg);
+    double tol = headingToleranceDeg.get();
+    double absError = Math.abs(headingErrorDeg);
 
-        // hysteretic heading gate: tight band to enter "on target", wider band to exit
-        if (!stickyHeadingOnTarget) {
-            headingOnTarget = absError < tol;
-            if (headingOnTarget) {
-                stickyHeadingOnTarget = true;
-            }
-        } else {
-            if (absError >= tol * HEADING_HYSTERESIS_FACTOR) {
-                stickyHeadingOnTarget = false;
-                headingOnTarget = false;
-            } else {
-                headingOnTarget = true;
-            }
-        }
-    }
-
-    /** Call once per robotPeriodic(). */
-    public void update() {
-        double now = Timer.getFPGATimestamp();
-
-        previousReadyToShoot = readyToShoot;
-
-        try {
-            HubShiftEngine engine = HubShiftEngine.getInstance();
-            HubShiftEngine.ShiftInfo info = engine.getOfficialInfo();
-            hubActive = info.hubActive();
-            wonAuto = engine.isWonAuto();
-            wonAutoFromFMS = engine.isWonAutoFromFMS();
-
-            // Map engine phase to shift number for per-shift stats.
-            // -1 for non-shift phases so MatchStatsTelemetry doesn't miscount them as endgame.
-            hubShiftNumber =
-                    switch (info.phase()) {
-                        case SHIFT1 -> 1;
-                        case SHIFT2 -> 2;
-                        case SHIFT3 -> 3;
-                        case SHIFT4 -> 4;
-                        case ENDGAME -> 0;
-                        default -> -1;
-                    };
-
-            if (!hubActive) {
-                timeToNextShiftSec = info.timeToNextActive();
-            } else {
-                timeToNextShiftSec = info.timeUntilDeactivation();
-            }
-        } catch (Throwable t) {
-            // HubShiftEngine not ready, safe defaults
-            hubActive = true;
-            hubShiftNumber = 0;
-            timeToNextShiftSec = 0;
-        }
-
-        debouncedShooterReady = shooterDebounce.calculate(shooterReady);
-        debouncedIndexerClear = indexerDebounce.calculate(indexerClear);
-        debouncedVisionLocked = visionDebounce.calculate(visionLocked);
-        debouncedShotConfident = confidenceDebounce.calculate(shotConfidence >= 50);
-
-        // fireAuthorized covers hubActive with TOF-compensated timing
-        readyToShoot =
-                debouncedShooterReady
-                        && debouncedIndexerClear
-                        && debouncedVisionLocked
-                        && hasBall
-                        && isFireAuthorized()
-                        && debouncedShotConfident
-                        && headingOnTarget
-                        && !inExclusionZone;
-
-        readyStateChanged = (readyToShoot != previousReadyToShoot);
-        if (readyStateChanged && !readyToShoot) {
-            readyLostReason = buildNotReadyReason();
-        } else if (readyStateChanged && readyToShoot) {
-            readyLostReason = "";
-        }
-
-        if (readyToShoot && !wasReady) {
-            readySinceTimestamp = now;
-        }
-        timeSinceReadyMs = readyToShoot ? (now - readySinceTimestamp) * 1000.0 : 0;
-        wasReady = readyToShoot;
-    }
-
-    private String buildNotReadyReason() {
-        StringBuilder sb = new StringBuilder();
-        if (!debouncedShooterReady) sb.append("Shooter");
-        if (!debouncedIndexerClear) {
-            if (sb.length() > 0) sb.append("+");
-            sb.append("Indexer");
-        }
-        if (!debouncedVisionLocked) {
-            if (sb.length() > 0) sb.append("+");
-            sb.append("Vision");
-        }
-        if (!isFireAuthorized()) {
-            if (sb.length() > 0) sb.append("+");
-            sb.append("FireAuth");
-        }
-        if (!hasBall) {
-            if (sb.length() > 0) sb.append("+");
-            sb.append("NoBall");
-        }
-        if (!debouncedShotConfident) {
-            if (sb.length() > 0) sb.append("+");
-            sb.append("Confidence");
-        }
-        if (!headingOnTarget) {
-            if (sb.length() > 0) sb.append("+");
-            sb.append("Heading");
-        }
-        if (inExclusionZone) {
-            if (sb.length() > 0) sb.append("+");
-            sb.append("ExclusionZone");
-        }
-        return sb.length() > 0 ? sb.toString() : "Unknown";
-    }
-
-    public boolean isReadyToShoot() {
-        return readyToShoot;
-    }
-
-    public boolean isHubActive() {
-        return hubActive;
-    }
-
-    public int getHubShiftNumber() {
-        return hubShiftNumber;
-    }
-
-    public double getTimeToNextShiftSec() {
-        return timeToNextShiftSec;
-    }
-
-    public boolean isReadyStateChanged() {
-        return readyStateChanged;
-    }
-
-    public String getReadyLostReason() {
-        return readyLostReason;
-    }
-
-    public double getTimeSinceReadyMs() {
-        return timeSinceReadyMs;
-    }
-
-    public boolean isWonAuto() {
-        return wonAuto;
-    }
-
-    public boolean isWonAutoFromFMS() {
-        return wonAutoFromFMS;
-    }
-
-    /** Reset for testing and teleopInit. */
-    public void reset() {
-        shooterReady = false;
-        indexerClear = true;
-        visionLocked = false;
-        hasBall = true;
-        shotConfidence = 0;
-        headingErrorDeg = 0;
-        headingOnTarget = false;
+    // hysteretic heading gate: tight band to enter "on target", wider band to exit
+    if (!stickyHeadingOnTarget) {
+      headingOnTarget = absError < tol;
+      if (headingOnTarget) {
+        stickyHeadingOnTarget = true;
+      }
+    } else {
+      if (absError >= tol * HEADING_HYSTERESIS_FACTOR) {
         stickyHeadingOnTarget = false;
-        inExclusionZone = false;
-        hubActive = true;
-        readyToShoot = false;
-        hubShiftNumber = 0;
-        timeToNextShiftSec = 0;
-        wonAuto = false;
-        wonAutoFromFMS = false;
-        shooterDebounce.reset();
-        indexerDebounce.reset();
-        visionDebounce.reset();
-        confidenceDebounce.reset();
-        debouncedShooterReady = false;
-        debouncedIndexerClear = false;
-        debouncedVisionLocked = false;
-        debouncedShotConfident = false;
-        previousReadyToShoot = false;
-        readyStateChanged = false;
-        readyLostReason = "";
-        readySinceTimestamp = 0;
-        timeSinceReadyMs = 0;
-        wasReady = false;
+        headingOnTarget = false;
+      } else {
+        headingOnTarget = true;
+      }
+    }
+  }
+
+  /** Call once per robotPeriodic(). */
+  public void update() {
+    double now = Timer.getFPGATimestamp();
+
+    previousReadyToShoot = readyToShoot;
+
+    try {
+      HubShiftEngine engine = HubShiftEngine.getInstance();
+      HubShiftEngine.ShiftInfo info = engine.getOfficialInfo();
+      hubActive = info.hubActive();
+      wonAuto = engine.isWonAuto();
+      wonAutoFromFMS = engine.isWonAutoFromFMS();
+
+      // Map engine phase to shift number for per-shift stats.
+      // -1 for non-shift phases so MatchStatsTelemetry doesn't miscount them as endgame.
+      hubShiftNumber =
+          switch (info.phase()) {
+            case SHIFT1 -> 1;
+            case SHIFT2 -> 2;
+            case SHIFT3 -> 3;
+            case SHIFT4 -> 4;
+            case ENDGAME -> 0;
+            default -> -1;
+          };
+
+      if (!hubActive) {
+        timeToNextShiftSec = info.timeToNextActive();
+      } else {
+        timeToNextShiftSec = info.timeUntilDeactivation();
+      }
+    } catch (Throwable t) {
+      // HubShiftEngine not ready, safe defaults
+      hubActive = true;
+      hubShiftNumber = 0;
+      timeToNextShiftSec = 0;
     }
 
-    public boolean isShooterReady() {
-        return shooterReady;
+    debouncedShooterReady = shooterDebounce.calculate(shooterReady);
+    debouncedIndexerClear = indexerDebounce.calculate(indexerClear);
+    debouncedVisionLocked = visionDebounce.calculate(visionLocked);
+    debouncedShotConfident = confidenceDebounce.calculate(shotConfidence >= 50);
+
+    // fireAuthorized covers hubActive with TOF-compensated timing
+    readyToShoot =
+        debouncedShooterReady
+            && debouncedIndexerClear
+            && debouncedVisionLocked
+            && hasBall
+            && isFireAuthorized()
+            && debouncedShotConfident
+            && headingOnTarget
+            && !inExclusionZone;
+
+    readyStateChanged = (readyToShoot != previousReadyToShoot);
+    if (readyStateChanged && !readyToShoot) {
+      readyLostReason = buildNotReadyReason();
+    } else if (readyStateChanged && readyToShoot) {
+      readyLostReason = "";
     }
 
-    public boolean isIndexerClear() {
-        return indexerClear;
+    if (readyToShoot && !wasReady) {
+      readySinceTimestamp = now;
     }
+    timeSinceReadyMs = readyToShoot ? (now - readySinceTimestamp) * 1000.0 : 0;
+    wasReady = readyToShoot;
+  }
 
-    public boolean isVisionLocked() {
-        return visionLocked;
+  private String buildNotReadyReason() {
+    StringBuilder sb = new StringBuilder();
+    if (!debouncedShooterReady) sb.append("Shooter");
+    if (!debouncedIndexerClear) {
+      if (sb.length() > 0) sb.append("+");
+      sb.append("Indexer");
     }
-
-    public boolean isHasBall() {
-        return hasBall;
+    if (!debouncedVisionLocked) {
+      if (sb.length() > 0) sb.append("+");
+      sb.append("Vision");
     }
-
-    public boolean isShotConfident() {
-        return shotConfidence >= 50;
+    if (!isFireAuthorized()) {
+      if (sb.length() > 0) sb.append("+");
+      sb.append("FireAuth");
     }
-
-    public double getShotConfidence() {
-        return shotConfidence;
+    if (!hasBall) {
+      if (sb.length() > 0) sb.append("+");
+      sb.append("NoBall");
     }
-
-    public boolean isHeadingOnTarget() {
-        return headingOnTarget;
+    if (!debouncedShotConfident) {
+      if (sb.length() > 0) sb.append("+");
+      sb.append("Confidence");
     }
-
-    public double getHeadingErrorDeg() {
-        return headingErrorDeg;
+    if (!headingOnTarget) {
+      if (sb.length() > 0) sb.append("+");
+      sb.append("Heading");
     }
-
-    public boolean isInExclusionZone() {
-        return inExclusionZone;
+    if (inExclusionZone) {
+      if (sb.length() > 0) sb.append("+");
+      sb.append("ExclusionZone");
     }
+    return sb.length() > 0 ? sb.toString() : "Unknown";
+  }
 
-    public boolean isDebouncedShooterReady() {
-        return debouncedShooterReady;
+  public boolean isReadyToShoot() {
+    return readyToShoot;
+  }
+
+  public boolean isHubActive() {
+    return hubActive;
+  }
+
+  public int getHubShiftNumber() {
+    return hubShiftNumber;
+  }
+
+  public double getTimeToNextShiftSec() {
+    return timeToNextShiftSec;
+  }
+
+  public boolean isReadyStateChanged() {
+    return readyStateChanged;
+  }
+
+  public String getReadyLostReason() {
+    return readyLostReason;
+  }
+
+  public double getTimeSinceReadyMs() {
+    return timeSinceReadyMs;
+  }
+
+  public boolean isWonAuto() {
+    return wonAuto;
+  }
+
+  public boolean isWonAutoFromFMS() {
+    return wonAutoFromFMS;
+  }
+
+  /** Reset for testing and teleopInit. */
+  public void reset() {
+    shooterReady = false;
+    indexerClear = true;
+    visionLocked = false;
+    hasBall = true;
+    shotConfidence = 0;
+    headingErrorDeg = 0;
+    headingOnTarget = false;
+    stickyHeadingOnTarget = false;
+    inExclusionZone = false;
+    hubActive = true;
+    readyToShoot = false;
+    hubShiftNumber = 0;
+    timeToNextShiftSec = 0;
+    wonAuto = false;
+    wonAutoFromFMS = false;
+    shooterDebounce.reset();
+    indexerDebounce.reset();
+    visionDebounce.reset();
+    confidenceDebounce.reset();
+    debouncedShooterReady = false;
+    debouncedIndexerClear = false;
+    debouncedVisionLocked = false;
+    debouncedShotConfident = false;
+    previousReadyToShoot = false;
+    readyStateChanged = false;
+    readyLostReason = "";
+    readySinceTimestamp = 0;
+    timeSinceReadyMs = 0;
+    wasReady = false;
+  }
+
+  public boolean isShooterReady() {
+    return shooterReady;
+  }
+
+  public boolean isIndexerClear() {
+    return indexerClear;
+  }
+
+  public boolean isVisionLocked() {
+    return visionLocked;
+  }
+
+  public boolean isHasBall() {
+    return hasBall;
+  }
+
+  public boolean isShotConfident() {
+    return shotConfidence >= 50;
+  }
+
+  public double getShotConfidence() {
+    return shotConfidence;
+  }
+
+  public boolean isHeadingOnTarget() {
+    return headingOnTarget;
+  }
+
+  public double getHeadingErrorDeg() {
+    return headingErrorDeg;
+  }
+
+  public boolean isInExclusionZone() {
+    return inExclusionZone;
+  }
+
+  public boolean isDebouncedShooterReady() {
+    return debouncedShooterReady;
+  }
+
+  public boolean isDebouncedIndexerClear() {
+    return debouncedIndexerClear;
+  }
+
+  public boolean isDebouncedVisionLocked() {
+    return debouncedVisionLocked;
+  }
+
+  public boolean isDebouncedShotConfident() {
+    return debouncedShotConfident;
+  }
+
+  /** Fail-open: permits firing if FireAuthorization throws. */
+  public boolean isFireAuthorized() {
+    try {
+      return FireAuthorization.getInstance().isAuthorized();
+    } catch (Throwable t) {
+      return true;
     }
+  }
 
-    public boolean isDebouncedIndexerClear() {
-        return debouncedIndexerClear;
+  public String getFireAuthLevel() {
+    try {
+      return FireAuthorization.getInstance().getLevel().name();
+    } catch (Throwable t) {
+      return "FIRE_AUTHORIZED";
     }
+  }
 
-    public boolean isDebouncedVisionLocked() {
-        return debouncedVisionLocked;
-    }
-
-    public boolean isDebouncedShotConfident() {
-        return debouncedShotConfident;
-    }
-
-    /** Fail-open: permits firing if FireAuthorization throws. */
-    public boolean isFireAuthorized() {
-        try {
-            return FireAuthorization.getInstance().isAuthorized();
-        } catch (Throwable t) {
-            return true;
+  /** Time remaining in the ballistic window (shifted by TOF). Positive = window open. */
+  public double getBallisticWindowRemainingSec() {
+    try {
+      HubShiftEngine engine = HubShiftEngine.getInstance();
+      if (engine.isFeatureEnabled()) {
+        HubShiftEngine.ShiftInfo shifted = engine.getShiftedInfo();
+        if (shifted.hubActive()) {
+          return shifted.timeUntilDeactivation();
+        } else {
+          return -shifted.timeToNextActive();
         }
+      }
+    } catch (Throwable t) {
+      // fall through
+    }
+    return 0;
+  }
+
+  /**
+   * Falling-edge hold: when the input drops from true to false, the output stays true for holdSec
+   * before following. Rising edges pass through immediately. Won't falsely report true at startup
+   * before the input has ever been true (unlike WPILib's Debouncer with kFalling baseline=true).
+   */
+  static class FallingDebounce {
+    private final double holdSec;
+    private boolean output = false;
+    private double falseSince = 0;
+
+    FallingDebounce(double holdSec) {
+      this.holdSec = holdSec;
     }
 
-    public String getFireAuthLevel() {
-        try {
-            return FireAuthorization.getInstance().getLevel().name();
-        } catch (Throwable t) {
-            return "FIRE_AUTHORIZED";
-        }
+    boolean calculate(boolean input) {
+      double now = Timer.getFPGATimestamp();
+      if (input) {
+        output = true;
+        falseSince = 0;
+        return true;
+      }
+      if (!output) {
+        return false;
+      }
+      if (falseSince == 0) {
+        falseSince = now;
+      }
+      if ((now - falseSince) >= holdSec) {
+        output = false;
+      }
+      return output;
     }
 
-    /** Time remaining in the ballistic window (shifted by TOF). Positive = window open. */
-    public double getBallisticWindowRemainingSec() {
-        try {
-            HubShiftEngine engine = HubShiftEngine.getInstance();
-            if (engine.isFeatureEnabled()) {
-                HubShiftEngine.ShiftInfo shifted = engine.getShiftedInfo();
-                if (shifted.hubActive()) {
-                    return shifted.timeUntilDeactivation();
-                } else {
-                    return -shifted.timeToNextActive();
-                }
-            }
-        } catch (Throwable t) {
-            // fall through
-        }
-        return 0;
+    void reset() {
+      output = false;
+      falseSince = 0;
     }
-
-    /**
-     * Falling-edge hold: when the input drops from true to false, the output stays true for holdSec
-     * before following. Rising edges pass through immediately. Won't falsely report true at startup
-     * before the input has ever been true (unlike WPILib's Debouncer with kFalling baseline=true).
-     */
-    static class FallingDebounce {
-        private final double holdSec;
-        private boolean output = false;
-        private double falseSince = 0;
-
-        FallingDebounce(double holdSec) {
-            this.holdSec = holdSec;
-        }
-
-        boolean calculate(boolean input) {
-            double now = Timer.getFPGATimestamp();
-            if (input) {
-                output = true;
-                falseSince = 0;
-                return true;
-            }
-            if (!output) {
-                return false;
-            }
-            if (falseSince == 0) {
-                falseSince = now;
-            }
-            if ((now - falseSince) >= holdSec) {
-                output = false;
-            }
-            return output;
-        }
-
-        void reset() {
-            output = false;
-            falseSince = 0;
-        }
-    }
+  }
 }

--- a/src/main/java/frc/robot/util/SpatialLaunchValidator.java
+++ b/src/main/java/frc/robot/util/SpatialLaunchValidator.java
@@ -3,216 +3,210 @@ package frc.robot.util;
 import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.math.geometry.Translation2d;
 import edu.wpi.first.wpilibj.DriverStation;
-
 import frc.robot.Constants.HubScoringConstants;
 import frc.robot.Constants.SpatialLaunchConstants;
 import frc.robot.telemetry.SafeLog;
 
 /**
- * Checks if the robot's field position is safe to shoot from: pillar obstruction,
- * minimum distance, and trench ceiling exclusion zones (velocity-expanded).
+ * Checks if the robot's field position is safe to shoot from: pillar obstruction, minimum distance,
+ * and trench ceiling exclusion zones (velocity-expanded).
  */
 public final class SpatialLaunchValidator {
 
-    private static final TunableNumber minLaunchDistance =
-            new TunableNumber(
-                    "SpatialLaunch/MinDistanceM", SpatialLaunchConstants.MIN_LAUNCH_DISTANCE_M);
-    private static final TunableNumber retractionTimeSec =
-            new TunableNumber(
-                    "SpatialLaunch/RetractionTimeSec", SpatialLaunchConstants.RETRACTION_TIME_SEC);
+  private static final TunableNumber minLaunchDistance =
+      new TunableNumber("SpatialLaunch/MinDistanceM", SpatialLaunchConstants.MIN_LAUNCH_DISTANCE_M);
+  private static final TunableNumber retractionTimeSec =
+      new TunableNumber(
+          "SpatialLaunch/RetractionTimeSec", SpatialLaunchConstants.RETRACTION_TIME_SEC);
 
-    public static final class ValidationResult {
-        public final boolean pathClear;
-        public final boolean distanceValid;
-        public final boolean outsideExclusionZone;
-        public final double distanceToHub;
-        public final double nearestTrenchDistM;
+  public static final class ValidationResult {
+    public final boolean pathClear;
+    public final boolean distanceValid;
+    public final boolean outsideExclusionZone;
+    public final double distanceToHub;
+    public final double nearestTrenchDistM;
 
-        ValidationResult(
-                boolean pathClear,
-                boolean distanceValid,
-                boolean outsideExclusionZone,
-                double distanceToHub,
-                double nearestTrenchDistM) {
-            this.pathClear = pathClear;
-            this.distanceValid = distanceValid;
-            this.outsideExclusionZone = outsideExclusionZone;
-            this.distanceToHub = distanceToHub;
-            this.nearestTrenchDistM = nearestTrenchDistM;
-        }
-
-        public boolean isValid() {
-            return pathClear && distanceValid && outsideExclusionZone;
-        }
+    ValidationResult(
+        boolean pathClear,
+        boolean distanceValid,
+        boolean outsideExclusionZone,
+        double distanceToHub,
+        double nearestTrenchDistM) {
+      this.pathClear = pathClear;
+      this.distanceValid = distanceValid;
+      this.outsideExclusionZone = outsideExclusionZone;
+      this.distanceToHub = distanceToHub;
+      this.nearestTrenchDistM = nearestTrenchDistM;
     }
 
-    public static ValidationResult validate(Pose2d robotPose) {
-        Translation2d hub = getHubCenter();
-        Translation2d robot = robotPose.getTranslation();
-        double dist = robot.getDistance(hub);
+    public boolean isValid() {
+      return pathClear && distanceValid && outsideExclusionZone;
+    }
+  }
 
-        boolean pathClear = isPathClear(robot, hub);
-        boolean distanceValid = dist >= minLaunchDistance.get();
-        boolean outsideExclusion = !isInExclusionZone(robot.getX(), robot.getY());
-        double nearestTrench = getNearestTrenchDistM(robot.getX(), robot.getY());
+  public static ValidationResult validate(Pose2d robotPose) {
+    Translation2d hub = getHubCenter();
+    Translation2d robot = robotPose.getTranslation();
+    double dist = robot.getDistance(hub);
 
-        return new ValidationResult(
-                pathClear, distanceValid, outsideExclusion, dist, nearestTrench);
+    boolean pathClear = isPathClear(robot, hub);
+    boolean distanceValid = dist >= minLaunchDistance.get();
+    boolean outsideExclusion = !isInExclusionZone(robot.getX(), robot.getY());
+    double nearestTrench = getNearestTrenchDistM(robot.getX(), robot.getY());
+
+    return new ValidationResult(pathClear, distanceValid, outsideExclusion, dist, nearestTrench);
+  }
+
+  /** Shooting from here hits the ceiling. */
+  public static boolean isInExclusionZone(double robotX, double robotY) {
+    for (double[] zone : SpatialLaunchConstants.TRENCH_EXCLUSION_ZONES) {
+      if (robotX >= zone[0] && robotX <= zone[2] && robotY >= zone[1] && robotY <= zone[3]) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /** Returns 0 if inside a zone. */
+  public static double getNearestTrenchDistM(double robotX, double robotY) {
+    double minDist = Double.MAX_VALUE;
+    for (double[] zone : SpatialLaunchConstants.TRENCH_EXCLUSION_ZONES) {
+      double dx = Math.max(0, Math.max(zone[0] - robotX, robotX - zone[2]));
+      double dy = Math.max(0, Math.max(zone[1] - robotY, robotY - zone[3]));
+      double dist = Math.sqrt(dx * dx + dy * dy);
+      minDist = Math.min(minDist, dist);
+    }
+    return minDist;
+  }
+
+  /**
+   * Expands the exclusion zone by closingSpeed * retractionTime so the driver gets warned before
+   * entering. Positive closing speed means approaching.
+   */
+  public static double computeTrenchBuffer(double closingSpeedMps) {
+    if (closingSpeedMps <= 0) {
+      return 0;
+    }
+    return closingSpeedMps * retractionTimeSec.get();
+  }
+
+  /** Includes velocity-based buffer so the driver gets warned before entering. */
+  public static boolean isInExpandedExclusionZone(
+      double robotX, double robotY, double velocityX, double velocityY) {
+    if (isInExclusionZone(robotX, robotY)) {
+      return true;
     }
 
-    /** Shooting from here hits the ceiling. */
-    public static boolean isInExclusionZone(double robotX, double robotY) {
-        for (double[] zone : SpatialLaunchConstants.TRENCH_EXCLUSION_ZONES) {
-            if (robotX >= zone[0] && robotX <= zone[2] && robotY >= zone[1] && robotY <= zone[3]) {
-                return true;
-            }
-        }
+    double speed = Math.sqrt(velocityX * velocityX + velocityY * velocityY);
+    if (speed < 0.1) {
+      return false;
+    }
+
+    double buffer = computeTrenchBuffer(speed);
+    if (buffer <= 0) {
+      return false;
+    }
+
+    double nearestDist = getNearestTrenchDistM(robotX, robotY);
+    return nearestDist < buffer;
+  }
+
+  public static void logTelemetry(
+      ValidationResult result, double closingSpeedMps, double bufferM, boolean exclusionWarning) {
+    SafeLog.put("Scoring/InExclusionZone", !result.outsideExclusionZone);
+    SafeLog.put("Scoring/NearestTrenchDistM", result.nearestTrenchDistM);
+    SafeLog.put("Scoring/TrenchClosingSpeedMps", closingSpeedMps);
+    SafeLog.put("Scoring/TrenchBufferM", bufferM);
+    SafeLog.put("Scoring/ExclusionZoneWarning", exclusionWarning);
+  }
+
+  /** 2D ray-cast via slab method, checks trench pillars between robot and hub. */
+  static boolean isPathClear(Translation2d robot, Translation2d hub) {
+    double margin = SpatialLaunchConstants.BALL_RADIUS_M;
+
+    for (double[] pillar : SpatialLaunchConstants.TRENCH_PILLARS) {
+      if (segmentIntersectsAABB(
+          robot.getX(),
+          robot.getY(),
+          hub.getX(),
+          hub.getY(),
+          pillar[0] - margin,
+          pillar[1] - margin,
+          pillar[2] + margin,
+          pillar[3] + margin)) {
         return false;
+      }
+    }
+    return true;
+  }
+
+  /** 2D line segment / axis-aligned bounding box intersection via slab method. */
+  static boolean segmentIntersectsAABB(
+      double x0,
+      double y0,
+      double x1,
+      double y1,
+      double minX,
+      double minY,
+      double maxX,
+      double maxY) {
+
+    double dx = x1 - x0;
+    double dy = y1 - y0;
+
+    double tMin = 0.0;
+    double tMax = 1.0;
+
+    if (Math.abs(dx) < 1e-12) {
+      if (x0 < minX || x0 > maxX) {
+        return false;
+      }
+    } else {
+      double invDx = 1.0 / dx;
+      double t1 = (minX - x0) * invDx;
+      double t2 = (maxX - x0) * invDx;
+      if (t1 > t2) {
+        double tmp = t1;
+        t1 = t2;
+        t2 = tmp;
+      }
+      tMin = Math.max(tMin, t1);
+      tMax = Math.min(tMax, t2);
+      if (tMin > tMax) {
+        return false;
+      }
     }
 
-    /** Returns 0 if inside a zone. */
-    public static double getNearestTrenchDistM(double robotX, double robotY) {
-        double minDist = Double.MAX_VALUE;
-        for (double[] zone : SpatialLaunchConstants.TRENCH_EXCLUSION_ZONES) {
-            double dx = Math.max(0, Math.max(zone[0] - robotX, robotX - zone[2]));
-            double dy = Math.max(0, Math.max(zone[1] - robotY, robotY - zone[3]));
-            double dist = Math.sqrt(dx * dx + dy * dy);
-            minDist = Math.min(minDist, dist);
-        }
-        return minDist;
+    if (Math.abs(dy) < 1e-12) {
+      if (y0 < minY || y0 > maxY) {
+        return false;
+      }
+    } else {
+      double invDy = 1.0 / dy;
+      double t1 = (minY - y0) * invDy;
+      double t2 = (maxY - y0) * invDy;
+      if (t1 > t2) {
+        double tmp = t1;
+        t1 = t2;
+        t2 = tmp;
+      }
+      tMin = Math.max(tMin, t1);
+      tMax = Math.min(tMax, t2);
+      if (tMin > tMax) {
+        return false;
+      }
     }
 
-    /**
-     * Expands the exclusion zone by closingSpeed * retractionTime so the driver gets warned before
-     * entering. Positive closing speed means approaching.
-     */
-    public static double computeTrenchBuffer(double closingSpeedMps) {
-        if (closingSpeedMps <= 0) {
-            return 0;
-        }
-        return closingSpeedMps * retractionTimeSec.get();
+    return true;
+  }
+
+  private static Translation2d getHubCenter() {
+    var alliance = DriverStation.getAlliance();
+    if (alliance.isPresent() && alliance.get() == DriverStation.Alliance.Red) {
+      return HubScoringConstants.RED_HUB_CENTER;
     }
+    return HubScoringConstants.BLUE_HUB_CENTER;
+  }
 
-    /** Includes velocity-based buffer so the driver gets warned before entering. */
-    public static boolean isInExpandedExclusionZone(
-            double robotX, double robotY, double velocityX, double velocityY) {
-        if (isInExclusionZone(robotX, robotY)) {
-            return true;
-        }
-
-        double speed = Math.sqrt(velocityX * velocityX + velocityY * velocityY);
-        if (speed < 0.1) {
-            return false;
-        }
-
-        double buffer = computeTrenchBuffer(speed);
-        if (buffer <= 0) {
-            return false;
-        }
-
-        double nearestDist = getNearestTrenchDistM(robotX, robotY);
-        return nearestDist < buffer;
-    }
-
-    public static void logTelemetry(
-            ValidationResult result,
-            double closingSpeedMps,
-            double bufferM,
-            boolean exclusionWarning) {
-        SafeLog.put("Scoring/InExclusionZone", !result.outsideExclusionZone);
-        SafeLog.put("Scoring/NearestTrenchDistM", result.nearestTrenchDistM);
-        SafeLog.put("Scoring/TrenchClosingSpeedMps", closingSpeedMps);
-        SafeLog.put("Scoring/TrenchBufferM", bufferM);
-        SafeLog.put("Scoring/ExclusionZoneWarning", exclusionWarning);
-    }
-
-    /** 2D ray-cast via slab method, checks trench pillars between robot and hub. */
-    static boolean isPathClear(Translation2d robot, Translation2d hub) {
-        double margin = SpatialLaunchConstants.BALL_RADIUS_M;
-
-        for (double[] pillar : SpatialLaunchConstants.TRENCH_PILLARS) {
-            if (segmentIntersectsAABB(
-                    robot.getX(),
-                    robot.getY(),
-                    hub.getX(),
-                    hub.getY(),
-                    pillar[0] - margin,
-                    pillar[1] - margin,
-                    pillar[2] + margin,
-                    pillar[3] + margin)) {
-                return false;
-            }
-        }
-        return true;
-    }
-
-    /** 2D line segment / axis-aligned bounding box intersection via slab method. */
-    static boolean segmentIntersectsAABB(
-            double x0,
-            double y0,
-            double x1,
-            double y1,
-            double minX,
-            double minY,
-            double maxX,
-            double maxY) {
-
-        double dx = x1 - x0;
-        double dy = y1 - y0;
-
-        double tMin = 0.0;
-        double tMax = 1.0;
-
-        if (Math.abs(dx) < 1e-12) {
-            if (x0 < minX || x0 > maxX) {
-                return false;
-            }
-        } else {
-            double invDx = 1.0 / dx;
-            double t1 = (minX - x0) * invDx;
-            double t2 = (maxX - x0) * invDx;
-            if (t1 > t2) {
-                double tmp = t1;
-                t1 = t2;
-                t2 = tmp;
-            }
-            tMin = Math.max(tMin, t1);
-            tMax = Math.min(tMax, t2);
-            if (tMin > tMax) {
-                return false;
-            }
-        }
-
-        if (Math.abs(dy) < 1e-12) {
-            if (y0 < minY || y0 > maxY) {
-                return false;
-            }
-        } else {
-            double invDy = 1.0 / dy;
-            double t1 = (minY - y0) * invDy;
-            double t2 = (maxY - y0) * invDy;
-            if (t1 > t2) {
-                double tmp = t1;
-                t1 = t2;
-                t2 = tmp;
-            }
-            tMin = Math.max(tMin, t1);
-            tMax = Math.min(tMax, t2);
-            if (tMin > tMax) {
-                return false;
-            }
-        }
-
-        return true;
-    }
-
-    private static Translation2d getHubCenter() {
-        var alliance = DriverStation.getAlliance();
-        if (alliance.isPresent() && alliance.get() == DriverStation.Alliance.Red) {
-            return HubScoringConstants.RED_HUB_CENTER;
-        }
-        return HubScoringConstants.BLUE_HUB_CENTER;
-    }
-
-    private SpatialLaunchValidator() {}
+  private SpatialLaunchValidator() {}
 }

--- a/src/test/java/frc/robot/telemetry/ScoringHubTimingTest.java
+++ b/src/test/java/frc/robot/telemetry/ScoringHubTimingTest.java
@@ -6,11 +6,9 @@ import edu.wpi.first.hal.HAL;
 import edu.wpi.first.networktables.NetworkTableInstance;
 import edu.wpi.first.wpilibj.simulation.DriverStationSim;
 import edu.wpi.first.wpilibj.simulation.SimHooks;
-
 import frc.robot.util.FireAuthorization;
 import frc.robot.util.HubShiftEngine;
 import frc.robot.util.ScoringReadiness;
-
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -21,142 +19,141 @@ import org.junit.jupiter.api.Test;
  */
 class ScoringHubTimingTest {
 
-    @BeforeEach
-    void setUp() throws Exception {
-        HAL.initialize(500, 0);
-        NetworkTableInstance.getDefault().startLocal();
-        // resetInstance() is package-private, use reflection from this package
-        java.lang.reflect.Field hubField = HubShiftEngine.class.getDeclaredField("instance");
-        hubField.setAccessible(true);
-        hubField.set(null, null);
-        java.lang.reflect.Field faField = FireAuthorization.class.getDeclaredField("instance");
-        faField.setAccessible(true);
-        faField.set(null, null);
-        ScoringReadiness.getInstance().reset();
-        SimHooks.pauseTiming();
-    }
+  @BeforeEach
+  void setUp() throws Exception {
+    HAL.initialize(500, 0);
+    NetworkTableInstance.getDefault().startLocal();
+    // resetInstance() is package-private, use reflection from this package
+    java.lang.reflect.Field hubField = HubShiftEngine.class.getDeclaredField("instance");
+    hubField.setAccessible(true);
+    hubField.set(null, null);
+    java.lang.reflect.Field faField = FireAuthorization.class.getDeclaredField("instance");
+    faField.setAccessible(true);
+    faField.set(null, null);
+    ScoringReadiness.getInstance().reset();
+    SimHooks.pauseTiming();
+  }
 
-    @AfterEach
-    void tearDown() {
-        SimHooks.resumeTiming();
-    }
+  @AfterEach
+  void tearDown() {
+    SimHooks.resumeTiming();
+  }
 
-    private void enterTeleop() {
-        DriverStationSim.setAutonomous(false);
-        DriverStationSim.setEnabled(true);
-        DriverStationSim.notifyNewData();
-    }
+  private void enterTeleop() {
+    DriverStationSim.setAutonomous(false);
+    DriverStationSim.setEnabled(true);
+    DriverStationSim.notifyNewData();
+  }
 
-    private void advanceAndUpdate(double seconds) {
-        HubShiftEngine engine = HubShiftEngine.getInstance();
-        SimHooks.stepTiming(seconds);
-        engine.update(0);
-        ScoringReadiness.getInstance().update();
-    }
+  private void advanceAndUpdate(double seconds) {
+    HubShiftEngine engine = HubShiftEngine.getInstance();
+    SimHooks.stepTiming(seconds);
+    engine.update(0);
+    ScoringReadiness.getInstance().update();
+  }
 
-    @Test
-    void testShiftNumber1() {
-        HubShiftEngine.getInstance().setWonAutoOverride(false);
-        enterTeleop();
-        HubShiftEngine.getInstance().initializeTeleop();
+  @Test
+  void testShiftNumber1() {
+    HubShiftEngine.getInstance().setWonAutoOverride(false);
+    enterTeleop();
+    HubShiftEngine.getInstance().initializeTeleop();
 
-        advanceAndUpdate(15.0); // SHIFT1: 10-35s
+    advanceAndUpdate(15.0); // SHIFT1: 10-35s
 
-        assertEquals(1, ScoringReadiness.getInstance().getHubShiftNumber());
-    }
+    assertEquals(1, ScoringReadiness.getInstance().getHubShiftNumber());
+  }
 
-    @Test
-    void testShiftNumber4() {
-        HubShiftEngine.getInstance().setWonAutoOverride(false);
-        enterTeleop();
-        HubShiftEngine.getInstance().initializeTeleop();
+  @Test
+  void testShiftNumber4() {
+    HubShiftEngine.getInstance().setWonAutoOverride(false);
+    enterTeleop();
+    HubShiftEngine.getInstance().initializeTeleop();
 
-        advanceAndUpdate(97.0); // SHIFT4: 85-110s
+    advanceAndUpdate(97.0); // SHIFT4: 85-110s
 
-        assertEquals(4, ScoringReadiness.getInstance().getHubShiftNumber());
-    }
+    assertEquals(4, ScoringReadiness.getInstance().getHubShiftNumber());
+  }
 
-    @Test
-    void testShiftNumberEndgame() {
-        HubShiftEngine.getInstance().setWonAutoOverride(false);
-        enterTeleop();
-        HubShiftEngine.getInstance().initializeTeleop();
+  @Test
+  void testShiftNumberEndgame() {
+    HubShiftEngine.getInstance().setWonAutoOverride(false);
+    enterTeleop();
+    HubShiftEngine.getInstance().initializeTeleop();
 
-        advanceAndUpdate(120.0); // ENDGAME: 110-140s
+    advanceAndUpdate(120.0); // ENDGAME: 110-140s
 
-        assertEquals(0, ScoringReadiness.getInstance().getHubShiftNumber());
-    }
+    assertEquals(0, ScoringReadiness.getInstance().getHubShiftNumber());
+  }
 
-    @Test
-    void testTransitionAlwaysActive() {
-        HubShiftEngine.getInstance().setWonAutoOverride(true);
-        enterTeleop();
-        HubShiftEngine.getInstance().initializeTeleop();
+  @Test
+  void testTransitionAlwaysActive() {
+    HubShiftEngine.getInstance().setWonAutoOverride(true);
+    enterTeleop();
+    HubShiftEngine.getInstance().initializeTeleop();
 
-        advanceAndUpdate(5.0); // TRANSITION: 0-10s
+    advanceAndUpdate(5.0); // TRANSITION: 0-10s
 
-        assertTrue(ScoringReadiness.getInstance().isHubActive());
-    }
+    assertTrue(ScoringReadiness.getInstance().isHubActive());
+  }
 
-    @Test
-    void testEndgameAlwaysActive() {
-        HubShiftEngine.getInstance().setWonAutoOverride(true);
-        enterTeleop();
-        HubShiftEngine.getInstance().initializeTeleop();
+  @Test
+  void testEndgameAlwaysActive() {
+    HubShiftEngine.getInstance().setWonAutoOverride(true);
+    enterTeleop();
+    HubShiftEngine.getInstance().initializeTeleop();
 
-        advanceAndUpdate(125.0);
+    advanceAndUpdate(125.0);
 
-        assertTrue(ScoringReadiness.getInstance().isHubActive());
-    }
+    assertTrue(ScoringReadiness.getInstance().isHubActive());
+  }
 
-    @Test
-    void testShift1WonAuto() {
-        HubShiftEngine.getInstance().setWonAutoOverride(true);
-        enterTeleop();
-        HubShiftEngine.getInstance().initializeTeleop();
+  @Test
+  void testShift1WonAuto() {
+    HubShiftEngine.getInstance().setWonAutoOverride(true);
+    enterTeleop();
+    HubShiftEngine.getInstance().initializeTeleop();
 
-        advanceAndUpdate(15.0);
+    advanceAndUpdate(15.0);
 
-        assertFalse(
-                ScoringReadiness.getInstance().isHubActive(),
-                "Winner should be INACTIVE during odd shift 1");
-    }
+    assertFalse(
+        ScoringReadiness.getInstance().isHubActive(),
+        "Winner should be INACTIVE during odd shift 1");
+  }
 
-    @Test
-    void testShift1LostAuto() {
-        HubShiftEngine.getInstance().setWonAutoOverride(false);
-        enterTeleop();
-        HubShiftEngine.getInstance().initializeTeleop();
+  @Test
+  void testShift1LostAuto() {
+    HubShiftEngine.getInstance().setWonAutoOverride(false);
+    enterTeleop();
+    HubShiftEngine.getInstance().initializeTeleop();
 
-        advanceAndUpdate(15.0);
+    advanceAndUpdate(15.0);
 
-        assertTrue(
-                ScoringReadiness.getInstance().isHubActive(),
-                "Loser should be ACTIVE during odd shift 1");
-    }
+    assertTrue(
+        ScoringReadiness.getInstance().isHubActive(), "Loser should be ACTIVE during odd shift 1");
+  }
 
-    @Test
-    void testShift2WonAuto() {
-        HubShiftEngine.getInstance().setWonAutoOverride(true);
-        enterTeleop();
-        HubShiftEngine.getInstance().initializeTeleop();
+  @Test
+  void testShift2WonAuto() {
+    HubShiftEngine.getInstance().setWonAutoOverride(true);
+    enterTeleop();
+    HubShiftEngine.getInstance().initializeTeleop();
 
-        advanceAndUpdate(40.0);
+    advanceAndUpdate(40.0);
 
-        assertTrue(
-                ScoringReadiness.getInstance().isHubActive(),
-                "Winner should be ACTIVE during even shift 2");
-    }
+    assertTrue(
+        ScoringReadiness.getInstance().isHubActive(),
+        "Winner should be ACTIVE during even shift 2");
+  }
 
-    @Test
-    void testTimeToNextShift() {
-        HubShiftEngine.getInstance().setWonAutoOverride(true);
-        enterTeleop();
-        HubShiftEngine.getInstance().initializeTeleop();
+  @Test
+  void testTimeToNextShift() {
+    HubShiftEngine.getInstance().setWonAutoOverride(true);
+    enterTeleop();
+    HubShiftEngine.getInstance().initializeTeleop();
 
-        advanceAndUpdate(5.0); // TRANSITION at 5s, 5s remaining
+    advanceAndUpdate(5.0); // TRANSITION at 5s, 5s remaining
 
-        double time = ScoringReadiness.getInstance().getTimeToNextShiftSec();
-        assertTrue(time > 0, "Should have positive time remaining");
-    }
+    double time = ScoringReadiness.getInstance().getTimeToNextShiftSec();
+    assertTrue(time > 0, "Should have positive time remaining");
+  }
 }

--- a/src/test/java/frc/robot/telemetry/ScoringTelemetryTest.java
+++ b/src/test/java/frc/robot/telemetry/ScoringTelemetryTest.java
@@ -2,199 +2,195 @@ package frc.robot.telemetry;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import edu.wpi.first.wpilibj.simulation.SimHooks;
 import edu.wpi.first.wpilibj.simulation.DriverStationSim;
-
+import edu.wpi.first.wpilibj.simulation.SimHooks;
 import frc.robot.util.ScoringReadiness;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class ScoringTelemetryTest extends TelemetryTestBase {
 
-    private ShooterTelemetry shooterTelemetry;
-    private IndexerTelemetry indexerTelemetry;
-    private VisionTelemetry visionTelemetry;
-    private ScoringTelemetry telemetry;
+  private ShooterTelemetry shooterTelemetry;
+  private IndexerTelemetry indexerTelemetry;
+  private VisionTelemetry visionTelemetry;
+  private ScoringTelemetry telemetry;
 
-    @BeforeEach
-    void setUp() {
-        shooterTelemetry = new ShooterTelemetry();
-        indexerTelemetry = new IndexerTelemetry();
-        visionTelemetry = new VisionTelemetry();
-        telemetry = new ScoringTelemetry(shooterTelemetry, indexerTelemetry, visionTelemetry);
-        // ScoringReadiness is a singleton, needs reset between tests to avoid leaking state
-        ScoringReadiness.getInstance().reset();
+  @BeforeEach
+  void setUp() {
+    shooterTelemetry = new ShooterTelemetry();
+    indexerTelemetry = new IndexerTelemetry();
+    visionTelemetry = new VisionTelemetry();
+    telemetry = new ScoringTelemetry(shooterTelemetry, indexerTelemetry, visionTelemetry);
+    // ScoringReadiness is a singleton, needs reset between tests to avoid leaking state
+    ScoringReadiness.getInstance().reset();
+  }
+
+  private void setDependencyField(Object obj, String fieldName, Object value) throws Exception {
+    java.lang.reflect.Field f = obj.getClass().getDeclaredField(fieldName);
+    f.setAccessible(true);
+    f.set(obj, value);
+  }
+
+  @Test
+  void testReadyToShootAllConditionsMet() throws Exception {
+    setDependencyField(shooterTelemetry, "atSpeed", true);
+    setDependencyField(indexerTelemetry, "jamDetected", false);
+    setDependencyField(visionTelemetry, "lockedOnTarget", true);
+
+    DriverStationSim.setEnabled(true);
+    DriverStationSim.setAutonomous(false);
+    DriverStationSim.setTest(false);
+    DriverStationSim.notifyNewData();
+
+    telemetry.update();
+    assertTrue(telemetry.isReadyToShoot(), "All conditions met, should be ready");
+  }
+
+  @Test
+  void testReadyToShootFailsWithoutShooter() throws Exception {
+    setDependencyField(visionTelemetry, "lockedOnTarget", true);
+
+    DriverStationSim.setEnabled(true);
+    DriverStationSim.setAutonomous(false);
+    DriverStationSim.setTest(false);
+    DriverStationSim.notifyNewData();
+
+    telemetry.update();
+    assertFalse(telemetry.isReadyToShoot(), "Not ready without shooter at speed");
+  }
+
+  @Test
+  void testReadyToShootFailsWithoutVision() throws Exception {
+    setDependencyField(shooterTelemetry, "atSpeed", true);
+
+    DriverStationSim.setEnabled(true);
+    DriverStationSim.setAutonomous(false);
+    DriverStationSim.setTest(false);
+    DriverStationSim.notifyNewData();
+
+    telemetry.update();
+    assertFalse(telemetry.isReadyToShoot(), "Not ready without vision lock");
+  }
+
+  @Test
+  void testReadyToShootFailsWithJam() throws Exception {
+    setDependencyField(shooterTelemetry, "atSpeed", true);
+    setDependencyField(indexerTelemetry, "jamDetected", true);
+    setDependencyField(visionTelemetry, "lockedOnTarget", true);
+
+    DriverStationSim.setEnabled(true);
+    DriverStationSim.setAutonomous(false);
+    DriverStationSim.setTest(false);
+    DriverStationSim.notifyNewData();
+
+    telemetry.update();
+    assertFalse(telemetry.isReadyToShoot(), "Not ready with indexer jammed");
+  }
+
+  @Test
+  void testHubActiveInNonTeleopMode() throws Exception {
+    DriverStationSim.setEnabled(false);
+    DriverStationSim.notifyNewData();
+    telemetry.update();
+
+    // hub active state now lives in ScoringReadiness
+    assertTrue(
+        ScoringReadiness.getInstance().isHubActive(), "Hub should be active in non-teleop mode");
+  }
+
+  @Test
+  void testReadyStateChangedDetectsTransition() throws Exception {
+    setDependencyField(shooterTelemetry, "atSpeed", true);
+    setDependencyField(indexerTelemetry, "jamDetected", false);
+    setDependencyField(visionTelemetry, "lockedOnTarget", true);
+    DriverStationSim.setEnabled(true);
+    DriverStationSim.setAutonomous(false);
+    DriverStationSim.setTest(false);
+    DriverStationSim.notifyNewData();
+
+    telemetry.update();
+    assertTrue(telemetry.isReadyToShoot(), "Should be ready");
+    assertTrue(
+        telemetry.isReadyStateChanged(), "State should have changed from default false to true");
+
+    telemetry.update();
+    assertFalse(telemetry.isReadyStateChanged(), "No change when still ready");
+  }
+
+  @Test
+  void testReadyLostReasonCapturesFailingCondition() throws Exception {
+    setDependencyField(shooterTelemetry, "atSpeed", true);
+    setDependencyField(indexerTelemetry, "jamDetected", false);
+    setDependencyField(visionTelemetry, "lockedOnTarget", true);
+    DriverStationSim.setEnabled(true);
+    DriverStationSim.setAutonomous(false);
+    DriverStationSim.setTest(false);
+    DriverStationSim.notifyNewData();
+    telemetry.update();
+    assertTrue(telemetry.isReadyToShoot());
+
+    setDependencyField(visionTelemetry, "lockedOnTarget", false);
+
+    // run enough cycles to expire the debounce window
+    for (int i = 0; i < 50; i++) {
+      SimHooks.stepTiming(0.02);
+      telemetry.update();
     }
 
-    private void setDependencyField(Object obj, String fieldName, Object value) throws Exception {
-        java.lang.reflect.Field f = obj.getClass().getDeclaredField(fieldName);
-        f.setAccessible(true);
-        f.set(obj, value);
+    assertFalse(telemetry.isReadyToShoot(), "Should lose ready after debounce");
+    String reason = telemetry.getReadyLostReason();
+    assertTrue(reason.contains("Vision"), "Lost reason should mention Vision, got: " + reason);
+  }
+
+  @Test
+  void testReadyLostReasonCapturesMultipleFailures() throws Exception {
+    setDependencyField(shooterTelemetry, "atSpeed", true);
+    setDependencyField(indexerTelemetry, "jamDetected", false);
+    setDependencyField(visionTelemetry, "lockedOnTarget", true);
+    DriverStationSim.setEnabled(true);
+    DriverStationSim.setAutonomous(false);
+    DriverStationSim.setTest(false);
+    DriverStationSim.notifyNewData();
+    telemetry.update();
+
+    setDependencyField(shooterTelemetry, "atSpeed", false);
+    setDependencyField(visionTelemetry, "lockedOnTarget", false);
+
+    // first update records falseSince timestamp in both debouncers
+    telemetry.update();
+    // step past both debounce windows (shooter 0.08s, vision 0.10s)
+    SimHooks.stepTiming(0.15);
+    // this update sees both expired, captures both in the reason
+    telemetry.update();
+
+    assertFalse(telemetry.isReadyToShoot());
+    String reason = telemetry.getReadyLostReason();
+    assertTrue(reason.contains("Shooter"), "Should mention Shooter, got: " + reason);
+    assertTrue(reason.contains("Vision"), "Should mention Vision, got: " + reason);
+  }
+
+  @Test
+  void testReadyLostReasonClearsWhenReadyRegained() throws Exception {
+    setDependencyField(shooterTelemetry, "atSpeed", true);
+    setDependencyField(indexerTelemetry, "jamDetected", false);
+    setDependencyField(visionTelemetry, "lockedOnTarget", true);
+    DriverStationSim.setEnabled(true);
+    DriverStationSim.setAutonomous(false);
+    DriverStationSim.setTest(false);
+    DriverStationSim.notifyNewData();
+    telemetry.update();
+
+    setDependencyField(visionTelemetry, "lockedOnTarget", false);
+    for (int i = 0; i < 50; i++) {
+      SimHooks.stepTiming(0.02);
+      telemetry.update();
     }
+    assertFalse(telemetry.isReadyToShoot());
+    assertFalse(telemetry.getReadyLostReason().isEmpty(), "Should have a reason");
 
-    @Test
-    void testReadyToShootAllConditionsMet() throws Exception {
-        setDependencyField(shooterTelemetry, "atSpeed", true);
-        setDependencyField(indexerTelemetry, "jamDetected", false);
-        setDependencyField(visionTelemetry, "lockedOnTarget", true);
-
-        DriverStationSim.setEnabled(true);
-        DriverStationSim.setAutonomous(false);
-        DriverStationSim.setTest(false);
-        DriverStationSim.notifyNewData();
-
-        telemetry.update();
-        assertTrue(telemetry.isReadyToShoot(), "All conditions met, should be ready");
-    }
-
-    @Test
-    void testReadyToShootFailsWithoutShooter() throws Exception {
-        setDependencyField(visionTelemetry, "lockedOnTarget", true);
-
-        DriverStationSim.setEnabled(true);
-        DriverStationSim.setAutonomous(false);
-        DriverStationSim.setTest(false);
-        DriverStationSim.notifyNewData();
-
-        telemetry.update();
-        assertFalse(telemetry.isReadyToShoot(), "Not ready without shooter at speed");
-    }
-
-    @Test
-    void testReadyToShootFailsWithoutVision() throws Exception {
-        setDependencyField(shooterTelemetry, "atSpeed", true);
-
-        DriverStationSim.setEnabled(true);
-        DriverStationSim.setAutonomous(false);
-        DriverStationSim.setTest(false);
-        DriverStationSim.notifyNewData();
-
-        telemetry.update();
-        assertFalse(telemetry.isReadyToShoot(), "Not ready without vision lock");
-    }
-
-    @Test
-    void testReadyToShootFailsWithJam() throws Exception {
-        setDependencyField(shooterTelemetry, "atSpeed", true);
-        setDependencyField(indexerTelemetry, "jamDetected", true);
-        setDependencyField(visionTelemetry, "lockedOnTarget", true);
-
-        DriverStationSim.setEnabled(true);
-        DriverStationSim.setAutonomous(false);
-        DriverStationSim.setTest(false);
-        DriverStationSim.notifyNewData();
-
-        telemetry.update();
-        assertFalse(telemetry.isReadyToShoot(), "Not ready with indexer jammed");
-    }
-
-    @Test
-    void testHubActiveInNonTeleopMode() throws Exception {
-        DriverStationSim.setEnabled(false);
-        DriverStationSim.notifyNewData();
-        telemetry.update();
-
-        // hub active state now lives in ScoringReadiness
-        assertTrue(
-                ScoringReadiness.getInstance().isHubActive(),
-                "Hub should be active in non-teleop mode");
-    }
-
-    @Test
-    void testReadyStateChangedDetectsTransition() throws Exception {
-        setDependencyField(shooterTelemetry, "atSpeed", true);
-        setDependencyField(indexerTelemetry, "jamDetected", false);
-        setDependencyField(visionTelemetry, "lockedOnTarget", true);
-        DriverStationSim.setEnabled(true);
-        DriverStationSim.setAutonomous(false);
-        DriverStationSim.setTest(false);
-        DriverStationSim.notifyNewData();
-
-        telemetry.update();
-        assertTrue(telemetry.isReadyToShoot(), "Should be ready");
-        assertTrue(
-                telemetry.isReadyStateChanged(),
-                "State should have changed from default false to true");
-
-        telemetry.update();
-        assertFalse(telemetry.isReadyStateChanged(), "No change when still ready");
-    }
-
-    @Test
-    void testReadyLostReasonCapturesFailingCondition() throws Exception {
-        setDependencyField(shooterTelemetry, "atSpeed", true);
-        setDependencyField(indexerTelemetry, "jamDetected", false);
-        setDependencyField(visionTelemetry, "lockedOnTarget", true);
-        DriverStationSim.setEnabled(true);
-        DriverStationSim.setAutonomous(false);
-        DriverStationSim.setTest(false);
-        DriverStationSim.notifyNewData();
-        telemetry.update();
-        assertTrue(telemetry.isReadyToShoot());
-
-        setDependencyField(visionTelemetry, "lockedOnTarget", false);
-
-        // run enough cycles to expire the debounce window
-        for (int i = 0; i < 50; i++) {
-            SimHooks.stepTiming(0.02);
-            telemetry.update();
-        }
-
-        assertFalse(telemetry.isReadyToShoot(), "Should lose ready after debounce");
-        String reason = telemetry.getReadyLostReason();
-        assertTrue(reason.contains("Vision"), "Lost reason should mention Vision, got: " + reason);
-    }
-
-    @Test
-    void testReadyLostReasonCapturesMultipleFailures() throws Exception {
-        setDependencyField(shooterTelemetry, "atSpeed", true);
-        setDependencyField(indexerTelemetry, "jamDetected", false);
-        setDependencyField(visionTelemetry, "lockedOnTarget", true);
-        DriverStationSim.setEnabled(true);
-        DriverStationSim.setAutonomous(false);
-        DriverStationSim.setTest(false);
-        DriverStationSim.notifyNewData();
-        telemetry.update();
-
-        setDependencyField(shooterTelemetry, "atSpeed", false);
-        setDependencyField(visionTelemetry, "lockedOnTarget", false);
-
-        // first update records falseSince timestamp in both debouncers
-        telemetry.update();
-        // step past both debounce windows (shooter 0.08s, vision 0.10s)
-        SimHooks.stepTiming(0.15);
-        // this update sees both expired, captures both in the reason
-        telemetry.update();
-
-        assertFalse(telemetry.isReadyToShoot());
-        String reason = telemetry.getReadyLostReason();
-        assertTrue(reason.contains("Shooter"), "Should mention Shooter, got: " + reason);
-        assertTrue(reason.contains("Vision"), "Should mention Vision, got: " + reason);
-    }
-
-    @Test
-    void testReadyLostReasonClearsWhenReadyRegained() throws Exception {
-        setDependencyField(shooterTelemetry, "atSpeed", true);
-        setDependencyField(indexerTelemetry, "jamDetected", false);
-        setDependencyField(visionTelemetry, "lockedOnTarget", true);
-        DriverStationSim.setEnabled(true);
-        DriverStationSim.setAutonomous(false);
-        DriverStationSim.setTest(false);
-        DriverStationSim.notifyNewData();
-        telemetry.update();
-
-        setDependencyField(visionTelemetry, "lockedOnTarget", false);
-        for (int i = 0; i < 50; i++) {
-            SimHooks.stepTiming(0.02);
-            telemetry.update();
-        }
-        assertFalse(telemetry.isReadyToShoot());
-        assertFalse(telemetry.getReadyLostReason().isEmpty(), "Should have a reason");
-
-        setDependencyField(visionTelemetry, "lockedOnTarget", true);
-        telemetry.update();
-        assertTrue(telemetry.isReadyToShoot());
-        assertEquals("", telemetry.getReadyLostReason(), "Reason should clear when ready regained");
-    }
+    setDependencyField(visionTelemetry, "lockedOnTarget", true);
+    telemetry.update();
+    assertTrue(telemetry.isReadyToShoot());
+    assertEquals("", telemetry.getReadyLostReason(), "Reason should clear when ready regained");
+  }
 }

--- a/src/test/java/frc/robot/util/FireAuthorizationTest.java
+++ b/src/test/java/frc/robot/util/FireAuthorizationTest.java
@@ -4,296 +4,285 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import edu.wpi.first.hal.HAL;
 import edu.wpi.first.networktables.NetworkTableInstance;
-
 import frc.robot.util.FireAuthorization.AuthorizationLevel;
 import frc.robot.util.HubShiftEngine.ScheduleConfidence;
 import frc.robot.util.HubShiftEngine.ShiftInfo;
 import frc.robot.util.HubShiftEngine.ShiftPhase;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class FireAuthorizationTest {
 
-    // mirrored from HubTimingConstants for readability in assertions
-    private static final double AVG_FUEL_DELAY = 1.5;
-    private static final double SAFE_MARGIN = 0.5;
-    private static final double EXTENSION = 3.0;
-    private static final double PRE_SPIN_WINDOW = 3.0;
-    private static final double FALLBACK_EXTRA = 1.0;
+  // mirrored from HubTimingConstants for readability in assertions
+  private static final double AVG_FUEL_DELAY = 1.5;
+  private static final double SAFE_MARGIN = 0.5;
+  private static final double EXTENSION = 3.0;
+  private static final double PRE_SPIN_WINDOW = 3.0;
+  private static final double FALLBACK_EXTRA = 1.0;
 
-    @BeforeEach
-    void setUp() {
-        HAL.initialize(500, 0);
-        NetworkTableInstance.getDefault().startLocal();
-        FireAuthorization.resetInstance();
-        HubShiftEngine.resetInstance();
-    }
+  @BeforeEach
+  void setUp() {
+    HAL.initialize(500, 0);
+    NetworkTableInstance.getDefault().startLocal();
+    FireAuthorization.resetInstance();
+    HubShiftEngine.resetInstance();
+  }
 
-    private ShiftInfo activeInfo(double remainingInState, double timeUntilDeactivation) {
-        return new ShiftInfo(
-                ShiftPhase.SHIFT2, true, 5.0, remainingInState, 0, timeUntilDeactivation);
-    }
+  private ShiftInfo activeInfo(double remainingInState, double timeUntilDeactivation) {
+    return new ShiftInfo(ShiftPhase.SHIFT2, true, 5.0, remainingInState, 0, timeUntilDeactivation);
+  }
 
-    private ShiftInfo activeInfoSimple(double timeUntilDeactivation) {
-        return new ShiftInfo(
-                ShiftPhase.SHIFT2, true, 5.0, timeUntilDeactivation, 0, timeUntilDeactivation);
-    }
+  private ShiftInfo activeInfoSimple(double timeUntilDeactivation) {
+    return new ShiftInfo(
+        ShiftPhase.SHIFT2, true, 5.0, timeUntilDeactivation, 0, timeUntilDeactivation);
+  }
 
-    private ShiftInfo inactiveInfo(double timeToNextActive) {
-        return new ShiftInfo(
-                ShiftPhase.SHIFT1, false, 5.0, 20.0, timeToNextActive, Double.MAX_VALUE);
-    }
+  private ShiftInfo inactiveInfo(double timeToNextActive) {
+    return new ShiftInfo(ShiftPhase.SHIFT1, false, 5.0, 20.0, timeToNextActive, Double.MAX_VALUE);
+  }
 
-    @Test
-    void testDefaultFailOpenBeforeFirstUpdate() {
-        FireAuthorization fa = FireAuthorization.getInstance();
-        assertEquals(
-                AuthorizationLevel.FIRE_AUTHORIZED,
-                fa.getLevel(),
-                "Fail-open: default must be FIRE_AUTHORIZED before first update()");
-        assertTrue(fa.isAuthorized(), "Fail-open: default must be authorized");
-        assertFalse(fa.isPreSpin(), "Fail-open: must not be PRE_SPIN");
-    }
+  @Test
+  void testDefaultFailOpenBeforeFirstUpdate() {
+    FireAuthorization fa = FireAuthorization.getInstance();
+    assertEquals(
+        AuthorizationLevel.FIRE_AUTHORIZED,
+        fa.getLevel(),
+        "Fail-open: default must be FIRE_AUTHORIZED before first update()");
+    assertTrue(fa.isAuthorized(), "Fail-open: default must be authorized");
+    assertFalse(fa.isPreSpin(), "Fail-open: must not be PRE_SPIN");
+  }
 
-    @Test
-    void testKillSwitchAlwaysAuthorizes() {
-        FireAuthorization fa = FireAuthorization.getInstance();
-        fa.update(inactiveInfo(15.0), 1.0, ScheduleConfidence.HIGH, false);
+  @Test
+  void testKillSwitchAlwaysAuthorizes() {
+    FireAuthorization fa = FireAuthorization.getInstance();
+    fa.update(inactiveInfo(15.0), 1.0, ScheduleConfidence.HIGH, false);
 
-        assertEquals(AuthorizationLevel.FIRE_AUTHORIZED, fa.getLevel());
-        assertTrue(fa.isAuthorized());
-    }
+    assertEquals(AuthorizationLevel.FIRE_AUTHORIZED, fa.getLevel());
+    assertTrue(fa.isAuthorized());
+  }
 
-    @Test
-    void testKillSwitchFieldValues() {
-        FireAuthorization fa = FireAuthorization.getInstance();
-        fa.update(inactiveInfo(15.0), 2.0, ScheduleConfidence.HIGH, false);
+  @Test
+  void testKillSwitchFieldValues() {
+    FireAuthorization fa = FireAuthorization.getInstance();
+    fa.update(inactiveInfo(15.0), 2.0, ScheduleConfidence.HIGH, false);
 
-        assertEquals(Double.MAX_VALUE, fa.getMargin(), "Kill switch must set margin to MAX_VALUE");
-        assertEquals(
-                0.0, fa.getBallLandingTime(), 0.001, "Kill switch must set ballLandingTime to 0");
-        assertEquals(
-                Double.MAX_VALUE,
-                fa.getWindowRemaining(),
-                "Kill switch must set windowRemaining to MAX_VALUE");
-    }
+    assertEquals(Double.MAX_VALUE, fa.getMargin(), "Kill switch must set margin to MAX_VALUE");
+    assertEquals(0.0, fa.getBallLandingTime(), 0.001, "Kill switch must set ballLandingTime to 0");
+    assertEquals(
+        Double.MAX_VALUE,
+        fa.getWindowRemaining(),
+        "Kill switch must set windowRemaining to MAX_VALUE");
+  }
 
-    @Test
-    void testFireAuthorizedWithLargeMargin() {
-        FireAuthorization fa = FireAuthorization.getInstance();
-        fa.update(activeInfoSimple(20.0), 1.0, ScheduleConfidence.HIGH, true);
+  @Test
+  void testFireAuthorizedWithLargeMargin() {
+    FireAuthorization fa = FireAuthorization.getInstance();
+    fa.update(activeInfoSimple(20.0), 1.0, ScheduleConfidence.HIGH, true);
 
-        assertEquals(AuthorizationLevel.FIRE_AUTHORIZED, fa.getLevel());
-        assertTrue(fa.isAuthorized());
-        assertTrue(fa.getMargin() > 10);
-    }
+    assertEquals(AuthorizationLevel.FIRE_AUTHORIZED, fa.getLevel());
+    assertTrue(fa.isAuthorized());
+    assertTrue(fa.getMargin() > 10);
+  }
 
-    @Test
-    void testFireAuthorizedExactBoundary() {
-        FireAuthorization fa = FireAuthorization.getInstance();
-        double tof = 1.0;
-        double windowRemaining = SAFE_MARGIN + tof + AVG_FUEL_DELAY;
-        fa.update(activeInfoSimple(windowRemaining), tof, ScheduleConfidence.HIGH, true);
+  @Test
+  void testFireAuthorizedExactBoundary() {
+    FireAuthorization fa = FireAuthorization.getInstance();
+    double tof = 1.0;
+    double windowRemaining = SAFE_MARGIN + tof + AVG_FUEL_DELAY;
+    fa.update(activeInfoSimple(windowRemaining), tof, ScheduleConfidence.HIGH, true);
 
-        assertEquals(
-                AuthorizationLevel.FIRE_AUTHORIZED,
-                fa.getLevel(),
-                "Exact safe margin boundary (margin=0.5) must be FIRE_AUTHORIZED, not"
-                    + " FIRE_MARGINAL");
-        assertEquals(SAFE_MARGIN, fa.getMargin(), 0.001);
-    }
+    assertEquals(
+        AuthorizationLevel.FIRE_AUTHORIZED,
+        fa.getLevel(),
+        "Exact safe margin boundary (margin=0.5) must be FIRE_AUTHORIZED, not" + " FIRE_MARGINAL");
+    assertEquals(SAFE_MARGIN, fa.getMargin(), 0.001);
+  }
 
-    @Test
-    void testFireMarginalInsideExtensionZone() {
-        FireAuthorization fa = FireAuthorization.getInstance();
-        fa.update(activeInfoSimple(2.0), 1.0, ScheduleConfidence.HIGH, true);
+  @Test
+  void testFireMarginalInsideExtensionZone() {
+    FireAuthorization fa = FireAuthorization.getInstance();
+    fa.update(activeInfoSimple(2.0), 1.0, ScheduleConfidence.HIGH, true);
 
-        assertEquals(AuthorizationLevel.FIRE_MARGINAL, fa.getLevel());
-        assertTrue(fa.isAuthorized(), "FIRE_MARGINAL should still be authorized");
-    }
+    assertEquals(AuthorizationLevel.FIRE_MARGINAL, fa.getLevel());
+    assertTrue(fa.isAuthorized(), "FIRE_MARGINAL should still be authorized");
+  }
 
-    @Test
-    void testExtensionBoundaryExact() {
-        FireAuthorization fa = FireAuthorization.getInstance();
-        // margin = 0.5 - (2.0 + 1.5) = -3.0
-        fa.update(activeInfoSimple(0.5), 2.0, ScheduleConfidence.HIGH, true);
+  @Test
+  void testExtensionBoundaryExact() {
+    FireAuthorization fa = FireAuthorization.getInstance();
+    // margin = 0.5 - (2.0 + 1.5) = -3.0
+    fa.update(activeInfoSimple(0.5), 2.0, ScheduleConfidence.HIGH, true);
 
-        assertEquals(-EXTENSION, fa.getMargin(), 0.001, "margin should be exactly -extension");
-        assertEquals(
-                AuthorizationLevel.HOLD_TIMING,
-                fa.getLevel(),
-                "At exact extension boundary, must be HOLD_TIMING not FIRE_MARGINAL");
-        assertFalse(fa.isAuthorized());
-    }
+    assertEquals(-EXTENSION, fa.getMargin(), 0.001, "margin should be exactly -extension");
+    assertEquals(
+        AuthorizationLevel.HOLD_TIMING,
+        fa.getLevel(),
+        "At exact extension boundary, must be HOLD_TIMING not FIRE_MARGINAL");
+    assertFalse(fa.isAuthorized());
+  }
 
-    @Test
-    void testHoldTimingWhenPastExtension() {
-        FireAuthorization fa = FireAuthorization.getInstance();
-        fa.update(activeInfoSimple(0.0), 2.0, ScheduleConfidence.HIGH, true);
+  @Test
+  void testHoldTimingWhenPastExtension() {
+    FireAuthorization fa = FireAuthorization.getInstance();
+    fa.update(activeInfoSimple(0.0), 2.0, ScheduleConfidence.HIGH, true);
 
-        assertEquals(AuthorizationLevel.HOLD_TIMING, fa.getLevel());
-        assertFalse(fa.isAuthorized());
-    }
+    assertEquals(AuthorizationLevel.HOLD_TIMING, fa.getLevel());
+    assertFalse(fa.isAuthorized());
+  }
 
-    @Test
-    void testPreSpinWhenWindowApproaching() {
-        FireAuthorization fa = FireAuthorization.getInstance();
-        fa.update(inactiveInfo(2.0), 1.0, ScheduleConfidence.HIGH, true);
+  @Test
+  void testPreSpinWhenWindowApproaching() {
+    FireAuthorization fa = FireAuthorization.getInstance();
+    fa.update(inactiveInfo(2.0), 1.0, ScheduleConfidence.HIGH, true);
 
-        assertEquals(AuthorizationLevel.PRE_SPIN, fa.getLevel());
-        assertTrue(fa.isPreSpin());
-        assertFalse(fa.isAuthorized());
-    }
+    assertEquals(AuthorizationLevel.PRE_SPIN, fa.getLevel());
+    assertTrue(fa.isPreSpin());
+    assertFalse(fa.isAuthorized());
+  }
 
-    @Test
-    void testPreSpinBoundaryExact() {
-        FireAuthorization fa = FireAuthorization.getInstance();
-        fa.update(inactiveInfo(PRE_SPIN_WINDOW), 1.0, ScheduleConfidence.HIGH, true);
+  @Test
+  void testPreSpinBoundaryExact() {
+    FireAuthorization fa = FireAuthorization.getInstance();
+    fa.update(inactiveInfo(PRE_SPIN_WINDOW), 1.0, ScheduleConfidence.HIGH, true);
 
-        assertEquals(
-                AuthorizationLevel.PRE_SPIN,
-                fa.getLevel(),
-                "At exact preSpinWindow (3.0s), must be PRE_SPIN not HOLD_INACTIVE");
-        assertTrue(fa.isPreSpin());
-    }
+    assertEquals(
+        AuthorizationLevel.PRE_SPIN,
+        fa.getLevel(),
+        "At exact preSpinWindow (3.0s), must be PRE_SPIN not HOLD_INACTIVE");
+    assertTrue(fa.isPreSpin());
+  }
 
-    @Test
-    void testPreSpinJustOverBoundary() {
-        FireAuthorization fa = FireAuthorization.getInstance();
-        fa.update(inactiveInfo(PRE_SPIN_WINDOW + 0.001), 1.0, ScheduleConfidence.HIGH, true);
+  @Test
+  void testPreSpinJustOverBoundary() {
+    FireAuthorization fa = FireAuthorization.getInstance();
+    fa.update(inactiveInfo(PRE_SPIN_WINDOW + 0.001), 1.0, ScheduleConfidence.HIGH, true);
 
-        assertEquals(
-                AuthorizationLevel.HOLD_INACTIVE,
-                fa.getLevel(),
-                "timeToActive=3.001 > preSpinWindow=3.0 -> HOLD_INACTIVE");
-        assertFalse(fa.isPreSpin());
-    }
+    assertEquals(
+        AuthorizationLevel.HOLD_INACTIVE,
+        fa.getLevel(),
+        "timeToActive=3.001 > preSpinWindow=3.0 -> HOLD_INACTIVE");
+    assertFalse(fa.isPreSpin());
+  }
 
-    @Test
-    void testTimeToActiveZeroIsHoldInactive() {
-        FireAuthorization fa = FireAuthorization.getInstance();
-        fa.update(inactiveInfo(0.0), 1.0, ScheduleConfidence.HIGH, true);
+  @Test
+  void testTimeToActiveZeroIsHoldInactive() {
+    FireAuthorization fa = FireAuthorization.getInstance();
+    fa.update(inactiveInfo(0.0), 1.0, ScheduleConfidence.HIGH, true);
 
-        assertEquals(
-                AuthorizationLevel.HOLD_INACTIVE,
-                fa.getLevel(),
-                "timeToActive=0 must be HOLD_INACTIVE (> 0 guard), not PRE_SPIN");
-        assertFalse(fa.isPreSpin());
-    }
+    assertEquals(
+        AuthorizationLevel.HOLD_INACTIVE,
+        fa.getLevel(),
+        "timeToActive=0 must be HOLD_INACTIVE (> 0 guard), not PRE_SPIN");
+    assertFalse(fa.isPreSpin());
+  }
 
-    @Test
-    void testHoldInactiveWhenFarFromWindow() {
-        FireAuthorization fa = FireAuthorization.getInstance();
-        fa.update(inactiveInfo(15.0), 1.0, ScheduleConfidence.HIGH, true);
+  @Test
+  void testHoldInactiveWhenFarFromWindow() {
+    FireAuthorization fa = FireAuthorization.getInstance();
+    fa.update(inactiveInfo(15.0), 1.0, ScheduleConfidence.HIGH, true);
 
-        assertEquals(AuthorizationLevel.HOLD_INACTIVE, fa.getLevel());
-        assertFalse(fa.isAuthorized());
-        assertFalse(fa.isPreSpin());
-    }
+    assertEquals(AuthorizationLevel.HOLD_INACTIVE, fa.getLevel());
+    assertFalse(fa.isAuthorized());
+    assertFalse(fa.isPreSpin());
+  }
 
-    @Test
-    void testInactiveWindowRemainingIsZero() {
-        FireAuthorization fa = FireAuthorization.getInstance();
-        fa.update(activeInfoSimple(20.0), 1.0, ScheduleConfidence.HIGH, true);
-        assertEquals(
-                20.0, fa.getWindowRemaining(), 0.01, "Precondition: windowRemaining set to 20");
+  @Test
+  void testInactiveWindowRemainingIsZero() {
+    FireAuthorization fa = FireAuthorization.getInstance();
+    fa.update(activeInfoSimple(20.0), 1.0, ScheduleConfidence.HIGH, true);
+    assertEquals(20.0, fa.getWindowRemaining(), 0.01, "Precondition: windowRemaining set to 20");
 
-        fa.update(inactiveInfo(5.0), 1.0, ScheduleConfidence.HIGH, true);
-        assertEquals(
-                0.0,
-                fa.getWindowRemaining(),
-                0.001,
-                "Inactive hub must set windowRemaining to 0, not carry over previous value");
-    }
+    fa.update(inactiveInfo(5.0), 1.0, ScheduleConfidence.HIGH, true);
+    assertEquals(
+        0.0,
+        fa.getWindowRemaining(),
+        0.001,
+        "Inactive hub must set windowRemaining to 0, not carry over previous value");
+  }
 
-    @Test
-    void testFallbackConfidenceWidensMargin() {
-        FireAuthorization fa = FireAuthorization.getInstance();
-        // margin = 3.0 - (1.0+1.5) = 0.5, but FALLBACK adds 1.0 to safe margin -> 0.5 < 1.5 ->
-        // MARGINAL
-        fa.update(activeInfoSimple(3.0), 1.0, ScheduleConfidence.FALLBACK, true);
+  @Test
+  void testFallbackConfidenceWidensMargin() {
+    FireAuthorization fa = FireAuthorization.getInstance();
+    // margin = 3.0 - (1.0+1.5) = 0.5, but FALLBACK adds 1.0 to safe margin -> 0.5 < 1.5 ->
+    // MARGINAL
+    fa.update(activeInfoSimple(3.0), 1.0, ScheduleConfidence.FALLBACK, true);
 
-        assertEquals(AuthorizationLevel.FIRE_MARGINAL, fa.getLevel());
-        assertTrue(fa.isAuthorized(), "FIRE_MARGINAL should still authorize");
-    }
+    assertEquals(AuthorizationLevel.FIRE_MARGINAL, fa.getLevel());
+    assertTrue(fa.isAuthorized(), "FIRE_MARGINAL should still authorize");
+  }
 
-    @Test
-    void testHighConfidenceSameConditionIsAuthorized() {
-        FireAuthorization fa = FireAuthorization.getInstance();
-        fa.update(activeInfoSimple(3.0), 1.0, ScheduleConfidence.HIGH, true);
+  @Test
+  void testHighConfidenceSameConditionIsAuthorized() {
+    FireAuthorization fa = FireAuthorization.getInstance();
+    fa.update(activeInfoSimple(3.0), 1.0, ScheduleConfidence.HIGH, true);
 
-        assertEquals(AuthorizationLevel.FIRE_AUTHORIZED, fa.getLevel());
-    }
+    assertEquals(AuthorizationLevel.FIRE_AUTHORIZED, fa.getLevel());
+  }
 
-    @Test
-    void testBallLandingTimeComputation() {
-        FireAuthorization fa = FireAuthorization.getInstance();
-        fa.update(activeInfoSimple(20.0), 1.2, ScheduleConfidence.HIGH, true);
+  @Test
+  void testBallLandingTimeComputation() {
+    FireAuthorization fa = FireAuthorization.getInstance();
+    fa.update(activeInfoSimple(20.0), 1.2, ScheduleConfidence.HIGH, true);
 
-        assertEquals(2.7, fa.getBallLandingTime(), 0.01);
-    }
+    assertEquals(2.7, fa.getBallLandingTime(), 0.01);
+  }
 
-    @Test
-    void testWindowRemainingUsesTimeUntilDeactivation() {
-        FireAuthorization fa = FireAuthorization.getInstance();
-        double remainingInState = 8.0;
-        double timeUntilDeactivation = 12.5;
-        fa.update(
-                activeInfo(remainingInState, timeUntilDeactivation),
-                1.0,
-                ScheduleConfidence.HIGH,
-                true);
+  @Test
+  void testWindowRemainingUsesTimeUntilDeactivation() {
+    FireAuthorization fa = FireAuthorization.getInstance();
+    double remainingInState = 8.0;
+    double timeUntilDeactivation = 12.5;
+    fa.update(
+        activeInfo(remainingInState, timeUntilDeactivation), 1.0, ScheduleConfidence.HIGH, true);
 
-        assertEquals(
-                timeUntilDeactivation,
-                fa.getWindowRemaining(),
-                0.01,
-                "windowRemaining must use timeUntilDeactivation (12.5), not remainingInState"
-                    + " (8.0)");
-    }
+    assertEquals(
+        timeUntilDeactivation,
+        fa.getWindowRemaining(),
+        0.01,
+        "windowRemaining must use timeUntilDeactivation (12.5), not remainingInState" + " (8.0)");
+  }
 
-    @Test
-    void testTransitionAlwaysActive() {
-        FireAuthorization fa = FireAuthorization.getInstance();
-        ShiftInfo transitionInfo = new ShiftInfo(ShiftPhase.TRANSITION, true, 3.0, 7.0, 0, 7.0);
-        fa.update(transitionInfo, 1.0, ScheduleConfidence.HIGH, true);
+  @Test
+  void testTransitionAlwaysActive() {
+    FireAuthorization fa = FireAuthorization.getInstance();
+    ShiftInfo transitionInfo = new ShiftInfo(ShiftPhase.TRANSITION, true, 3.0, 7.0, 0, 7.0);
+    fa.update(transitionInfo, 1.0, ScheduleConfidence.HIGH, true);
 
-        assertEquals(AuthorizationLevel.FIRE_AUTHORIZED, fa.getLevel());
-        assertTrue(fa.isAuthorized());
-    }
+    assertEquals(AuthorizationLevel.FIRE_AUTHORIZED, fa.getLevel());
+    assertTrue(fa.isAuthorized());
+  }
 
-    @Test
-    void testEndgameAlwaysActive() {
-        FireAuthorization fa = FireAuthorization.getInstance();
-        ShiftInfo endgameInfo = new ShiftInfo(ShiftPhase.ENDGAME, true, 10.0, 20.0, 0, 20.0);
-        fa.update(endgameInfo, 1.0, ScheduleConfidence.HIGH, true);
+  @Test
+  void testEndgameAlwaysActive() {
+    FireAuthorization fa = FireAuthorization.getInstance();
+    ShiftInfo endgameInfo = new ShiftInfo(ShiftPhase.ENDGAME, true, 10.0, 20.0, 0, 20.0);
+    fa.update(endgameInfo, 1.0, ScheduleConfidence.HIGH, true);
 
-        assertEquals(AuthorizationLevel.FIRE_AUTHORIZED, fa.getLevel());
-        assertTrue(fa.isAuthorized());
-    }
+    assertEquals(AuthorizationLevel.FIRE_AUTHORIZED, fa.getLevel());
+    assertTrue(fa.isAuthorized());
+  }
 
-    @Test
-    void testStateTransitionActiveToInactive() {
-        FireAuthorization fa = FireAuthorization.getInstance();
+  @Test
+  void testStateTransitionActiveToInactive() {
+    FireAuthorization fa = FireAuthorization.getInstance();
 
-        fa.update(activeInfoSimple(20.0), 1.0, ScheduleConfidence.HIGH, true);
-        assertTrue(fa.isAuthorized());
+    fa.update(activeInfoSimple(20.0), 1.0, ScheduleConfidence.HIGH, true);
+    assertTrue(fa.isAuthorized());
 
-        fa.update(inactiveInfo(5.0), 1.0, ScheduleConfidence.HIGH, true);
-        assertFalse(fa.isAuthorized(), "Should not be authorized after switching to inactive");
-        assertEquals(0.0, fa.getWindowRemaining(), 0.001);
-    }
+    fa.update(inactiveInfo(5.0), 1.0, ScheduleConfidence.HIGH, true);
+    assertFalse(fa.isAuthorized(), "Should not be authorized after switching to inactive");
+    assertEquals(0.0, fa.getWindowRemaining(), 0.001);
+  }
 
-    @Test
-    void testKillSwitchToEnabledTransition() {
-        FireAuthorization fa = FireAuthorization.getInstance();
+  @Test
+  void testKillSwitchToEnabledTransition() {
+    FireAuthorization fa = FireAuthorization.getInstance();
 
-        fa.update(inactiveInfo(15.0), 1.0, ScheduleConfidence.HIGH, false);
-        assertEquals(Double.MAX_VALUE, fa.getMargin());
+    fa.update(inactiveInfo(15.0), 1.0, ScheduleConfidence.HIGH, false);
+    assertEquals(Double.MAX_VALUE, fa.getMargin());
 
-        fa.update(inactiveInfo(2.0), 1.0, ScheduleConfidence.HIGH, true);
-        assertNotEquals(Double.MAX_VALUE, fa.getMargin());
-        assertEquals(AuthorizationLevel.PRE_SPIN, fa.getLevel());
-    }
+    fa.update(inactiveInfo(2.0), 1.0, ScheduleConfidence.HIGH, true);
+    assertNotEquals(Double.MAX_VALUE, fa.getMargin());
+    assertEquals(AuthorizationLevel.PRE_SPIN, fa.getLevel());
+  }
 }

--- a/src/test/java/frc/robot/util/HubShiftEngineTest.java
+++ b/src/test/java/frc/robot/util/HubShiftEngineTest.java
@@ -6,485 +6,472 @@ import edu.wpi.first.hal.HAL;
 import edu.wpi.first.networktables.NetworkTableInstance;
 import edu.wpi.first.wpilibj.simulation.DriverStationSim;
 import edu.wpi.first.wpilibj.simulation.SimHooks;
-
 import frc.robot.util.HubShiftEngine.ScheduleConfidence;
 import frc.robot.util.HubShiftEngine.ShiftInfo;
 import frc.robot.util.HubShiftEngine.ShiftPhase;
-
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class HubShiftEngineTest {
 
-    @BeforeEach
-    void setUp() {
-        HAL.initialize(500, 0);
-        NetworkTableInstance.getDefault().startLocal();
-        HubShiftEngine.resetInstance();
-        FireAuthorization.resetInstance();
-        SimHooks.pauseTiming();
+  @BeforeEach
+  void setUp() {
+    HAL.initialize(500, 0);
+    NetworkTableInstance.getDefault().startLocal();
+    HubShiftEngine.resetInstance();
+    FireAuthorization.resetInstance();
+    SimHooks.pauseTiming();
+  }
+
+  @AfterEach
+  void tearDown() {
+    SimHooks.resumeTiming();
+  }
+
+  private void enterTeleop() {
+    DriverStationSim.setAutonomous(false);
+    DriverStationSim.setEnabled(true);
+    DriverStationSim.notifyNewData();
+  }
+
+  private void advanceAndUpdate(HubShiftEngine engine, double seconds, double tof) {
+    SimHooks.stepTiming(seconds);
+    engine.update(tof);
+  }
+
+  @Test
+  void testInitialStateIsDisabled() {
+    HubShiftEngine engine = HubShiftEngine.getInstance();
+    ShiftInfo info = engine.getOfficialInfo();
+    assertEquals(ShiftPhase.DISABLED, info.phase());
+    assertTrue(info.hubActive(), "Hub should be active when disabled (safe default)");
+  }
+
+  @Test
+  void testAutoPhaseIsActive() {
+    HubShiftEngine engine = HubShiftEngine.getInstance();
+    DriverStationSim.setAutonomous(true);
+    DriverStationSim.setEnabled(true);
+    DriverStationSim.notifyNewData();
+    engine.update(0);
+
+    ShiftInfo info = engine.getOfficialInfo();
+    assertEquals(ShiftPhase.AUTO, info.phase());
+    assertTrue(info.hubActive(), "Both hubs active during auto");
+  }
+
+  @Test
+  void testUpdateWithoutInitReturnsDisabledEvenInTeleop() {
+    HubShiftEngine engine = HubShiftEngine.getInstance();
+    enterTeleop();
+    engine.update(1.0);
+
+    assertEquals(
+        ShiftPhase.DISABLED,
+        engine.getOfficialInfo().phase(),
+        "Without initializeTeleop(), must stay DISABLED even if DS says teleop");
+    assertTrue(
+        engine.getOfficialInfo().hubActive(), "DISABLED state must be hub-active (safe fail-open)");
+  }
+
+  @Test
+  void testFeatureEnabledDefault() {
+    HubShiftEngine engine = HubShiftEngine.getInstance();
+    assertTrue(engine.isFeatureEnabled(), "Feature should be enabled by default");
+    assertTrue(engine.isHubTrackingEnabled(), "Tracking should be enabled by default");
+  }
+
+  @Test
+  void testGetTeleopElapsed() {
+    HubShiftEngine engine = HubShiftEngine.getInstance();
+    assertEquals(0, engine.getTeleopElapsed(), "Should be 0 before teleop init");
+    enterTeleop();
+    engine.initializeTeleop();
+    SimHooks.stepTiming(5.0);
+    assertTrue(engine.getTeleopElapsed() >= 4.5, "Should reflect elapsed time");
+  }
+
+  @Test
+  void testWonAutoShift1Inactive() {
+    HubShiftEngine engine = HubShiftEngine.getInstance();
+    engine.setWonAutoOverride(true);
+    enterTeleop();
+    engine.initializeTeleop();
+
+    advanceAndUpdate(engine, 15.0, 0);
+
+    ShiftInfo info = engine.getOfficialInfo();
+    assertEquals(ShiftPhase.SHIFT1, info.phase(), "Should be in SHIFT1 at 15s");
+    assertFalse(
+        info.hubActive(), "Won auto -> SHIFT1 must be INACTIVE (our first inactive window)");
+  }
+
+  @Test
+  void testWonAutoShift2Active() {
+    HubShiftEngine engine = HubShiftEngine.getInstance();
+    engine.setWonAutoOverride(true);
+    enterTeleop();
+    engine.initializeTeleop();
+
+    advanceAndUpdate(engine, 40.0, 0);
+
+    ShiftInfo info = engine.getOfficialInfo();
+    assertEquals(ShiftPhase.SHIFT2, info.phase(), "Should be in SHIFT2 at 40s");
+    assertTrue(info.hubActive(), "Won auto -> SHIFT2 must be ACTIVE (our second active window)");
+  }
+
+  @Test
+  void testLostAutoShift1Active() {
+    HubShiftEngine engine = HubShiftEngine.getInstance();
+    engine.setWonAutoOverride(false);
+    enterTeleop();
+    engine.initializeTeleop();
+
+    advanceAndUpdate(engine, 15.0, 0);
+
+    ShiftInfo info = engine.getOfficialInfo();
+    assertEquals(ShiftPhase.SHIFT1, info.phase());
+    assertTrue(
+        info.hubActive(), "Lost auto -> SHIFT1 must be ACTIVE (compensates for losing auto)");
+  }
+
+  @Test
+  void testLostAutoShift2Inactive() {
+    HubShiftEngine engine = HubShiftEngine.getInstance();
+    engine.setWonAutoOverride(false);
+    enterTeleop();
+    engine.initializeTeleop();
+
+    advanceAndUpdate(engine, 40.0, 0);
+
+    ShiftInfo info = engine.getOfficialInfo();
+    assertEquals(ShiftPhase.SHIFT2, info.phase());
+    assertFalse(info.hubActive(), "Lost auto -> SHIFT2 must be INACTIVE");
+  }
+
+  @Test
+  void testWonScheduleFullPattern() {
+    HubShiftEngine engine = HubShiftEngine.getInstance();
+    engine.setWonAutoOverride(true);
+    enterTeleop();
+    engine.initializeTeleop();
+
+    boolean[] expected = {true, false, true, false, true, true};
+    double[] midpoints = {5.0, 22.0, 47.0, 72.0, 97.0, 125.0};
+    ShiftPhase[] phases = {
+      ShiftPhase.TRANSITION, ShiftPhase.SHIFT1, ShiftPhase.SHIFT2,
+      ShiftPhase.SHIFT3, ShiftPhase.SHIFT4, ShiftPhase.ENDGAME
+    };
+
+    for (int i = 0; i < expected.length; i++) {
+      HubShiftEngine.resetInstance();
+      FireAuthorization.resetInstance();
+      engine = HubShiftEngine.getInstance();
+      engine.setWonAutoOverride(true);
+      enterTeleop();
+      engine.initializeTeleop();
+      advanceAndUpdate(engine, midpoints[i], 0);
+
+      ShiftInfo info = engine.getOfficialInfo();
+      assertEquals(
+          phases[i], info.phase(), "Phase at " + midpoints[i] + "s should be " + phases[i]);
+      assertEquals(
+          expected[i],
+          info.hubActive(),
+          "Won schedule: hubActive at " + phases[i] + " should be " + expected[i]);
     }
-
-    @AfterEach
-    void tearDown() {
-        SimHooks.resumeTiming();
-    }
-
-    private void enterTeleop() {
-        DriverStationSim.setAutonomous(false);
-        DriverStationSim.setEnabled(true);
-        DriverStationSim.notifyNewData();
-    }
-
-    private void advanceAndUpdate(HubShiftEngine engine, double seconds, double tof) {
-        SimHooks.stepTiming(seconds);
-        engine.update(tof);
-    }
-
-    @Test
-    void testInitialStateIsDisabled() {
-        HubShiftEngine engine = HubShiftEngine.getInstance();
-        ShiftInfo info = engine.getOfficialInfo();
-        assertEquals(ShiftPhase.DISABLED, info.phase());
-        assertTrue(info.hubActive(), "Hub should be active when disabled (safe default)");
-    }
-
-    @Test
-    void testAutoPhaseIsActive() {
-        HubShiftEngine engine = HubShiftEngine.getInstance();
-        DriverStationSim.setAutonomous(true);
-        DriverStationSim.setEnabled(true);
-        DriverStationSim.notifyNewData();
-        engine.update(0);
-
-        ShiftInfo info = engine.getOfficialInfo();
-        assertEquals(ShiftPhase.AUTO, info.phase());
-        assertTrue(info.hubActive(), "Both hubs active during auto");
-    }
-
-    @Test
-    void testUpdateWithoutInitReturnsDisabledEvenInTeleop() {
-        HubShiftEngine engine = HubShiftEngine.getInstance();
-        enterTeleop();
-        engine.update(1.0);
-
-        assertEquals(
-                ShiftPhase.DISABLED,
-                engine.getOfficialInfo().phase(),
-                "Without initializeTeleop(), must stay DISABLED even if DS says teleop");
-        assertTrue(
-                engine.getOfficialInfo().hubActive(),
-                "DISABLED state must be hub-active (safe fail-open)");
-    }
-
-    @Test
-    void testFeatureEnabledDefault() {
-        HubShiftEngine engine = HubShiftEngine.getInstance();
-        assertTrue(engine.isFeatureEnabled(), "Feature should be enabled by default");
-        assertTrue(engine.isHubTrackingEnabled(), "Tracking should be enabled by default");
-    }
-
-    @Test
-    void testGetTeleopElapsed() {
-        HubShiftEngine engine = HubShiftEngine.getInstance();
-        assertEquals(0, engine.getTeleopElapsed(), "Should be 0 before teleop init");
-        enterTeleop();
-        engine.initializeTeleop();
-        SimHooks.stepTiming(5.0);
-        assertTrue(engine.getTeleopElapsed() >= 4.5, "Should reflect elapsed time");
-    }
-
-    @Test
-    void testWonAutoShift1Inactive() {
-        HubShiftEngine engine = HubShiftEngine.getInstance();
-        engine.setWonAutoOverride(true);
-        enterTeleop();
-        engine.initializeTeleop();
-
-        advanceAndUpdate(engine, 15.0, 0);
-
-        ShiftInfo info = engine.getOfficialInfo();
-        assertEquals(ShiftPhase.SHIFT1, info.phase(), "Should be in SHIFT1 at 15s");
-        assertFalse(
-                info.hubActive(),
-                "Won auto -> SHIFT1 must be INACTIVE (our first inactive window)");
-    }
-
-    @Test
-    void testWonAutoShift2Active() {
-        HubShiftEngine engine = HubShiftEngine.getInstance();
-        engine.setWonAutoOverride(true);
-        enterTeleop();
-        engine.initializeTeleop();
-
-        advanceAndUpdate(engine, 40.0, 0);
-
-        ShiftInfo info = engine.getOfficialInfo();
-        assertEquals(ShiftPhase.SHIFT2, info.phase(), "Should be in SHIFT2 at 40s");
-        assertTrue(
-                info.hubActive(), "Won auto -> SHIFT2 must be ACTIVE (our second active window)");
-    }
-
-    @Test
-    void testLostAutoShift1Active() {
-        HubShiftEngine engine = HubShiftEngine.getInstance();
-        engine.setWonAutoOverride(false);
-        enterTeleop();
-        engine.initializeTeleop();
-
-        advanceAndUpdate(engine, 15.0, 0);
-
-        ShiftInfo info = engine.getOfficialInfo();
-        assertEquals(ShiftPhase.SHIFT1, info.phase());
-        assertTrue(
-                info.hubActive(),
-                "Lost auto -> SHIFT1 must be ACTIVE (compensates for losing auto)");
-    }
-
-    @Test
-    void testLostAutoShift2Inactive() {
-        HubShiftEngine engine = HubShiftEngine.getInstance();
-        engine.setWonAutoOverride(false);
-        enterTeleop();
-        engine.initializeTeleop();
-
-        advanceAndUpdate(engine, 40.0, 0);
-
-        ShiftInfo info = engine.getOfficialInfo();
-        assertEquals(ShiftPhase.SHIFT2, info.phase());
-        assertFalse(info.hubActive(), "Lost auto -> SHIFT2 must be INACTIVE");
-    }
-
-    @Test
-    void testWonScheduleFullPattern() {
-        HubShiftEngine engine = HubShiftEngine.getInstance();
-        engine.setWonAutoOverride(true);
-        enterTeleop();
-        engine.initializeTeleop();
-
-        boolean[] expected = {true, false, true, false, true, true};
-        double[] midpoints = {5.0, 22.0, 47.0, 72.0, 97.0, 125.0};
-        ShiftPhase[] phases = {
-            ShiftPhase.TRANSITION, ShiftPhase.SHIFT1, ShiftPhase.SHIFT2,
-            ShiftPhase.SHIFT3, ShiftPhase.SHIFT4, ShiftPhase.ENDGAME
-        };
-
-        for (int i = 0; i < expected.length; i++) {
-            HubShiftEngine.resetInstance();
-            FireAuthorization.resetInstance();
-            engine = HubShiftEngine.getInstance();
-            engine.setWonAutoOverride(true);
-            enterTeleop();
-            engine.initializeTeleop();
-            advanceAndUpdate(engine, midpoints[i], 0);
-
-            ShiftInfo info = engine.getOfficialInfo();
-            assertEquals(
-                    phases[i],
-                    info.phase(),
-                    "Phase at " + midpoints[i] + "s should be " + phases[i]);
-            assertEquals(
-                    expected[i],
-                    info.hubActive(),
-                    "Won schedule: hubActive at " + phases[i] + " should be " + expected[i]);
-        }
-    }
-
-    @Test
-    void testPhaseBoundaryExactTransitionToShift1() {
-        HubShiftEngine engine = HubShiftEngine.getInstance();
-        engine.setWonAutoOverride(false);
-        enterTeleop();
-        engine.initializeTeleop();
-
-        advanceAndUpdate(engine, 10.0, 0);
-
-        assertEquals(
-                ShiftPhase.SHIFT1,
-                engine.getOfficialInfo().phase(),
-                "At exactly 10.0s, should be SHIFT1 (inclusive lower bound)");
-    }
-
-    @Test
-    void testPhaseBoundaryJustBeforeShift1() {
-        HubShiftEngine engine = HubShiftEngine.getInstance();
-        engine.setWonAutoOverride(false);
-        enterTeleop();
-        engine.initializeTeleop();
-
-        advanceAndUpdate(engine, 9.99, 0);
-
-        assertEquals(
-                ShiftPhase.TRANSITION,
-                engine.getOfficialInfo().phase(),
-                "At 9.99s, should still be in TRANSITION");
-    }
-
-    @Test
-    void testPastEndgameFallsBackToEndgame() {
-        HubShiftEngine engine = HubShiftEngine.getInstance();
-        engine.setWonAutoOverride(true);
-        enterTeleop();
-        engine.initializeTeleop();
-
-        advanceAndUpdate(engine, 145.0, 0);
-
-        ShiftInfo info = engine.getOfficialInfo();
-        assertEquals(
-                ShiftPhase.ENDGAME,
-                info.phase(),
-                "Past 140s should still report ENDGAME (last phase fallback)");
-        assertTrue(info.hubActive(), "ENDGAME is always active for both schedules");
-    }
-
-    @Test
-    void testConsecutiveMergeRemainingInState() {
-        // LOST schedule: TRANSITION + SHIFT1 are both active, so remainingInState merges them
-        HubShiftEngine engine = HubShiftEngine.getInstance();
-        engine.setWonAutoOverride(false);
-        enterTeleop();
-        engine.initializeTeleop();
-
-        advanceAndUpdate(engine, 5.0, 0);
-
-        ShiftInfo info = engine.getOfficialInfo();
-        assertEquals(ShiftPhase.TRANSITION, info.phase());
-        assertTrue(info.hubActive());
-        assertEquals(
-                30.0,
-                info.remainingInState(),
-                0.5,
-                "LOST schedule: TRANSITION+SHIFT1 are both active, remainingInState merges to"
-                    + " SHIFT1_END");
-    }
-
-    @Test
-    void testTimeUntilDeactivationDuringActivePhase() {
-        // WON: TRANSITION(active, 0-10) then SHIFT1(inactive, 10-35)
-        HubShiftEngine engine = HubShiftEngine.getInstance();
-        engine.setWonAutoOverride(true);
-        enterTeleop();
-        engine.initializeTeleop();
-
-        advanceAndUpdate(engine, 5.0, 0);
-
-        ShiftInfo info = engine.getOfficialInfo();
-        assertTrue(info.hubActive());
-        assertEquals(
-                5.0,
-                info.timeUntilDeactivation(),
-                0.5,
-                "Active phase ending at 10s, elapsed 5s -> 5s until deactivation");
-    }
-
-    @Test
-    void testTimeToNextActiveDuringInactivePhase() {
-        // WON: SHIFT1(inactive, 10-35) then SHIFT2(active, 35-60)
-        HubShiftEngine engine = HubShiftEngine.getInstance();
-        engine.setWonAutoOverride(true);
-        enterTeleop();
-        engine.initializeTeleop();
-
-        advanceAndUpdate(engine, 20.0, 0);
-
-        ShiftInfo info = engine.getOfficialInfo();
-        assertFalse(info.hubActive(), "WON SHIFT1 should be inactive");
-        assertEquals(
-                15.0,
-                info.timeToNextActive(),
-                0.5,
-                "At 20s in inactive SHIFT1, next active starts at 35s -> 15s to go");
-    }
-
-    @Test
-    void testShiftedInfoWithZeroTOFFallsBackToOfficial() {
-        HubShiftEngine engine = HubShiftEngine.getInstance();
-        engine.setWonAutoOverride(true);
-        enterTeleop();
-        engine.initializeTeleop();
-
-        advanceAndUpdate(engine, 15.0, 0);
-
-        assertEquals(
-                engine.getOfficialInfo().hubActive(),
-                engine.getShiftedInfo().hubActive(),
-                "With TOF=0, shifted should equal official");
-        assertEquals(
-                engine.getOfficialInfo().phase(),
-                engine.getShiftedInfo().phase(),
-                "With TOF=0, shifted phase should equal official phase");
-    }
-
-    @Test
-    void testNegativeTOFClampedToZero() {
-        HubShiftEngine engine = HubShiftEngine.getInstance();
-        engine.setWonAutoOverride(true);
-        enterTeleop();
-        engine.initializeTeleop();
-
-        advanceAndUpdate(engine, 15.0, -5.0);
-
-        assertEquals(
-                engine.getOfficialInfo().hubActive(),
-                engine.getShiftedInfo().hubActive(),
-                "Negative TOF clamped to 0 -> no shift");
-    }
-
-    @Test
-    void testOverrideLocksScheduleThroughMultipleUpdates() {
-        HubShiftEngine engine = HubShiftEngine.getInstance();
-        engine.setWonAutoOverride(true);
-        enterTeleop();
-        engine.initializeTeleop();
-
-        advanceAndUpdate(engine, 5.0, 0);
-        assertTrue(engine.isWonAuto());
-        advanceAndUpdate(engine, 5.0, 0);
-        assertTrue(engine.isWonAuto());
-        assertEquals(ScheduleConfidence.LOW, engine.getConfidence());
-    }
-
-    @Test
-    void testGameDataMissingWhenFMSAttached() {
-        HubShiftEngine engine = HubShiftEngine.getInstance();
-        enterTeleop();
-        DriverStationSim.setFmsAttached(true);
-        DriverStationSim.notifyNewData();
-        engine.initializeTeleop();
-        engine.update(1.0);
-
-        assertTrue(
-                engine.isGameDataMissing(),
-                "FMS attached + no game data + no override + in transition -> missing");
-    }
-
-    @Test
-    void testGameDataNotMissingWithoutFMS() {
-        HubShiftEngine engine = HubShiftEngine.getInstance();
-        enterTeleop();
-        DriverStationSim.setFmsAttached(false);
-        DriverStationSim.notifyNewData();
-        engine.initializeTeleop();
-        engine.update(1.0);
-
-        assertFalse(
-                engine.isGameDataMissing(),
-                "No FMS -> game data missing should be false (this is practice)");
-    }
-
-    @Test
-    void testGameDataNotMissingWithOverride() {
-        HubShiftEngine engine = HubShiftEngine.getInstance();
-        engine.setWonAutoOverride(true);
-        enterTeleop();
-        DriverStationSim.setFmsAttached(true);
-        DriverStationSim.notifyNewData();
-        engine.initializeTeleop();
-        engine.update(1.0);
-
-        assertFalse(
-                engine.isGameDataMissing(),
-                "Copilot override set -> game data missing should be false (deliberate choice)");
-    }
-
-    @Test
-    void testGameDataNotMissingAfterTransition() {
-        HubShiftEngine engine = HubShiftEngine.getInstance();
-        enterTeleop();
-        DriverStationSim.setFmsAttached(true);
-        DriverStationSim.notifyNewData();
-        engine.initializeTeleop();
-
-        advanceAndUpdate(engine, 11.0, 1.0);
-
-        assertFalse(
-                engine.isGameDataMissing(),
-                "Past TRANSITION_END (10s), game data missing alert must stop");
-    }
-
-    @Test
-    void testFMSAttachedNoGameDataIsFallbackConfidence() {
-        HubShiftEngine engine = HubShiftEngine.getInstance();
-        enterTeleop();
-        DriverStationSim.setFmsAttached(true);
-        DriverStationSim.notifyNewData();
-        engine.initializeTeleop();
-        engine.update(1.0);
-
-        assertEquals(
-                ScheduleConfidence.FALLBACK,
-                engine.getConfidence(),
-                "FMS attached but no game data -> FALLBACK (50/50 guess)");
-    }
-
-    @Test
-    void testNonFMSIsLowConfidence() {
-        HubShiftEngine engine = HubShiftEngine.getInstance();
-        enterTeleop();
-        DriverStationSim.setFmsAttached(false);
-        DriverStationSim.notifyNewData();
-        engine.initializeTeleop();
-        engine.update(1.0);
-
-        assertEquals(
-                ScheduleConfidence.LOW,
-                engine.getConfidence(),
-                "Non-FMS (practice) -> LOW confidence (SmartDashboard path)");
-    }
-
-    @Test
-    void testCopilotOverrideSetsLowConfidence() {
-        HubShiftEngine engine = HubShiftEngine.getInstance();
-        engine.setWonAutoOverride(true);
-        assertEquals(ScheduleConfidence.LOW, engine.getConfidence());
-        assertTrue(engine.isWonAuto());
-    }
-
-    @Test
-    void testClearOverrideUnlocks() {
-        HubShiftEngine engine = HubShiftEngine.getInstance();
-        engine.setWonAutoOverride(true);
-        engine.clearWonAutoOverride();
-        enterTeleop();
-        engine.initializeTeleop();
-        engine.update(1.0);
-        assertNotEquals(
-                ScheduleConfidence.HIGH,
-                engine.getConfidence(),
-                "Without FMS data, should not be HIGH");
-    }
-
-    @Test
-    void testDefaultWonAutoIsFalse() {
-        HubShiftEngine engine = HubShiftEngine.getInstance();
-        enterTeleop();
-        DriverStationSim.setFmsAttached(false);
-        DriverStationSim.notifyNewData();
-        engine.initializeTeleop();
-        engine.update(1.0);
-
-        assertFalse(
-                engine.isWonAuto(), "Default wonAuto should be false (assume lost, conservative)");
-    }
-
-    @Test
-    void testDisabledTrackingMakesAllPhasesActive() {
-        HubShiftEngine engine = HubShiftEngine.getInstance();
-        engine.setWonAutoOverride(true);
-        enterTeleop();
-        engine.initializeTeleop();
-
-        edu.wpi.first.wpilibj.smartdashboard.SmartDashboard.putNumber(
-                "HubShift/TrackingEnabled", 0.0);
-
-        advanceAndUpdate(engine, 15.0, 0);
-
-        ShiftInfo info = engine.getOfficialInfo();
-        assertEquals(ShiftPhase.SHIFT1, info.phase(), "Phase detection still works");
-        assertTrue(
-                info.hubActive(),
-                "With hub tracking disabled, SHIFT1 must be active even though WON schedule says"
-                    + " inactive");
-    }
+  }
+
+  @Test
+  void testPhaseBoundaryExactTransitionToShift1() {
+    HubShiftEngine engine = HubShiftEngine.getInstance();
+    engine.setWonAutoOverride(false);
+    enterTeleop();
+    engine.initializeTeleop();
+
+    advanceAndUpdate(engine, 10.0, 0);
+
+    assertEquals(
+        ShiftPhase.SHIFT1,
+        engine.getOfficialInfo().phase(),
+        "At exactly 10.0s, should be SHIFT1 (inclusive lower bound)");
+  }
+
+  @Test
+  void testPhaseBoundaryJustBeforeShift1() {
+    HubShiftEngine engine = HubShiftEngine.getInstance();
+    engine.setWonAutoOverride(false);
+    enterTeleop();
+    engine.initializeTeleop();
+
+    advanceAndUpdate(engine, 9.99, 0);
+
+    assertEquals(
+        ShiftPhase.TRANSITION,
+        engine.getOfficialInfo().phase(),
+        "At 9.99s, should still be in TRANSITION");
+  }
+
+  @Test
+  void testPastEndgameFallsBackToEndgame() {
+    HubShiftEngine engine = HubShiftEngine.getInstance();
+    engine.setWonAutoOverride(true);
+    enterTeleop();
+    engine.initializeTeleop();
+
+    advanceAndUpdate(engine, 145.0, 0);
+
+    ShiftInfo info = engine.getOfficialInfo();
+    assertEquals(
+        ShiftPhase.ENDGAME,
+        info.phase(),
+        "Past 140s should still report ENDGAME (last phase fallback)");
+    assertTrue(info.hubActive(), "ENDGAME is always active for both schedules");
+  }
+
+  @Test
+  void testConsecutiveMergeRemainingInState() {
+    // LOST schedule: TRANSITION + SHIFT1 are both active, so remainingInState merges them
+    HubShiftEngine engine = HubShiftEngine.getInstance();
+    engine.setWonAutoOverride(false);
+    enterTeleop();
+    engine.initializeTeleop();
+
+    advanceAndUpdate(engine, 5.0, 0);
+
+    ShiftInfo info = engine.getOfficialInfo();
+    assertEquals(ShiftPhase.TRANSITION, info.phase());
+    assertTrue(info.hubActive());
+    assertEquals(
+        30.0,
+        info.remainingInState(),
+        0.5,
+        "LOST schedule: TRANSITION+SHIFT1 are both active, remainingInState merges to"
+            + " SHIFT1_END");
+  }
+
+  @Test
+  void testTimeUntilDeactivationDuringActivePhase() {
+    // WON: TRANSITION(active, 0-10) then SHIFT1(inactive, 10-35)
+    HubShiftEngine engine = HubShiftEngine.getInstance();
+    engine.setWonAutoOverride(true);
+    enterTeleop();
+    engine.initializeTeleop();
+
+    advanceAndUpdate(engine, 5.0, 0);
+
+    ShiftInfo info = engine.getOfficialInfo();
+    assertTrue(info.hubActive());
+    assertEquals(
+        5.0,
+        info.timeUntilDeactivation(),
+        0.5,
+        "Active phase ending at 10s, elapsed 5s -> 5s until deactivation");
+  }
+
+  @Test
+  void testTimeToNextActiveDuringInactivePhase() {
+    // WON: SHIFT1(inactive, 10-35) then SHIFT2(active, 35-60)
+    HubShiftEngine engine = HubShiftEngine.getInstance();
+    engine.setWonAutoOverride(true);
+    enterTeleop();
+    engine.initializeTeleop();
+
+    advanceAndUpdate(engine, 20.0, 0);
+
+    ShiftInfo info = engine.getOfficialInfo();
+    assertFalse(info.hubActive(), "WON SHIFT1 should be inactive");
+    assertEquals(
+        15.0,
+        info.timeToNextActive(),
+        0.5,
+        "At 20s in inactive SHIFT1, next active starts at 35s -> 15s to go");
+  }
+
+  @Test
+  void testShiftedInfoWithZeroTOFFallsBackToOfficial() {
+    HubShiftEngine engine = HubShiftEngine.getInstance();
+    engine.setWonAutoOverride(true);
+    enterTeleop();
+    engine.initializeTeleop();
+
+    advanceAndUpdate(engine, 15.0, 0);
+
+    assertEquals(
+        engine.getOfficialInfo().hubActive(),
+        engine.getShiftedInfo().hubActive(),
+        "With TOF=0, shifted should equal official");
+    assertEquals(
+        engine.getOfficialInfo().phase(),
+        engine.getShiftedInfo().phase(),
+        "With TOF=0, shifted phase should equal official phase");
+  }
+
+  @Test
+  void testNegativeTOFClampedToZero() {
+    HubShiftEngine engine = HubShiftEngine.getInstance();
+    engine.setWonAutoOverride(true);
+    enterTeleop();
+    engine.initializeTeleop();
+
+    advanceAndUpdate(engine, 15.0, -5.0);
+
+    assertEquals(
+        engine.getOfficialInfo().hubActive(),
+        engine.getShiftedInfo().hubActive(),
+        "Negative TOF clamped to 0 -> no shift");
+  }
+
+  @Test
+  void testOverrideLocksScheduleThroughMultipleUpdates() {
+    HubShiftEngine engine = HubShiftEngine.getInstance();
+    engine.setWonAutoOverride(true);
+    enterTeleop();
+    engine.initializeTeleop();
+
+    advanceAndUpdate(engine, 5.0, 0);
+    assertTrue(engine.isWonAuto());
+    advanceAndUpdate(engine, 5.0, 0);
+    assertTrue(engine.isWonAuto());
+    assertEquals(ScheduleConfidence.LOW, engine.getConfidence());
+  }
+
+  @Test
+  void testGameDataMissingWhenFMSAttached() {
+    HubShiftEngine engine = HubShiftEngine.getInstance();
+    enterTeleop();
+    DriverStationSim.setFmsAttached(true);
+    DriverStationSim.notifyNewData();
+    engine.initializeTeleop();
+    engine.update(1.0);
+
+    assertTrue(
+        engine.isGameDataMissing(),
+        "FMS attached + no game data + no override + in transition -> missing");
+  }
+
+  @Test
+  void testGameDataNotMissingWithoutFMS() {
+    HubShiftEngine engine = HubShiftEngine.getInstance();
+    enterTeleop();
+    DriverStationSim.setFmsAttached(false);
+    DriverStationSim.notifyNewData();
+    engine.initializeTeleop();
+    engine.update(1.0);
+
+    assertFalse(
+        engine.isGameDataMissing(),
+        "No FMS -> game data missing should be false (this is practice)");
+  }
+
+  @Test
+  void testGameDataNotMissingWithOverride() {
+    HubShiftEngine engine = HubShiftEngine.getInstance();
+    engine.setWonAutoOverride(true);
+    enterTeleop();
+    DriverStationSim.setFmsAttached(true);
+    DriverStationSim.notifyNewData();
+    engine.initializeTeleop();
+    engine.update(1.0);
+
+    assertFalse(
+        engine.isGameDataMissing(),
+        "Copilot override set -> game data missing should be false (deliberate choice)");
+  }
+
+  @Test
+  void testGameDataNotMissingAfterTransition() {
+    HubShiftEngine engine = HubShiftEngine.getInstance();
+    enterTeleop();
+    DriverStationSim.setFmsAttached(true);
+    DriverStationSim.notifyNewData();
+    engine.initializeTeleop();
+
+    advanceAndUpdate(engine, 11.0, 1.0);
+
+    assertFalse(
+        engine.isGameDataMissing(), "Past TRANSITION_END (10s), game data missing alert must stop");
+  }
+
+  @Test
+  void testFMSAttachedNoGameDataIsFallbackConfidence() {
+    HubShiftEngine engine = HubShiftEngine.getInstance();
+    enterTeleop();
+    DriverStationSim.setFmsAttached(true);
+    DriverStationSim.notifyNewData();
+    engine.initializeTeleop();
+    engine.update(1.0);
+
+    assertEquals(
+        ScheduleConfidence.FALLBACK,
+        engine.getConfidence(),
+        "FMS attached but no game data -> FALLBACK (50/50 guess)");
+  }
+
+  @Test
+  void testNonFMSIsLowConfidence() {
+    HubShiftEngine engine = HubShiftEngine.getInstance();
+    enterTeleop();
+    DriverStationSim.setFmsAttached(false);
+    DriverStationSim.notifyNewData();
+    engine.initializeTeleop();
+    engine.update(1.0);
+
+    assertEquals(
+        ScheduleConfidence.LOW,
+        engine.getConfidence(),
+        "Non-FMS (practice) -> LOW confidence (SmartDashboard path)");
+  }
+
+  @Test
+  void testCopilotOverrideSetsLowConfidence() {
+    HubShiftEngine engine = HubShiftEngine.getInstance();
+    engine.setWonAutoOverride(true);
+    assertEquals(ScheduleConfidence.LOW, engine.getConfidence());
+    assertTrue(engine.isWonAuto());
+  }
+
+  @Test
+  void testClearOverrideUnlocks() {
+    HubShiftEngine engine = HubShiftEngine.getInstance();
+    engine.setWonAutoOverride(true);
+    engine.clearWonAutoOverride();
+    enterTeleop();
+    engine.initializeTeleop();
+    engine.update(1.0);
+    assertNotEquals(
+        ScheduleConfidence.HIGH, engine.getConfidence(), "Without FMS data, should not be HIGH");
+  }
+
+  @Test
+  void testDefaultWonAutoIsFalse() {
+    HubShiftEngine engine = HubShiftEngine.getInstance();
+    enterTeleop();
+    DriverStationSim.setFmsAttached(false);
+    DriverStationSim.notifyNewData();
+    engine.initializeTeleop();
+    engine.update(1.0);
+
+    assertFalse(engine.isWonAuto(), "Default wonAuto should be false (assume lost, conservative)");
+  }
+
+  @Test
+  void testDisabledTrackingMakesAllPhasesActive() {
+    HubShiftEngine engine = HubShiftEngine.getInstance();
+    engine.setWonAutoOverride(true);
+    enterTeleop();
+    engine.initializeTeleop();
+
+    edu.wpi.first.wpilibj.smartdashboard.SmartDashboard.putNumber("HubShift/TrackingEnabled", 0.0);
+
+    advanceAndUpdate(engine, 15.0, 0);
+
+    ShiftInfo info = engine.getOfficialInfo();
+    assertEquals(ShiftPhase.SHIFT1, info.phase(), "Phase detection still works");
+    assertTrue(
+        info.hubActive(),
+        "With hub tracking disabled, SHIFT1 must be active even though WON schedule says"
+            + " inactive");
+  }
 }

--- a/src/test/java/frc/robot/util/SpatialLaunchValidatorTest.java
+++ b/src/test/java/frc/robot/util/SpatialLaunchValidatorTest.java
@@ -8,153 +8,144 @@ import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.math.geometry.Translation2d;
 import edu.wpi.first.wpilibj.simulation.DriverStationSim;
-
 import frc.robot.Constants.SpatialLaunchConstants;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class SpatialLaunchValidatorTest {
 
-    @BeforeEach
-    void setUp() {
-        HAL.initialize(500, 0);
-        DriverStationSim.setAllianceStationId(AllianceStationID.Blue1);
-        DriverStationSim.notifyNewData();
-    }
+  @BeforeEach
+  void setUp() {
+    HAL.initialize(500, 0);
+    DriverStationSim.setAllianceStationId(AllianceStationID.Blue1);
+    DriverStationSim.notifyNewData();
+  }
 
-    @Test
-    void openFieldIsValid() {
-        SpatialLaunchValidator.ValidationResult r =
-                SpatialLaunchValidator.validate(poseAt(2.0, 4.0));
-        assertTrue(r.isValid());
-        assertTrue(r.pathClear);
-        assertTrue(r.distanceValid);
-    }
+  @Test
+  void openFieldIsValid() {
+    SpatialLaunchValidator.ValidationResult r = SpatialLaunchValidator.validate(poseAt(2.0, 4.0));
+    assertTrue(r.isValid());
+    assertTrue(r.pathClear);
+    assertTrue(r.distanceValid);
+  }
 
-    @Test
-    void tooCloseToHubIsInvalid() {
-        SpatialLaunchValidator.ValidationResult r =
-                SpatialLaunchValidator.validate(poseAt(4.1, 4.0));
-        assertFalse(r.distanceValid);
-        assertFalse(r.isValid());
-    }
+  @Test
+  void tooCloseToHubIsInvalid() {
+    SpatialLaunchValidator.ValidationResult r = SpatialLaunchValidator.validate(poseAt(4.1, 4.0));
+    assertFalse(r.distanceValid);
+    assertFalse(r.isValid());
+  }
 
-    @Test
-    void exactlyAtMinDistanceIsValid() {
-        double hubX = 4.5974;
-        double hubY = 4.035;
-        double minDist = SpatialLaunchConstants.MIN_LAUNCH_DISTANCE_M;
-        SpatialLaunchValidator.ValidationResult r =
-                SpatialLaunchValidator.validate(poseAt(hubX - minDist, hubY));
-        assertTrue(r.distanceValid);
-    }
+  @Test
+  void exactlyAtMinDistanceIsValid() {
+    double hubX = 4.5974;
+    double hubY = 4.035;
+    double minDist = SpatialLaunchConstants.MIN_LAUNCH_DISTANCE_M;
+    SpatialLaunchValidator.ValidationResult r =
+        SpatialLaunchValidator.validate(poseAt(hubX - minDist, hubY));
+    assertTrue(r.distanceValid);
+  }
 
-    @Test
-    void trenchPillarBlocksPath() {
-        // blue near-side pillar is at X [3.96, 4.265], Y [1.265, 1.57]
-        // ray from (3.5, 0.0) to blue hub passes through the pillar
-        SpatialLaunchValidator.ValidationResult r =
-                SpatialLaunchValidator.validate(poseAt(3.5, 0.0));
-        assertFalse(r.pathClear);
-        assertFalse(r.isValid());
-    }
+  @Test
+  void trenchPillarBlocksPath() {
+    // blue near-side pillar is at X [3.96, 4.265], Y [1.265, 1.57]
+    // ray from (3.5, 0.0) to blue hub passes through the pillar
+    SpatialLaunchValidator.ValidationResult r = SpatialLaunchValidator.validate(poseAt(3.5, 0.0));
+    assertFalse(r.pathClear);
+    assertFalse(r.isValid());
+  }
 
-    @Test
-    void missedPillarIsValid() {
-        SpatialLaunchValidator.ValidationResult r =
-                SpatialLaunchValidator.validate(poseAt(2.5, 3.0));
-        assertTrue(r.pathClear);
-        assertTrue(r.isValid());
-    }
+  @Test
+  void missedPillarIsValid() {
+    SpatialLaunchValidator.ValidationResult r = SpatialLaunchValidator.validate(poseAt(2.5, 3.0));
+    assertTrue(r.pathClear);
+    assertTrue(r.isValid());
+  }
 
-    @Test
-    void redAlliancePillarBlocks() {
-        DriverStationSim.setAllianceStationId(AllianceStationID.Red1);
-        DriverStationSim.notifyNewData();
+  @Test
+  void redAlliancePillarBlocks() {
+    DriverStationSim.setAllianceStationId(AllianceStationID.Red1);
+    DriverStationSim.notifyNewData();
 
-        SpatialLaunchValidator.ValidationResult r =
-                SpatialLaunchValidator.validate(poseAt(13.0, 0.0));
-        assertFalse(r.pathClear);
-    }
+    SpatialLaunchValidator.ValidationResult r = SpatialLaunchValidator.validate(poseAt(13.0, 0.0));
+    assertFalse(r.pathClear);
+  }
 
-    @Test
-    void parallelRayMissesCorrectly() {
-        assertTrue(
-                SpatialLaunchValidator.isPathClear(
-                        new Translation2d(3.5, 4.0), new Translation2d(4.5974, 4.0)));
-    }
+  @Test
+  void parallelRayMissesCorrectly() {
+    assertTrue(
+        SpatialLaunchValidator.isPathClear(
+            new Translation2d(3.5, 4.0), new Translation2d(4.5974, 4.0)));
+  }
 
-    @Test
-    void segmentIntersectsAABBBasic() {
-        assertTrue(SpatialLaunchValidator.segmentIntersectsAABB(0, 0.5, 2, 0.5, 0.5, 0, 1.5, 1));
-        assertFalse(SpatialLaunchValidator.segmentIntersectsAABB(0, 2, 2, 2, 0.5, 0, 1.5, 1));
-    }
+  @Test
+  void segmentIntersectsAABBBasic() {
+    assertTrue(SpatialLaunchValidator.segmentIntersectsAABB(0, 0.5, 2, 0.5, 0.5, 0, 1.5, 1));
+    assertFalse(SpatialLaunchValidator.segmentIntersectsAABB(0, 2, 2, 2, 0.5, 0, 1.5, 1));
+  }
 
-    @Test
-    void distanceFieldIsPopulated() {
-        SpatialLaunchValidator.ValidationResult r =
-                SpatialLaunchValidator.validate(poseAt(2.0, 4.0));
-        assertTrue(r.distanceToHub > 0);
-        assertEquals(2.6256, r.distanceToHub, 0.01);
-    }
+  @Test
+  void distanceFieldIsPopulated() {
+    SpatialLaunchValidator.ValidationResult r = SpatialLaunchValidator.validate(poseAt(2.0, 4.0));
+    assertTrue(r.distanceToHub > 0);
+    assertEquals(2.6256, r.distanceToHub, 0.01);
+  }
 
-    @Test
-    void staticExclusionUnderTrench() {
-        assertTrue(SpatialLaunchValidator.isInExclusionZone(4.5, 2.5));
-    }
+  @Test
+  void staticExclusionUnderTrench() {
+    assertTrue(SpatialLaunchValidator.isInExclusionZone(4.5, 2.5));
+  }
 
-    @Test
-    void staticExclusionOpenField() {
-        assertFalse(SpatialLaunchValidator.isInExclusionZone(8.0, 4.0));
-    }
+  @Test
+  void staticExclusionOpenField() {
+    assertFalse(SpatialLaunchValidator.isInExclusionZone(8.0, 4.0));
+  }
 
-    @Test
-    void velocityBufferGrowsWithSpeed() {
-        double buffer = SpatialLaunchValidator.computeTrenchBuffer(4.0);
-        assertTrue(buffer > 0.5, "buffer should be at least 0.5m at 4 m/s");
-        assertEquals(1.0, buffer, 0.01);
-    }
+  @Test
+  void velocityBufferGrowsWithSpeed() {
+    double buffer = SpatialLaunchValidator.computeTrenchBuffer(4.0);
+    assertTrue(buffer > 0.5, "buffer should be at least 0.5m at 4 m/s");
+    assertEquals(1.0, buffer, 0.01);
+  }
 
-    @Test
-    void velocityBufferZeroWhenStationary() {
-        assertEquals(0.0, SpatialLaunchValidator.computeTrenchBuffer(0.0));
-    }
+  @Test
+  void velocityBufferZeroWhenStationary() {
+    assertEquals(0.0, SpatialLaunchValidator.computeTrenchBuffer(0.0));
+  }
 
-    @Test
-    void velocityBufferZeroWhenMovingAway() {
-        assertEquals(0.0, SpatialLaunchValidator.computeTrenchBuffer(-2.0));
-    }
+  @Test
+  void velocityBufferZeroWhenMovingAway() {
+    assertEquals(0.0, SpatialLaunchValidator.computeTrenchBuffer(-2.0));
+  }
 
-    @Test
-    void expandedZoneDetectsApproach() {
-        assertTrue(SpatialLaunchValidator.isInExpandedExclusionZone(3.5, 2.5, 2.0, 0.0));
-    }
+  @Test
+  void expandedZoneDetectsApproach() {
+    assertTrue(SpatialLaunchValidator.isInExpandedExclusionZone(3.5, 2.5, 2.0, 0.0));
+  }
 
-    @Test
-    void expandedZoneIgnoresSlowRobot() {
-        assertFalse(SpatialLaunchValidator.isInExpandedExclusionZone(3.5, 2.5, 0.05, 0.0));
-    }
+  @Test
+  void expandedZoneIgnoresSlowRobot() {
+    assertFalse(SpatialLaunchValidator.isInExpandedExclusionZone(3.5, 2.5, 0.05, 0.0));
+  }
 
-    @Test
-    void nearestTrenchDistanceInsideIsZero() {
-        assertEquals(0.0, SpatialLaunchValidator.getNearestTrenchDistM(4.5, 2.5), 0.01);
-    }
+  @Test
+  void nearestTrenchDistanceInsideIsZero() {
+    assertEquals(0.0, SpatialLaunchValidator.getNearestTrenchDistM(4.5, 2.5), 0.01);
+  }
 
-    @Test
-    void nearestTrenchDistanceOutsideIsPositive() {
-        assertTrue(SpatialLaunchValidator.getNearestTrenchDistM(8.0, 4.0) > 1.0);
-    }
+  @Test
+  void nearestTrenchDistanceOutsideIsPositive() {
+    assertTrue(SpatialLaunchValidator.getNearestTrenchDistM(8.0, 4.0) > 1.0);
+  }
 
-    @Test
-    void validationIncludesExclusionZone() {
-        SpatialLaunchValidator.ValidationResult r =
-                SpatialLaunchValidator.validate(poseAt(4.5, 2.5));
-        assertFalse(r.outsideExclusionZone);
-        assertFalse(r.isValid());
-    }
+  @Test
+  void validationIncludesExclusionZone() {
+    SpatialLaunchValidator.ValidationResult r = SpatialLaunchValidator.validate(poseAt(4.5, 2.5));
+    assertFalse(r.outsideExclusionZone);
+    assertFalse(r.isValid());
+  }
 
-    private static Pose2d poseAt(double x, double y) {
-        return new Pose2d(x, y, new Rotation2d());
-    }
+  private static Pose2d poseAt(double x, double y) {
+    return new Pose2d(x, y, new Rotation2d());
+  }
 }


### PR DESCRIPTION
Fixes #98

Right now ReadyToShoot is just 5 raw booleans ANDed together with a single debounce timer for the whole thing. If the shooter dips for one frame it kills the entire composite and you have to wait for the full debounce again even though vision and indexer were fine the whole time.

This adds a proper scoring pipeline with per-condition debounce, hub shift awareness, fire authorization, and trench exclusion zones.

New files:
  - HubShiftEngine: tracks the 4 hub shift windows during teleop. Reads auto winner from FMS game data, falls back to dashboard toggle for practice. Copilot can override via button
  - FireAuthorization: 5-level fire auth (AUTHORIZED, MARGINAL, PRE_SPIN, HOLD_TIMING, HOLD_INACTIVE) based on whether a shot fired right now would land while the hub is still counting
  - ScoringReadiness: the new ReadyToShoot composite. Each condition (shooter, indexer, vision, confidence) gets its own falling-edge debounce so a glitch on one doesn't kill the others. Heading hysteresis prevents flicker near the tolerance edge
  - SpatialLaunchValidator: blocks shots from under trench ceilings and behind pillars. Velocity-predictive buffer warns the driver before they enter a no-shoot zone

Changes to existing files:
  - ScoringTelemetry: delegates to ScoringReadiness instead of doing everything inline. Logs all 8 conditions plus debounced values so you can see what the composite is actually using
  - MatchStatsTelemetry: removed dead timeIntakingMs field, added fire auth analytics (wasted shots, marginal shots, pre-spin events)
  - Robot.java: wires HubShiftEngine and FireAuthorization into robotPeriodic before telemetry, resets scoring state in teleopInit
  - Constants.java: hub timing constants, trench exclusion zones, per-component debounce times