### PR TITLE
fix: shooter follower motor cleanup + slew limiter targetRPM bug

### DIFF
--- a/src/main/java/frc/robot/subsystems/Shooter.java
+++ b/src/main/java/frc/robot/subsystems/Shooter.java
@@ -33,6 +33,7 @@ public class Shooter extends Actuator {
   // private RelativeEncoder followerEncoder2;
   // private SparkMaxConfig followerConfig2;
 
+  private double desiredRPM = 0;
   private double targetRPM = 0;
 
   // Tunable PID values
@@ -138,8 +139,8 @@ public class Shooter extends Actuator {
   }
 
   public boolean isAtSpeed() {
-    if (targetRPM == 0) return false;
-    return Math.abs(targetRPM - getVelocityRPM()) < toleranceRPM.get();
+    if (desiredRPM == 0) return false;
+    return Math.abs(desiredRPM - getVelocityRPM()) < toleranceRPM.get();
   }
 
   @Override
@@ -155,6 +156,7 @@ public class Shooter extends Actuator {
 
   @Override
   public void moveToVelocityWithPID(double rpm) {
+    this.desiredRPM = rpm;
     rpm = limiter.calculate(rpm);
     this.targetRPM = rpm;
     super.moveToVelocityWithPID(rpm);
@@ -180,7 +182,7 @@ public class Shooter extends Actuator {
 
   // Hardware accessors
   public double getTargetRPM() {
-    return targetRPM;
+    return desiredRPM;
   }
 
   public double getAppliedOutput() {

--- a/src/test/java/frc/robot/integration/FeedbackPipelineIntegrationTest.java
+++ b/src/test/java/frc/robot/integration/FeedbackPipelineIntegrationTest.java
@@ -102,9 +102,7 @@ class FeedbackPipelineIntegrationTest {
     // LEDStatusDisplay.update() requires hardware; use resolveState for LED state verification
   }
 
-  // ==================== PIPELINE FLOW TESTS ====================
-
-  // ==================== BROWNOUT -> CRITICAL LED ====================
+  // Brownout -> Critical LED
 
   @Test
   void testBrownoutFlowsToCriticalLED() throws Exception {
@@ -136,7 +134,7 @@ class FeedbackPipelineIntegrationTest {
         "LED should recover from CRITICAL_ALERT when voltage returns to normal");
   }
 
-  // ==================== DISABLED -> NO HAPTICS ====================
+  // Disabled -> no haptics
 
   @Test
   void testDisabledBlocksAllHaptics() {
@@ -175,7 +173,7 @@ class FeedbackPipelineIntegrationTest {
         LEDState.DISABLED, resolveLEDState(), "LED should show DISABLED when robot is disabled");
   }
 
-  // ==================== ENABLED IDLE STATE ====================
+  // Enabled idle state
 
   @Test
   void testEnabledIdleState() throws Exception {
@@ -194,7 +192,7 @@ class FeedbackPipelineIntegrationTest {
     assertNotEquals(LEDState.DISABLED, state, "LED should not be DISABLED when robot is enabled");
   }
 
-  // ==================== TELEOP TRANSITION -> HAPTIC ====================
+  // Teleop transition -> haptic
 
   @Test
   void testAutoToTeleopTransitionTriggersHaptic() {
@@ -221,7 +219,7 @@ class FeedbackPipelineIntegrationTest {
     assertTrue(feedback.getRightMotor() > 0, "Right rumble should be active");
   }
 
-  // ==================== LOW BATTERY -> WARNING LED ====================
+  // Low battery -> warning LED
 
   @Test
   void testLowBatteryFlowsToWarningLED() throws Exception {
@@ -236,7 +234,7 @@ class FeedbackPipelineIntegrationTest {
         LEDState.WARNING, state, "LED should show WARNING when battery is between 10.0V and 11.5V");
   }
 
-  // ==================== PROGRESSIVE AIM -> LED AIM_PROGRESS ====================
+  // Progressive aim -> LED aim progress
 
   @Test
   void testProgressiveAimFlowsToLED() throws Exception {
@@ -274,7 +272,7 @@ class FeedbackPipelineIntegrationTest {
         "LED should not show AIM_PROGRESS after clearing progressive aim");
   }
 
-  // ==================== PROGRESSIVE AIM STALE -> AUTO CLEAR ====================
+  // Progressive aim stale -> auto clear
 
   @Test
   void testProgressiveAimStaleTimeoutClearsHapticAndLED() throws Exception {
@@ -307,7 +305,7 @@ class FeedbackPipelineIntegrationTest {
         "LED should not show AIM_PROGRESS after stale timeout");
   }
 
-  // ==================== CHANNEL COORDINATOR -> LOW CONFIDENCE -> WARNING ====================
+  // Channel coordinator -> low confidence -> warning
 
   @Test
   void testLowVisionConfidenceFlowsToWarningLED() throws Exception {
@@ -331,7 +329,7 @@ class FeedbackPipelineIntegrationTest {
     // If not low (e.g., confidence never set), that's still a valid pipeline state
   }
 
-  // ==================== MULTIPLE CYCLES STABILITY ====================
+  // Multiple cycles stability
 
   @Test
   void testPipelineStabilityAcrossModeTransitions() throws Exception {
@@ -370,7 +368,7 @@ class FeedbackPipelineIntegrationTest {
     assertEquals(0, driverSim.getRumble(GenericHID.RumbleType.kRightRumble), 0.02);
   }
 
-  // ==================== HELPERS ====================
+  // Helpers
 
   private LEDState resolveLEDState() throws Exception {
     // Build snapshot and resolve state via reflection (avoids needing real LED hardware).
@@ -420,6 +418,21 @@ class FeedbackPipelineIntegrationTest {
         Object motor = getMotor.invoke(instance);
         if (motor instanceof AutoCloseable) {
           ((AutoCloseable) motor).close();
+        }
+        // Close follower motors if present (e.g. Shooter has 3 followers)
+        try {
+          Field followersField = clazz.getDeclaredField("followers");
+          followersField.setAccessible(true);
+          Object[] followers = (Object[]) followersField.get(instance);
+          if (followers != null) {
+            for (Object follower : followers) {
+              if (follower instanceof AutoCloseable) {
+                ((AutoCloseable) follower).close();
+              }
+            }
+          }
+        } catch (NoSuchFieldException e2) {
+          // No followers field, that's fine
         }
       }
     } catch (Exception e) {

--- a/src/test/java/frc/robot/telemetry/SparkSimTestBase.java
+++ b/src/test/java/frc/robot/telemetry/SparkSimTestBase.java
@@ -78,6 +78,21 @@ public abstract class SparkSimTestBase {
         if (motor instanceof AutoCloseable) {
           ((AutoCloseable) motor).close();
         }
+        // Close follower motors if present (e.g. Shooter has 3 followers)
+        try {
+          java.lang.reflect.Field followersField = clazz.getDeclaredField("followers");
+          followersField.setAccessible(true);
+          Object[] followers = (Object[]) followersField.get(instance);
+          if (followers != null) {
+            for (Object follower : followers) {
+              if (follower instanceof AutoCloseable) {
+                ((AutoCloseable) follower).close();
+              }
+            }
+          }
+        } catch (NoSuchFieldException e2) {
+          // No followers field, that's fine
+        }
       }
     } catch (Exception e) {
       // Class may not have been loaded or doesn't have getMotor

--- a/src/test/java/frc/robot/telemetry/TelemetryManagerCrashIsolationTest.java
+++ b/src/test/java/frc/robot/telemetry/TelemetryManagerCrashIsolationTest.java
@@ -169,6 +169,19 @@ class TelemetryManagerCrashIsolationTest {
         if (motor instanceof AutoCloseable) {
           ((AutoCloseable) motor).close();
         }
+        try {
+          Field followersField = clazz.getDeclaredField("followers");
+          followersField.setAccessible(true);
+          Object[] followers = (Object[]) followersField.get(instance);
+          if (followers != null) {
+            for (Object follower : followers) {
+              if (follower instanceof AutoCloseable) {
+                ((AutoCloseable) follower).close();
+              }
+            }
+          }
+        } catch (NoSuchFieldException e2) {
+        }
       }
     } catch (Exception e) {
     }

--- a/src/test/java/frc/robot/telemetry/TelemetryTestBase.java
+++ b/src/test/java/frc/robot/telemetry/TelemetryTestBase.java
@@ -40,7 +40,7 @@ public abstract class TelemetryTestBase {
     }
   }
 
-  /** Close SparkMax motor to free CAN device ID before singleton reset */
+  /** Close SparkMax motor (and any followers) to free CAN device IDs before singleton reset */
   protected static void closeSubsystemMotor(String className) {
     try {
       Class<?> clazz = Class.forName(className);
@@ -52,6 +52,21 @@ public abstract class TelemetryTestBase {
         Object motor = getMotor.invoke(instance);
         if (motor instanceof AutoCloseable) {
           ((AutoCloseable) motor).close();
+        }
+        // Close follower motors if present (e.g. Shooter has 3 followers)
+        try {
+          Field followersField = clazz.getDeclaredField("followers");
+          followersField.setAccessible(true);
+          Object[] followers = (Object[]) followersField.get(instance);
+          if (followers != null) {
+            for (Object follower : followers) {
+              if (follower instanceof AutoCloseable) {
+                ((AutoCloseable) follower).close();
+              }
+            }
+          }
+        } catch (NoSuchFieldException e2) {
+          // No followers field, that's fine
         }
       }
     } catch (Exception e) {

--- a/src/test/java/frc/robot/util/AlertManagerTest.java
+++ b/src/test/java/frc/robot/util/AlertManagerTest.java
@@ -119,7 +119,7 @@ class AlertManagerTest {
     resetSingleton("frc.robot.telemetry.TelemetryManager");
   }
 
-  // ==================== BATTERY: FALSE POSITIVES ====================
+  // Battery: false positives
 
   @Test
   void testNoBatteryAlertWhenVoltageHealthy() {
@@ -146,7 +146,7 @@ class AlertManagerTest {
         "Battery warning must not fire mid-match (voltage sag is normal)");
   }
 
-  // ==================== BATTERY: FALSE NEGATIVES ====================
+  // Battery: false negatives
 
   @Test
   void testBatteryWarningFiresWhenLowAndDisabled() {
@@ -189,7 +189,7 @@ class AlertManagerTest {
     assertFalse(warnAlert.get());
   }
 
-  // ==================== BATTERY: HYSTERESIS ====================
+  // Battery: hysteresis
 
   @Test
   void testHysteresisPreventsPrematureClearing() throws Exception {
@@ -244,7 +244,7 @@ class AlertManagerTest {
         "Exactly 12.0V should clear warning (12.0 is not < 12.0)");
   }
 
-  // ==================== BATTERY: DEBOUNCER GATE ====================
+  // Battery: debouncer gate
 
   @Test
   void testBatteryWarningRequiresDebouncedDisabled() {
@@ -271,7 +271,7 @@ class AlertManagerTest {
         "Warning must fire after 1.5s debounce satisfied");
   }
 
-  // ==================== ALERT LIST ACCURACY ====================
+  // Alert list accuracy
 
   @Test
   void testCheckAllClearsAlertListEachCall() {
@@ -297,7 +297,7 @@ class AlertManagerTest {
     assertNotSame(list1, list2, "Must return defensive copy");
   }
 
-  // ==================== STALL ALERTS VIA TELEMETRY ====================
+  // Stall alerts via telemetry
 
   @Test
   void testShooterStallAlertActivates() throws Exception {
@@ -350,7 +350,7 @@ class AlertManagerTest {
     assertTrue(am.getActiveAlerts().contains("IntakeStall"));
   }
 
-  // ==================== JAM ALERTS VIA TELEMETRY ====================
+  // Jam alerts via telemetry
 
   @Test
   void testIndexerJamAlertActivates() throws Exception {
@@ -387,7 +387,7 @@ class AlertManagerTest {
     assertTrue(am.getActiveAlerts().contains("IntakeJam"));
   }
 
-  // ==================== BROWNOUT RISK ====================
+  // Brownout risk
 
   @Test
   void testBrownoutRiskAlertActivates() throws Exception {
@@ -412,7 +412,7 @@ class AlertManagerTest {
     assertFalse(am.getActiveAlerts().contains("BrownoutRisk"));
   }
 
-  // ==================== ELASTIC DEBOUNCE ====================
+  // Elastic debounce
 
   @Test
   void testClearDebounceResetsTimers() throws Exception {
@@ -428,7 +428,7 @@ class AlertManagerTest {
     assertTrue(times.isEmpty(), "clearDebounce() must reset all notification timers");
   }
 
-  // ==================== NO FALSE ALARMS ON HEALTHY STATE ====================
+  // No false alarms on healthy state
 
   @Test
   void testNoAlertsOnHealthyState() throws Exception {
@@ -444,7 +444,7 @@ class AlertManagerTest {
     assertEquals(0, alerts.size(), "Healthy robot should have zero active alerts, got: " + alerts);
   }
 
-  // ==================== HELPERS ====================
+  // Helpers
 
   private void satisfyDisabledDebouncer() {
     DriverStationSim.setEnabled(false);
@@ -518,6 +518,19 @@ class AlertManagerTest {
         Object motor = getMotor.invoke(instance);
         if (motor instanceof AutoCloseable) {
           ((AutoCloseable) motor).close();
+        }
+        try {
+          Field followersField = clazz.getDeclaredField("followers");
+          followersField.setAccessible(true);
+          Object[] followers = (Object[]) followersField.get(instance);
+          if (followers != null) {
+            for (Object follower : followers) {
+              if (follower instanceof AutoCloseable) {
+                ((AutoCloseable) follower).close();
+              }
+            }
+          }
+        } catch (NoSuchFieldException e2) {
         }
       }
     } catch (Exception e) {

--- a/src/test/java/frc/robot/util/PredictiveAlertsTest.java
+++ b/src/test/java/frc/robot/util/PredictiveAlertsTest.java
@@ -230,6 +230,19 @@ class PredictiveAlertsTest {
         if (motor instanceof AutoCloseable) {
           ((AutoCloseable) motor).close();
         }
+        try {
+          Field followersField = clazz.getDeclaredField("followers");
+          followersField.setAccessible(true);
+          Object[] followers = (Object[]) followersField.get(instance);
+          if (followers != null) {
+            for (Object follower : followers) {
+              if (follower instanceof AutoCloseable) {
+                ((AutoCloseable) follower).close();
+              }
+            }
+          }
+        } catch (NoSuchFieldException e2) {
+        }
       }
     } catch (Exception e) {
     }


### PR DESCRIPTION
## Summary
- Close follower motors in all 6 copies of closeSubsystemMotor() so CAN IDs actually get freed between
tests
- Track desiredRPM separately from the slew-limited value so getTargetRPM() and isAtSpeed() work correctly
- Clean up decorated headers in touched files (pre-commit hook caught them)

Fixes #104