### PR TITLE
Add aim-and-shoot command with fire control and hub shift engine

### DIFF
--- a/dashboards/elastic/rebuilt_driver_competition.json
+++ b/dashboards/elastic/rebuilt_driver_competition.json
@@ -11,8 +11,8 @@
             "title": "Match Time",
             "x": 0.0,
             "y": 0.0,
-            "width": 1500.0,
-            "height": 113.6,
+            "width": 1300.0,
+            "height": 100.0,
             "type": "Match Time",
             "properties": {
               "topic": "/AdvantageKit/RealOutputs/Match/Time",
@@ -23,211 +23,220 @@
             }
           },
           {
-            "title": "READY TO SHOOT",
+            "title": "HUB ACTIVE",
             "x": 0.0,
-            "y": 113.6,
-            "width": 512.1,
-            "height": 350.0,
+            "y": 100.0,
+            "width": 350.0,
+            "height": 250.0,
             "type": "Boolean Box",
             "properties": {
-              "topic": "/AdvantageKit/RealOutputs/Scoring/ReadyToShoot",
+              "topic": "/AdvantageKit/RealOutputs/HubShift/OfficialActive",
               "period": 0.033,
               "true_color": 4278255360,
-              "false_color": 4294901760,
-              "true_icon": "None",
-              "false_icon": "None"
+              "false_color": 4294901760
             }
           },
           {
-            "title": "Target Lock",
-            "x": 512.1,
-            "y": 113.6,
-            "width": 209.7,
-            "height": 231.9,
+            "title": "AT SPEED",
+            "x": 350.0,
+            "y": 100.0,
+            "width": 350.0,
+            "height": 250.0,
             "type": "Boolean Box",
             "properties": {
-              "topic": "/AdvantageKit/RealOutputs/Vision/LockedOnTarget",
+              "topic": "/AdvantageKit/RealOutputs/Shooter/AtSpeed",
               "period": 0.033,
               "true_color": 4278255360,
-              "false_color": 4294927872,
-              "true_icon": "None",
-              "false_icon": "None"
+              "false_color": 4294901760
             }
           },
           {
-            "title": "Battery",
-            "x": 721.8,
-            "y": 113.6,
-            "width": 778.2,
-            "height": 113.7,
-            "type": "Voltage View",
+            "title": "FEEDING",
+            "x": 700.0,
+            "y": 100.0,
+            "width": 300.0,
+            "height": 250.0,
+            "type": "Boolean Box",
             "properties": {
-              "topic": "/AdvantageKit/RealOutputs/SystemHealth/BatteryVoltage",
+              "topic": "/AdvantageKit/RealOutputs/AimAndShoot/Feeding",
               "period": 0.033,
-              "min_value": 8.0,
-              "max_value": 13.0,
-              "divisions": 5,
-              "inverted": false,
-              "orientation": "horizontal"
+              "true_color": 4278255360,
+              "false_color": 4284900966
+            }
+          },
+          {
+            "title": "AIM ACTIVE",
+            "x": 1000.0,
+            "y": 100.0,
+            "width": 300.0,
+            "height": 125.0,
+            "type": "Boolean Box",
+            "properties": {
+              "topic": "/AdvantageKit/RealOutputs/AimAndShoot/Active",
+              "period": 0.033,
+              "true_color": 4278255360,
+              "false_color": 4284900966
+            }
+          },
+          {
+            "title": "Valid Solution",
+            "x": 1000.0,
+            "y": 225.0,
+            "width": 300.0,
+            "height": 125.0,
+            "type": "Boolean Box",
+            "properties": {
+              "topic": "/AdvantageKit/RealOutputs/ShotCalc/IsValid",
+              "period": 0.033,
+              "true_color": 4278255360,
+              "false_color": 4294901760
             }
           },
           {
             "title": "Shooter RPM",
-            "x": 721.8,
-            "y": 227.3,
-            "width": 778.2,
-            "height": 118.2,
+            "x": 0.0,
+            "y": 350.0,
+            "width": 700.0,
+            "height": 120.0,
             "type": "Number Bar",
             "properties": {
               "topic": "/AdvantageKit/RealOutputs/Shooter/VelocityRPM",
               "period": 0.033,
               "min_value": 0.0,
-              "max_value": 5700.0,
-              "divisions": 5,
-              "inverted": false,
+              "max_value": 6000.0,
+              "num_tick_marks": 7,
               "orientation": "horizontal"
             }
           },
           {
-            "title": "Hub Active",
-            "x": 512.1,
-            "y": 345.5,
-            "width": 209.7,
-            "height": 118.1,
+            "title": "Heading Error",
+            "x": 0.0,
+            "y": 470.0,
+            "width": 700.0,
+            "height": 100.0,
+            "type": "Number Bar",
+            "properties": {
+              "topic": "/AdvantageKit/RealOutputs/AimAndShoot/HeadingErrorDeg",
+              "period": 0.033,
+              "min_value": -30.0,
+              "max_value": 30.0,
+              "center": 0.0,
+              "num_tick_marks": 7,
+              "orientation": "horizontal"
+            }
+          },
+          {
+            "title": "Hub Phase",
+            "x": 700.0,
+            "y": 350.0,
+            "width": 200.0,
+            "height": 80.0,
+            "type": "Text Display",
+            "properties": {
+              "topic": "/AdvantageKit/RealOutputs/HubShift/Phase",
+              "period": 0.033
+            }
+          },
+          {
+            "title": "Time To Deactivation",
+            "x": 900.0,
+            "y": 350.0,
+            "width": 200.0,
+            "height": 80.0,
+            "type": "Text Display",
+            "properties": {
+              "topic": "/AdvantageKit/RealOutputs/HubShift/TimeUntilDeactivation",
+              "period": 0.033
+            }
+          },
+          {
+            "title": "Won Auto",
+            "x": 1100.0,
+            "y": 350.0,
+            "width": 200.0,
+            "height": 80.0,
             "type": "Boolean Box",
             "properties": {
-              "topic": "/AdvantageKit/RealOutputs/Scoring/Conditions/HubActive",
+              "topic": "/AdvantageKit/RealOutputs/HubShift/WonAuto",
               "period": 0.033,
               "true_color": 4278255360,
-              "false_color": 4294927872,
-              "true_icon": "None",
-              "false_icon": "None"
+              "false_color": 4294901760
             }
           },
           {
-            "title": "Hub Shift#",
-            "x": 721.8,
-            "y": 345.5,
-            "width": 387.1,
-            "height": 118.1,
+            "title": "Distance",
+            "x": 700.0,
+            "y": 430.0,
+            "width": 200.0,
+            "height": 70.0,
             "type": "Text Display",
             "properties": {
-              "topic": "/AdvantageKit/RealOutputs/Scoring/HubShiftNumber",
-              "period": 0.033,
-              "show_submit_button": false
+              "topic": "/AdvantageKit/RealOutputs/ShotCalc/Distance",
+              "period": 0.033
             }
           },
           {
-            "title": "Shift Timer",
-            "x": 1108.9,
-            "y": 345.5,
-            "width": 391.1,
-            "height": 118.1,
+            "title": "Effective RPM",
+            "x": 900.0,
+            "y": 430.0,
+            "width": 200.0,
+            "height": 70.0,
             "type": "Text Display",
             "properties": {
-              "topic": "/AdvantageKit/RealOutputs/Scoring/TimeToNextShiftSec",
-              "period": 0.033,
-              "show_submit_button": false
+              "topic": "/AdvantageKit/RealOutputs/ShotCalc/EffectiveRPM",
+              "period": 0.033
             }
           },
           {
-            "title": "Auto Selector",
-            "x": 0.0,
-            "y": 463.6,
-            "width": 512.1,
-            "height": 118.2,
-            "type": "ComboBox Chooser",
+            "title": "Battery",
+            "x": 700.0,
+            "y": 500.0,
+            "width": 600.0,
+            "height": 70.0,
+            "type": "Voltage View",
             "properties": {
-              "topic": "/SmartDashboard/Auto Chooser",
-              "period": 0.033,
-              "sort_options": false
-            }
-          },
-          {
-            "title": "AMDA Mode",
-            "x": 512.1,
-            "y": 463.6,
-            "width": 197.6,
-            "height": 118.2,
-            "type": "Text Display",
-            "properties": {
-              "topic": "/AdvantageKit/RealOutputs/AMDA/Mode",
-              "period": 0.033,
-              "show_submit_button": false
-            }
-          },
-          {
-            "title": "Confidence",
-            "x": 709.7,
-            "y": 463.6,
-            "width": 197.6,
-            "height": 118.2,
-            "type": "Text Display",
-            "properties": {
-              "topic": "/AdvantageKit/RealOutputs/AMDA/Confidence",
-              "period": 0.033,
-              "show_submit_button": false
+              "topic": "/AdvantageKit/RealOutputs/SystemHealth/BatteryVoltage",
+              "period": 0.033
             }
           },
           {
             "title": "JAM!",
-            "x": 907.3,
-            "y": 463.6,
-            "width": 197.5,
-            "height": 118.2,
+            "x": 1100.0,
+            "y": 430.0,
+            "width": 200.0,
+            "height": 70.0,
             "type": "Boolean Box",
             "properties": {
               "topic": "/AdvantageKit/RealOutputs/Indexer/JamDetected",
               "period": 0.033,
               "true_color": 4294901760,
-              "false_color": 4278233600,
-              "true_icon": "None",
-              "false_icon": "None"
+              "false_color": 4284900966
             }
           },
           {
-            "title": "Intake Jam",
-            "x": 1104.8,
-            "y": 463.6,
-            "width": 197.6,
-            "height": 118.2,
+            "title": "Auto Selector",
+            "x": 0.0,
+            "y": 570.0,
+            "width": 500.0,
+            "height": 80.0,
+            "type": "ComboBox Chooser",
+            "properties": {
+              "topic": "/SmartDashboard/Auto Chooser",
+              "period": 0.033
+            }
+          },
+          {
+            "title": "GAME DATA MISSING",
+            "x": 500.0,
+            "y": 570.0,
+            "width": 300.0,
+            "height": 80.0,
             "type": "Boolean Box",
             "properties": {
-              "topic": "/AdvantageKit/RealOutputs/Intake/JamDetected",
+              "topic": "/AdvantageKit/RealOutputs/HubShift/GameDataMissing",
               "period": 0.033,
               "true_color": 4294901760,
-              "false_color": 4278233600,
-              "true_icon": "None",
-              "false_icon": "None"
-            }
-          },
-          {
-            "title": "Agitator",
-            "x": 1302.4,
-            "y": 463.6,
-            "width": 197.6,
-            "height": 118.2,
-            "type": "Boolean Box",
-            "properties": {
-              "topic": "/AdvantageKit/RealOutputs/Agitator/Running",
-              "period": 0.033,
-              "true_color": 4278255360,
-              "false_color": 4281545523,
-              "true_icon": "None",
-              "false_icon": "None"
-            }
-          },
-          {
-            "title": "Alerts",
-            "x": 0.0,
-            "y": 581.8,
-            "width": 1500.0,
-            "height": 118.2,
-            "type": "Text Display",
-            "properties": {
-              "topic": "/AdvantageKit/RealOutputs/Alerts/ActiveList",
-              "period": 0.033,
-              "show_submit_button": false
+              "false_color": 4284900966
             }
           }
         ]
@@ -242,8 +251,8 @@
             "title": "Match Time",
             "x": 0.0,
             "y": 0.0,
-            "width": 827.3,
-            "height": 116.3,
+            "width": 1300.0,
+            "height": 80.0,
             "type": "Match Time",
             "properties": {
               "topic": "/AdvantageKit/RealOutputs/Match/Time",
@@ -254,354 +263,287 @@
             }
           },
           {
-            "title": "READY",
-            "x": 827.3,
-            "y": 0.0,
-            "width": 310.1,
-            "height": 233.7,
+            "title": "HUB ACTIVE",
+            "x": 0.0,
+            "y": 80.0,
+            "width": 300.0,
+            "height": 150.0,
             "type": "Boolean Box",
             "properties": {
-              "topic": "/AdvantageKit/RealOutputs/Scoring/ReadyToShoot",
+              "topic": "/AdvantageKit/RealOutputs/HubShift/OfficialActive",
               "period": 0.033,
               "true_color": 4278255360,
-              "false_color": 4294901760,
-              "true_icon": "None",
-              "false_icon": "None"
+              "false_color": 4294901760
+            }
+          },
+          {
+            "title": "AT SPEED",
+            "x": 300.0,
+            "y": 80.0,
+            "width": 300.0,
+            "height": 150.0,
+            "type": "Boolean Box",
+            "properties": {
+              "topic": "/AdvantageKit/RealOutputs/Shooter/AtSpeed",
+              "period": 0.033,
+              "true_color": 4278255360,
+              "false_color": 4294901760
             }
           },
           {
             "title": "Battery",
-            "x": 1137.4,
-            "y": 0.0,
-            "width": 361.6,
-            "height": 116.3,
+            "x": 600.0,
+            "y": 80.0,
+            "width": 400.0,
+            "height": 70.0,
             "type": "Voltage View",
             "properties": {
               "topic": "/AdvantageKit/RealOutputs/SystemHealth/BatteryVoltage",
-              "period": 0.033,
-              "min_value": 8.0,
-              "max_value": 13.0,
-              "divisions": 5,
-              "inverted": false,
-              "orientation": "horizontal"
-            }
-          },
-          {
-            "title": "Shots Scored",
-            "x": 0.0,
-            "y": 116.3,
-            "width": 310.1,
-            "height": 233.7,
-            "type": "Large Text Display",
-            "properties": {
-              "topic": "/AdvantageKit/RealOutputs/MatchStats/TotalShots",
               "period": 0.033
             }
           },
           {
-            "title": "Fire Rate",
-            "x": 310.1,
-            "y": 116.3,
-            "width": 207.1,
-            "height": 116.3,
-            "type": "Text Display",
-            "properties": {
-              "topic": "/AdvantageKit/RealOutputs/MatchStats/ShotsPerMinute",
-              "period": 0.033,
-              "show_submit_button": false
-            }
-          },
-          {
-            "title": "Hub Active",
-            "x": 517.2,
-            "y": 116.3,
-            "width": 207.0,
-            "height": 116.3,
-            "type": "Boolean Box",
-            "properties": {
-              "topic": "/AdvantageKit/RealOutputs/Scoring/Conditions/HubActive",
-              "period": 0.033,
-              "true_color": 4278255360,
-              "false_color": 4294927872,
-              "true_icon": "None",
-              "false_icon": "None"
-            }
-          },
-          {
-            "title": "Shooter RPM",
-            "x": 1137.4,
-            "y": 116.3,
-            "width": 361.6,
-            "height": 116.3,
-            "type": "Number Bar",
-            "properties": {
-              "topic": "/AdvantageKit/RealOutputs/Shooter/VelocityRPM",
-              "period": 0.033,
-              "min_value": 0.0,
-              "max_value": 5700.0,
-              "divisions": 5,
-              "inverted": false,
-              "orientation": "horizontal"
-            }
-          },
-          {
-            "title": "Hub Util",
-            "x": 310.1,
-            "y": 233.7,
-            "width": 207.1,
-            "height": 116.3,
-            "type": "Text Display",
-            "properties": {
-              "topic": "/AdvantageKit/RealOutputs/MatchStats/HubUtilization",
-              "period": 0.033,
-              "show_submit_button": false
-            }
-          },
-          {
-            "title": "Active Shots",
-            "x": 517.2,
-            "y": 233.7,
-            "width": 207.0,
-            "height": 116.3,
-            "type": "Text Display",
-            "properties": {
-              "topic": "/AdvantageKit/RealOutputs/MatchStats/ActiveHubShots",
-              "period": 0.033,
-              "show_submit_button": false
-            }
-          },
-          {
-            "title": "Shift Timer",
-            "x": 724.2,
-            "y": 233.7,
-            "width": 103.1,
-            "height": 116.3,
-            "type": "Text Display",
-            "properties": {
-              "topic": "/AdvantageKit/RealOutputs/Scoring/TimeToNextShiftSec",
-              "period": 0.033,
-              "show_submit_button": false
-            }
-          },
-          {
-            "title": "Total Current",
-            "x": 1137.4,
-            "y": 233.7,
-            "width": 361.6,
-            "height": 116.3,
-            "type": "Number Bar",
-            "properties": {
-              "topic": "/AdvantageKit/RealOutputs/SystemHealth/TotalCurrentAmps",
-              "period": 0.033,
-              "min_value": 0.0,
-              "max_value": 200.0,
-              "divisions": 5,
-              "inverted": false,
-              "orientation": "horizontal"
-            }
-          },
-          {
-            "title": "Cycles",
-            "x": 0.0,
-            "y": 350.0,
-            "width": 207.1,
-            "height": 116.3,
-            "type": "Text Display",
-            "properties": {
-              "topic": "/AdvantageKit/RealOutputs/MatchStats/CompletedCycles",
-              "period": 0.033,
-              "show_submit_button": false
-            }
-          },
-          {
-            "title": "Failed",
-            "x": 207.1,
-            "y": 350.0,
-            "width": 207.0,
-            "height": 116.3,
-            "type": "Text Display",
-            "properties": {
-              "topic": "/AdvantageKit/RealOutputs/MatchStats/FailedCycles",
-              "period": 0.033,
-              "show_submit_button": false
-            }
-          },
-          {
-            "title": "JAM!",
-            "x": 414.1,
-            "y": 350.0,
-            "width": 207.1,
-            "height": 116.3,
-            "type": "Boolean Box",
-            "properties": {
-              "topic": "/AdvantageKit/RealOutputs/Indexer/JamDetected",
-              "period": 0.033,
-              "true_color": 4294901760,
-              "false_color": 4278233600,
-              "true_icon": "None",
-              "false_icon": "None"
-            }
-          },
-          {
-            "title": "Agitator",
-            "x": 620.2,
-            "y": 350.0,
-            "width": 207.1,
-            "height": 116.3,
-            "type": "Boolean Box",
-            "properties": {
-              "topic": "/AdvantageKit/RealOutputs/Agitator/Running",
-              "period": 0.033,
-              "true_color": 4278255360,
-              "false_color": 4281545523,
-              "true_icon": "None",
-              "false_icon": "None"
-            }
-          },
-          {
-            "title": "AMDA",
-            "x": 827.3,
-            "y": 350.0,
-            "width": 207.0,
-            "height": 116.3,
-            "type": "Text Display",
-            "properties": {
-              "topic": "/AdvantageKit/RealOutputs/AMDA/Mode",
-              "period": 0.033,
-              "show_submit_button": false
-            }
-          },
-          {
             "title": "Brownout Risk",
-            "x": 1034.3,
-            "y": 350.0,
-            "width": 207.1,
-            "height": 116.3,
+            "x": 1000.0,
+            "y": 80.0,
+            "width": 200.0,
+            "height": 70.0,
             "type": "Text Display",
             "properties": {
               "topic": "/AdvantageKit/RealOutputs/SystemHealth/BrownoutRiskLevel",
-              "period": 0.033,
-              "show_submit_button": false
+              "period": 0.033
             }
           },
           {
             "title": "BrownedOut",
-            "x": 1241.4,
-            "y": 350.0,
-            "width": 103.0,
-            "height": 116.3,
+            "x": 1200.0,
+            "y": 80.0,
+            "width": 100.0,
+            "height": 70.0,
             "type": "Boolean Box",
             "properties": {
               "topic": "/AdvantageKit/RealOutputs/SystemHealth/BrownedOut",
               "period": 0.033,
               "true_color": 4294901760,
-              "false_color": 4278233600,
-              "true_icon": "None",
-              "false_icon": "None"
+              "false_color": 4284900966
             }
           },
           {
-            "title": "Auto Selector",
-            "x": 0.0,
-            "y": 467.4,
-            "width": 517.2,
-            "height": 116.3,
-            "type": "ComboBox Chooser",
+            "title": "Shooter RPM",
+            "x": 600.0,
+            "y": 150.0,
+            "width": 700.0,
+            "height": 80.0,
+            "type": "Number Bar",
             "properties": {
-              "topic": "/SmartDashboard/Auto Chooser",
+              "topic": "/AdvantageKit/RealOutputs/Shooter/VelocityRPM",
               "period": 0.033,
-              "sort_options": false
+              "min_value": 0.0,
+              "max_value": 6000.0,
+              "num_tick_marks": 7,
+              "orientation": "horizontal"
             }
           },
           {
-            "title": "Alerts",
-            "x": 517.2,
-            "y": 467.4,
-            "width": 982.8,
-            "height": 116.3,
+            "title": "Hub Phase",
+            "x": 0.0,
+            "y": 230.0,
+            "width": 200.0,
+            "height": 70.0,
             "type": "Text Display",
             "properties": {
-              "topic": "/AdvantageKit/RealOutputs/Alerts/ActiveList",
+              "topic": "/AdvantageKit/RealOutputs/HubShift/Phase",
+              "period": 0.033
+            }
+          },
+          {
+            "title": "Time To Deactivation",
+            "x": 200.0,
+            "y": 230.0,
+            "width": 200.0,
+            "height": 70.0,
+            "type": "Text Display",
+            "properties": {
+              "topic": "/AdvantageKit/RealOutputs/HubShift/TimeUntilDeactivation",
+              "period": 0.033
+            }
+          },
+          {
+            "title": "Remaining",
+            "x": 400.0,
+            "y": 230.0,
+            "width": 200.0,
+            "height": 70.0,
+            "type": "Text Display",
+            "properties": {
+              "topic": "/AdvantageKit/RealOutputs/HubShift/RemainingInState",
+              "period": 0.033
+            }
+          },
+          {
+            "title": "Won Auto",
+            "x": 600.0,
+            "y": 230.0,
+            "width": 150.0,
+            "height": 70.0,
+            "type": "Boolean Box",
+            "properties": {
+              "topic": "/AdvantageKit/RealOutputs/HubShift/WonAuto",
               "period": 0.033,
-              "show_submit_button": false
+              "true_color": 4278255360,
+              "false_color": 4294901760
+            }
+          },
+          {
+            "title": "Confidence",
+            "x": 750.0,
+            "y": 230.0,
+            "width": 150.0,
+            "height": 70.0,
+            "type": "Text Display",
+            "properties": {
+              "topic": "/AdvantageKit/RealOutputs/HubShift/ScheduleConfidence",
+              "period": 0.033
+            }
+          },
+          {
+            "title": "Total Current",
+            "x": 900.0,
+            "y": 230.0,
+            "width": 400.0,
+            "height": 70.0,
+            "type": "Number Bar",
+            "properties": {
+              "topic": "/AdvantageKit/RealOutputs/SystemHealth/TotalCurrentAmps",
+              "period": 0.033,
+              "min_value": 0.0,
+              "max_value": 120.0,
+              "num_tick_marks": 7,
+              "orientation": "horizontal"
             }
           },
           {
             "title": "Rate 10s",
             "x": 0.0,
-            "y": 583.7,
-            "width": 310.1,
-            "height": 116.3,
+            "y": 300.0,
+            "width": 150.0,
+            "height": 70.0,
             "type": "Text Display",
             "properties": {
               "topic": "/AdvantageKit/RealOutputs/Shooter/FireRate10s",
-              "period": 0.033,
-              "show_submit_button": false
+              "period": 0.033
             }
           },
           {
             "title": "Rate 30s",
-            "x": 310.1,
-            "y": 583.7,
-            "width": 310.1,
-            "height": 116.3,
+            "x": 150.0,
+            "y": 300.0,
+            "width": 150.0,
+            "height": 70.0,
             "type": "Text Display",
             "properties": {
               "topic": "/AdvantageKit/RealOutputs/Shooter/FireRate30s",
-              "period": 0.033,
-              "show_submit_button": false
+              "period": 0.033
             }
           },
           {
             "title": "Peak BPS",
-            "x": 620.2,
-            "y": 583.7,
-            "width": 207.1,
-            "height": 116.3,
+            "x": 300.0,
+            "y": 300.0,
+            "width": 150.0,
+            "height": 70.0,
             "type": "Text Display",
             "properties": {
               "topic": "/AdvantageKit/RealOutputs/Shooter/PeakBPS5s",
-              "period": 0.033,
-              "show_submit_button": false
+              "period": 0.033
             }
           },
           {
             "title": "Streak",
-            "x": 827.3,
-            "y": 583.7,
-            "width": 207.0,
-            "height": 116.3,
+            "x": 450.0,
+            "y": 300.0,
+            "width": 150.0,
+            "height": 70.0,
             "type": "Text Display",
             "properties": {
               "topic": "/AdvantageKit/RealOutputs/Shooter/ScoringStreak",
-              "period": 0.033,
-              "show_submit_button": false
+              "period": 0.033
             }
           },
           {
             "title": "Best Streak",
-            "x": 1034.3,
-            "y": 583.7,
-            "width": 207.1,
-            "height": 116.3,
+            "x": 600.0,
+            "y": 300.0,
+            "width": 150.0,
+            "height": 70.0,
             "type": "Text Display",
             "properties": {
               "topic": "/AdvantageKit/RealOutputs/Shooter/LongestStreak",
+              "period": 0.033
+            }
+          },
+          {
+            "title": "JAM!",
+            "x": 750.0,
+            "y": 300.0,
+            "width": 150.0,
+            "height": 70.0,
+            "type": "Boolean Box",
+            "properties": {
+              "topic": "/AdvantageKit/RealOutputs/Indexer/JamDetected",
               "period": 0.033,
-              "show_submit_button": false
+              "true_color": 4294901760,
+              "false_color": 4284900966
+            }
+          },
+          {
+            "title": "Agitator",
+            "x": 900.0,
+            "y": 300.0,
+            "width": 150.0,
+            "height": 70.0,
+            "type": "Boolean Box",
+            "properties": {
+              "topic": "/AdvantageKit/RealOutputs/Agitator/Running",
+              "period": 0.033,
+              "true_color": 4278255360,
+              "false_color": 4284900966
             }
           },
           {
             "title": "Vis Accept %",
-            "x": 1241.4,
-            "y": 583.7,
-            "width": 258.6,
-            "height": 116.3,
+            "x": 1050.0,
+            "y": 300.0,
+            "width": 250.0,
+            "height": 70.0,
             "type": "Text Display",
             "properties": {
               "topic": "/AdvantageKit/RealOutputs/Vision/Filter/AcceptRatePct",
-              "period": 0.033,
-              "show_submit_button": false
+              "period": 0.033
+            }
+          },
+          {
+            "title": "Alerts",
+            "x": 0.0,
+            "y": 370.0,
+            "width": 700.0,
+            "height": 70.0,
+            "type": "Text Display",
+            "properties": {
+              "topic": "/AdvantageKit/RealOutputs/Alerts/ActiveList",
+              "period": 0.033
+            }
+          },
+          {
+            "title": "Auto Selector",
+            "x": 700.0,
+            "y": 370.0,
+            "width": 600.0,
+            "height": 70.0,
+            "type": "ComboBox Chooser",
+            "properties": {
+              "topic": "/SmartDashboard/Auto Chooser",
+              "period": 0.033
             }
           }
         ]

--- a/dashboards/elastic/rebuilt_tuning_session.json
+++ b/dashboards/elastic/rebuilt_tuning_session.json
@@ -3,6 +3,361 @@
   "grid_size": 128,
   "tabs": [
     {
+      "name": "Shooting",
+      "grid_layout": {
+        "layouts": [],
+        "containers": [
+          {
+            "title": "RPM Override",
+            "x": 0.0,
+            "y": 0.0,
+            "width": 300.0,
+            "height": 100.0,
+            "type": "Text Display",
+            "properties": {
+              "topic": "/SmartDashboard/ShotCalc/RPMOverride",
+              "period": 0.033,
+              "show_submit_button": true
+            }
+          },
+          {
+            "title": "Distance to Hub (m)",
+            "x": 300.0,
+            "y": 0.0,
+            "width": 300.0,
+            "height": 100.0,
+            "type": "Text Display",
+            "properties": {
+              "topic": "/AdvantageKit/RealOutputs/ShotCalc/Distance",
+              "period": 0.033
+            }
+          },
+          {
+            "title": "Effective RPM",
+            "x": 600.0,
+            "y": 0.0,
+            "width": 300.0,
+            "height": 100.0,
+            "type": "Text Display",
+            "properties": {
+              "topic": "/AdvantageKit/RealOutputs/ShotCalc/EffectiveRPM",
+              "period": 0.033
+            }
+          },
+          {
+            "title": "RPM Override Active",
+            "x": 900.0,
+            "y": 0.0,
+            "width": 200.0,
+            "height": 100.0,
+            "type": "Boolean Box",
+            "properties": {
+              "topic": "/AdvantageKit/RealOutputs/ShotCalc/RPMOverrideActive",
+              "period": 0.033,
+              "true_color": 4294944000,
+              "false_color": 4284900966
+            }
+          },
+          {
+            "title": "Hub Center X",
+            "x": 1100.0,
+            "y": 0.0,
+            "width": 200.0,
+            "height": 100.0,
+            "type": "Text Display",
+            "properties": {
+              "topic": "/AdvantageKit/RealOutputs/ShotCalc/HubCenterX",
+              "period": 0.033
+            }
+          },
+          {
+            "title": "Shooter RPM",
+            "x": 0.0,
+            "y": 100.0,
+            "width": 900.0,
+            "height": 250.0,
+            "type": "Graph",
+            "properties": {
+              "topic": "/AdvantageKit/RealOutputs/Shooter/VelocityRPM",
+              "period": 0.033,
+              "time_displayed": 5.0,
+              "color": 4278238420,
+              "line_width": 2.0
+            }
+          },
+          {
+            "title": "AT SPEED",
+            "x": 900.0,
+            "y": 100.0,
+            "width": 200.0,
+            "height": 125.0,
+            "type": "Boolean Box",
+            "properties": {
+              "topic": "/AdvantageKit/RealOutputs/Shooter/AtSpeed",
+              "period": 0.033,
+              "true_color": 4278255360,
+              "false_color": 4294901760
+            }
+          },
+          {
+            "title": "FEEDING",
+            "x": 1100.0,
+            "y": 100.0,
+            "width": 200.0,
+            "height": 125.0,
+            "type": "Boolean Box",
+            "properties": {
+              "topic": "/AdvantageKit/RealOutputs/AimAndShoot/Feeding",
+              "period": 0.033,
+              "true_color": 4278255360,
+              "false_color": 4284900966
+            }
+          },
+          {
+            "title": "AIM ACTIVE",
+            "x": 900.0,
+            "y": 225.0,
+            "width": 200.0,
+            "height": 125.0,
+            "type": "Boolean Box",
+            "properties": {
+              "topic": "/AdvantageKit/RealOutputs/AimAndShoot/Active",
+              "period": 0.033,
+              "true_color": 4278255360,
+              "false_color": 4284900966
+            }
+          },
+          {
+            "title": "Valid Solution",
+            "x": 1100.0,
+            "y": 225.0,
+            "width": 200.0,
+            "height": 125.0,
+            "type": "Boolean Box",
+            "properties": {
+              "topic": "/AdvantageKit/RealOutputs/ShotCalc/IsValid",
+              "period": 0.033,
+              "true_color": 4278255360,
+              "false_color": 4294901760
+            }
+          },
+          {
+            "title": "Heading Error (deg)",
+            "x": 0.0,
+            "y": 350.0,
+            "width": 600.0,
+            "height": 100.0,
+            "type": "Number Bar",
+            "properties": {
+              "topic": "/AdvantageKit/RealOutputs/AimAndShoot/HeadingErrorDeg",
+              "period": 0.033,
+              "min_value": -30.0,
+              "max_value": 30.0,
+              "center": 0.0,
+              "num_tick_marks": 7,
+              "orientation": "horizontal"
+            }
+          },
+          {
+            "title": "Heading kP",
+            "x": 600.0,
+            "y": 350.0,
+            "width": 200.0,
+            "height": 100.0,
+            "type": "Text Display",
+            "properties": {
+              "topic": "/SmartDashboard/HeadingLock/kP",
+              "period": 0.033,
+              "show_submit_button": true
+            }
+          },
+          {
+            "title": "Heading kD",
+            "x": 800.0,
+            "y": 350.0,
+            "width": 200.0,
+            "height": 100.0,
+            "type": "Text Display",
+            "properties": {
+              "topic": "/SmartDashboard/HeadingLock/kD",
+              "period": 0.033,
+              "show_submit_button": true
+            }
+          },
+          {
+            "title": "RPM Mult Short",
+            "x": 0.0,
+            "y": 450.0,
+            "width": 250.0,
+            "height": 80.0,
+            "type": "Text Display",
+            "properties": {
+              "topic": "/SmartDashboard/ShotCalc/RPMMultShort",
+              "period": 0.033,
+              "show_submit_button": true
+            }
+          },
+          {
+            "title": "RPM Mult Medium",
+            "x": 250.0,
+            "y": 450.0,
+            "width": 250.0,
+            "height": 80.0,
+            "type": "Text Display",
+            "properties": {
+              "topic": "/SmartDashboard/ShotCalc/RPMMultMedium",
+              "period": 0.033,
+              "show_submit_button": true
+            }
+          },
+          {
+            "title": "RPM Mult Long",
+            "x": 500.0,
+            "y": 450.0,
+            "width": 250.0,
+            "height": 80.0,
+            "type": "Text Display",
+            "properties": {
+              "topic": "/SmartDashboard/ShotCalc/RPMMultLong",
+              "period": 0.033,
+              "show_submit_button": true
+            }
+          },
+          {
+            "title": "Fallback RPM",
+            "x": 750.0,
+            "y": 450.0,
+            "width": 250.0,
+            "height": 80.0,
+            "type": "Text Display",
+            "properties": {
+              "topic": "/SmartDashboard/Shooter/TargetRPM",
+              "period": 0.033,
+              "show_submit_button": true
+            }
+          },
+          {
+            "title": "Motor Temp",
+            "x": 1000.0,
+            "y": 450.0,
+            "width": 300.0,
+            "height": 80.0,
+            "type": "Number Bar",
+            "properties": {
+              "topic": "/AdvantageKit/RealOutputs/Shooter/TemperatureCelsius",
+              "period": 0.033,
+              "min_value": 20.0,
+              "max_value": 80.0,
+              "num_tick_marks": 4,
+              "orientation": "horizontal"
+            }
+          },
+          {
+            "title": "Hub Phase",
+            "x": 0.0,
+            "y": 530.0,
+            "width": 200.0,
+            "height": 80.0,
+            "type": "Text Display",
+            "properties": {
+              "topic": "/AdvantageKit/RealOutputs/HubShift/Phase",
+              "period": 0.033
+            }
+          },
+          {
+            "title": "HUB ACTIVE",
+            "x": 200.0,
+            "y": 530.0,
+            "width": 200.0,
+            "height": 80.0,
+            "type": "Boolean Box",
+            "properties": {
+              "topic": "/AdvantageKit/RealOutputs/HubShift/OfficialActive",
+              "period": 0.033,
+              "true_color": 4278255360,
+              "false_color": 4294901760
+            }
+          },
+          {
+            "title": "Time Until Deactivation",
+            "x": 400.0,
+            "y": 530.0,
+            "width": 250.0,
+            "height": 80.0,
+            "type": "Text Display",
+            "properties": {
+              "topic": "/AdvantageKit/RealOutputs/HubShift/TimeUntilDeactivation",
+              "period": 0.033
+            }
+          },
+          {
+            "title": "Remaining In State",
+            "x": 650.0,
+            "y": 530.0,
+            "width": 250.0,
+            "height": 80.0,
+            "type": "Text Display",
+            "properties": {
+              "topic": "/AdvantageKit/RealOutputs/HubShift/RemainingInState",
+              "period": 0.033
+            }
+          },
+          {
+            "title": "Won Auto",
+            "x": 900.0,
+            "y": 530.0,
+            "width": 200.0,
+            "height": 80.0,
+            "type": "Boolean Box",
+            "properties": {
+              "topic": "/AdvantageKit/RealOutputs/HubShift/WonAuto",
+              "period": 0.033,
+              "true_color": 4278255360,
+              "false_color": 4294901760
+            }
+          },
+          {
+            "title": "Confidence",
+            "x": 1100.0,
+            "y": 530.0,
+            "width": 200.0,
+            "height": 80.0,
+            "type": "Text Display",
+            "properties": {
+              "topic": "/AdvantageKit/RealOutputs/HubShift/ScheduleConfidence",
+              "period": 0.033
+            }
+          },
+          {
+            "title": "GAME DATA MISSING",
+            "x": 0.0,
+            "y": 610.0,
+            "width": 300.0,
+            "height": 70.0,
+            "type": "Boolean Box",
+            "properties": {
+              "topic": "/AdvantageKit/RealOutputs/HubShift/GameDataMissing",
+              "period": 0.033,
+              "true_color": 4294901760,
+              "false_color": 4284900966
+            }
+          },
+          {
+            "title": "WonAuto Override",
+            "x": 300.0,
+            "y": 610.0,
+            "width": 200.0,
+            "height": 70.0,
+            "type": "Toggle Button",
+            "properties": {
+              "topic": "/SmartDashboard/WonAuto",
+              "period": 0.033
+            }
+          }
+        ]
+      }
+    },
+    {
       "name": "Shooter",
       "grid_layout": {
         "layouts": [],

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -157,6 +157,7 @@ public final class Constants {
     public static final double SHOT_DETECTION_DROP_RPM = 200.0;
     public static final double SHOT_DETECTION_MIN_RPM = 1000.0;
     public static final double TEMP_WARNING_CELSIUS = 65.0;
+    public static final double EMERGENCY_DUMP_RPM = 2500.0;
   }
 
   public static final class IndexerConstants {
@@ -365,8 +366,80 @@ public final class Constants {
     public static final double BALL_RADIUS_M = 0.0889; // 3.5" radius
   }
 
-  /** Shot calculator constants (launcher geometry) */
+  /** Shot calculator constants (launcher geometry + Newton solver + SOTM) */
   public static final class ShotCalculatorConstants {
-    public static final double FIXED_LAUNCH_ANGLE_DEG = 68.0; // measured from OnShape CAD
+    // Launcher geometry (drum shooter, rear-mounted)
+    public static final double LAUNCHER_OFFSET_X = -0.0577; // behind center (OnShape)
+    public static final double LAUNCHER_OFFSET_Y = 0.0;
+    public static final double FIXED_LAUNCH_ANGLE_DEG = 60.0; // drum shooter angle
+    // rear-mounted shooter: rotate aim by 180 deg so the back faces the hub
+    public static final double SHOOTER_ANGLE_OFFSET_RAD = Math.PI;
+
+    // Newton solver
+    public static final int MAX_ITERATIONS = 25;
+    public static final double CONVERGENCE_TOLERANCE = 0.001;
+    public static final double TOF_MIN = 0.05;
+    public static final double TOF_MAX = 5.0;
+
+    // Velocity filter
+    public static final double MIN_SOTM_SPEED = 0.1;
+
+    // Latency compensation
+    public static final double PHASE_DELAY_MS = 30.0;
+    public static final double MECH_LATENCY_MS = 20.0;
+
+    // Drag compensation
+    public static final double SOTM_DRAG_COEFF = 0.47;
+
+    // Scoring range
+    public static final double MIN_SCORING_DISTANCE = 0.5;
+    public static final double MAX_SCORING_DISTANCE = 5.0;
+
+    // Speed cap while shooting on the move
+    public static final double MAX_SOTM_SPEED = 3.0;
+
+    // Per-distance RPM band boundaries (meters)
+    public static final double RPM_BAND_SHORT_END = 1.5;
+    public static final double RPM_BAND_MEDIUM_END = 3.0;
+  }
+
+  /** Hub shift timing: shift schedule, fuel delay, fire authorization margins */
+  public static final class HubTimingConstants {
+    public static final double FUEL_COUNT_DELAY_MIN_SEC = 1.0;
+    public static final double FUEL_COUNT_DELAY_MAX_SEC = 2.0;
+    public static final double FUEL_COUNT_EXTENSION_SEC = 3.0;
+    public static final double FIRE_SAFE_MARGIN_SEC = 0.5;
+    public static final double PRE_SPIN_WINDOW_SEC = 3.0;
+    public static final double FALLBACK_MARGIN_EXTRA_SEC = 1.0;
+    public static final double GAME_DATA_ALERT_INTERVAL_SEC = 2.0;
+
+    // Game Manual Section 6.4: 10s transition, 4x25s shifts, 30s endgame = 140s total
+    public static final double TRANSITION_END = 10.0;
+    public static final double SHIFT1_END = 35.0;
+    public static final double SHIFT2_END = 60.0;
+    public static final double SHIFT3_END = 85.0;
+    public static final double SHIFT4_END = 110.0;
+    public static final double ENDGAME_END = 140.0;
+
+    public static final double AUTO_DURATION = 20.0;
+  }
+
+  /** Heading lock controller for SOTM: PID + feedforward + lookahead */
+  public static final class HeadingLockConstants {
+    public static final double P = 3.0;
+    public static final double I = 0.0;
+    public static final double D = 0.1;
+
+    // FF gains (layer OFF by default, these just sit ready)
+    public static final double FF_KS = 0.05;
+    public static final double FF_KV = 0.8;
+    public static final double FF_KA = 0.0;
+
+    // Lookahead (disabled by default)
+    public static final double LOOKAHEAD_SEC = 0.0;
+
+    // FF distance scaling
+    public static final double FF_MIN_DIST_M = 0.5;
+    public static final double FF_MAX_DIST_M = 1.5;
   }
 }

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -195,9 +195,19 @@ public class Robot extends LoggedRobot {
     safeCall("CommandScheduler", () -> CommandScheduler.getInstance().run());
     safeCall("Tracer", () -> LoggedTracer.record("CommandsMs"));
 
+    safeCall("ShotCalc", () -> frc.robot.util.ShotCalculator.getInstance().calculate());
+
     safeCall("Telemetry", () -> TelemetryManager.getInstance().updateAll());
     safeCall("NaNGuard", () -> checkNaNInfinity());
     safeCall("Tracer", () -> LoggedTracer.record("TelemetryMs"));
+
+    safeCall(
+        "HubShift",
+        () -> {
+          double tof =
+              frc.robot.util.ShotCalculator.getInstance().getParameters().timeOfFlightSec();
+          frc.robot.util.HubShiftEngine.getInstance().update(tof);
+        });
 
     safeCall(
         "ChannelCoordinator",
@@ -349,6 +359,7 @@ public class Robot extends LoggedRobot {
     try {
       EventMarker.modeChange("TELEOP");
       PostMatchSummary.getInstance().startTracking();
+      frc.robot.util.HubShiftEngine.getInstance().initializeTeleop();
     } catch (Throwable t) {
       safeLog("Health/CrashBarrier/TeleopInit", true);
     }

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -29,6 +29,7 @@ import edu.wpi.first.wpilibj2.command.button.CommandXboxController;
 import edu.wpi.first.wpilibj2.command.button.Trigger;
 import frc.robot.Constants.OperatorConstants;
 import frc.robot.commands.AgitateAndIndex;
+import frc.robot.commands.AimAndShootCommand;
 import frc.robot.commands.DeployIntake;
 import frc.robot.commands.HoldAndIntake;
 import frc.robot.commands.HubArcDrive;
@@ -37,6 +38,9 @@ import frc.robot.commands.RetractIntake;
 import frc.robot.commands.SetIntakePosition;
 import frc.robot.commands.SpeedUpThenIndex;
 import frc.robot.sim.SimDriveOverride;
+import frc.robot.subsystems.Agitator;
+import frc.robot.subsystems.Indexer;
+import frc.robot.subsystems.Shooter;
 import frc.robot.subsystems.swervedrive.SwerveSubsystem;
 import frc.robot.subsystems.swervedrive.Vision;
 import frc.robot.telemetry.TelemetryManager;
@@ -186,6 +190,16 @@ public class RobotContainer {
             .alongWith(new SpeedUpThenIndex()));
 
     NamedCommands.registerCommand("shoot", new SpeedUpThenIndex());
+    NamedCommands.registerCommand(
+        "AimAndShoot",
+        new AimAndShootCommand(
+            drivebase,
+            Shooter.getInstance(),
+            Indexer.getInstance(),
+            Agitator.getInstance(),
+            () -> 0,
+            () -> 0,
+            true));
 
     // Build an auto chooser. This will use Commands.none() as the default option.
     autoChooser = AutoBuilder.buildAutoChooser("TrenchHumanScore"); // "New New New Auto"
@@ -203,6 +217,30 @@ public class RobotContainer {
     TelemetryManager.getInstance().setSwerveSubsystem(drivebase);
     TelemetryManager.getInstance().setControllers(driverXbox.getHID(), copilotXbox.getHID());
     DriverFeedback.getInstance().initialize(driverXbox.getHID(), copilotXbox.getHID());
+
+    // Fire control init
+    frc.robot.util.ShotCalculator.getInstance().setSwerve(drivebase);
+
+    // Pre-spin: auto-spin shooter 5s before hub goes active so RPM is ready at window open.
+    // Requires Shooter so it yields to AimAndShootCommand when operator presses RT.
+    // runEnd stops the motor when the trigger goes false.
+    new Trigger(
+            () -> {
+              var info = frc.robot.util.HubShiftEngine.getInstance().getOfficialInfo();
+              return !info.hubActive()
+                  && info.timeToNextActive() > 0
+                  && info.timeToNextActive() < 5.0;
+            })
+        .whileTrue(
+            Commands.runEnd(
+                () ->
+                    Shooter.getInstance()
+                        .moveToVelocityWithPID(Shooter.getInstance().getTunableTargetRPM()),
+                () -> Shooter.getInstance().move(0),
+                Shooter.getInstance()));
+
+    // Hub deactivation warning is handled inside DriverFeedback.update() so it
+    // doesn't compete with other haptic patterns for HID rumble output.
   }
 
   /**
@@ -321,12 +359,59 @@ public class RobotContainer {
               new AgitateAndIndex(
                   -Constants.AgitatorConstants.TARGET_RPM, -2000, hubArcDrive::isScheduled));
       copilotXbox.a().whileTrue(new DeployIntake().andThen(new HoldAndIntake()));
-      copilotXbox.rightTrigger().whileTrue(new SpeedUpThenIndex());
+      copilotXbox
+          .rightTrigger()
+          .whileTrue(
+              new AimAndShootCommand(
+                  drivebase,
+                  Shooter.getInstance(),
+                  Indexer.getInstance(),
+                  Agitator.getInstance(),
+                  () -> -driverXbox.getLeftY(),
+                  () -> -driverXbox.getLeftX(),
+                  false));
       copilotXbox
           .leftTrigger()
           .whileTrue(
               (new PivotIntake(-0.3).withTimeout(.89).andThen(new PivotIntake(0.2).withTimeout(.7)))
                   .repeatedly());
+
+      // second controller Start toggles wonAuto override (fixes bad FMS data mid-match)
+      // second controller Back clears override and returns to FMS-derived schedule
+      copilotXbox
+          .start()
+          .onTrue(
+              Commands.runOnce(
+                  () -> {
+                    var engine = frc.robot.util.HubShiftEngine.getInstance();
+                    engine.setWonAutoOverride(!engine.isWonAuto());
+                  }));
+      copilotXbox
+          .back()
+          .onTrue(
+              Commands.runOnce(
+                  () -> frc.robot.util.HubShiftEngine.getInstance().clearWonAutoOverride()));
+
+      // emergency dump: flat RPM, immediate feed, bypasses everything
+      copilotXbox
+          .povDown()
+          .whileTrue(
+              Commands.runEnd(
+                  () -> {
+                    Shooter.getInstance()
+                        .moveToVelocityWithPID(Constants.ShooterConstants.EMERGENCY_DUMP_RPM);
+                    Indexer.getInstance()
+                        .moveToVelocityWithPID(Indexer.getInstance().getTunableTargetSpeed());
+                    Agitator.getInstance().move(0.5);
+                  },
+                  () -> {
+                    Shooter.getInstance().move(0);
+                    Indexer.getInstance().move(0);
+                    Agitator.getInstance().move(0);
+                  },
+                  Shooter.getInstance(),
+                  Indexer.getInstance(),
+                  Agitator.getInstance()));
 
       //       Trigger crossingZone = new Trigger(()->{
       //     Pose2d pose = drivebase.getPose();

--- a/src/main/java/frc/robot/commands/AimAndShootCommand.java
+++ b/src/main/java/frc/robot/commands/AimAndShootCommand.java
@@ -1,0 +1,265 @@
+package frc.robot.commands;
+
+import edu.wpi.first.math.MathUtil;
+import edu.wpi.first.math.geometry.Rotation2d;
+import edu.wpi.first.math.geometry.Translation2d;
+import edu.wpi.first.math.kinematics.ChassisSpeeds;
+import edu.wpi.first.wpilibj.DriverStation;
+import edu.wpi.first.wpilibj.DriverStation.Alliance;
+import edu.wpi.first.wpilibj.Timer;
+import edu.wpi.first.wpilibj2.command.Command;
+import frc.robot.Constants.HubScoringConstants;
+import frc.robot.Constants.ShotCalculatorConstants;
+import frc.robot.subsystems.Agitator;
+import frc.robot.subsystems.Indexer;
+import frc.robot.subsystems.Shooter;
+import frc.robot.subsystems.swervedrive.SwerveSubsystem;
+import frc.robot.telemetry.SafeLog;
+import frc.robot.util.HeadingController;
+import frc.robot.util.ShotCalculator;
+import frc.robot.util.TunableNumber;
+import java.util.function.DoubleSupplier;
+
+/**
+ * Points the rear at the hub, spins up, and feeds balls when at speed. Driver keeps translation
+ * control. In auto mode it times out; in teleop it runs until the operator lets go of RT.
+ */
+public class AimAndShootCommand extends Command {
+
+  private final SwerveSubsystem swerve;
+  private final Shooter shooter;
+  private final Indexer indexer;
+  private final Agitator agitator;
+  private final DoubleSupplier forwardInput;
+  private final DoubleSupplier strafeInput;
+  private final boolean autoFinish;
+
+  private final HeadingController headingController = new HeadingController();
+  private final Timer autoTimer = new Timer();
+
+  // Firing hysteresis state
+  private boolean reachedSpeed = false;
+  private boolean feeding = false;
+  private double underShootingSince = -1;
+
+  // blend COR from launcher (precise) to robot center (fast) based on heading error
+  private static final double COR_MIN_ERROR_RAD = Math.toRadians(2.0);
+  private static final double COR_MAX_ERROR_RAD = Math.toRadians(15.0);
+  private static final Translation2d LAUNCHER_OFFSET =
+      new Translation2d(ShotCalculatorConstants.LAUNCHER_OFFSET_X, 0);
+
+  // Tunable thresholds matching SpeedUpThenIndex
+  private static final TunableNumber autoTimeoutSec =
+      new TunableNumber("AimAndShoot/AutoTimeoutSec", 4.0);
+  private static final TunableNumber underShootPct =
+      new TunableNumber("AimAndShoot/UnderShootPct", 0.85);
+  private static final TunableNumber underShootDebounceMs =
+      new TunableNumber("AimAndShoot/DebounceMs", 400);
+  private static final TunableNumber feedRatioFloor =
+      new TunableNumber("AimAndShoot/FeedRatioFloor", 0.5);
+
+  // X-lock wheels when driver isn't moving to prevent drift while shooting
+  private static final double OLOCK_TRANSLATION_THRESHOLD = 0.1;
+  private static final double OLOCK_OMEGA_THRESHOLD = 0.15;
+
+  public AimAndShootCommand(
+      SwerveSubsystem swerve,
+      Shooter shooter,
+      Indexer indexer,
+      Agitator agitator,
+      DoubleSupplier forwardInput,
+      DoubleSupplier strafeInput,
+      boolean autoFinish) {
+    this.swerve = swerve;
+    this.shooter = shooter;
+    this.indexer = indexer;
+    this.agitator = agitator;
+    this.forwardInput = forwardInput;
+    this.strafeInput = strafeInput;
+    this.autoFinish = autoFinish;
+
+    addRequirements(swerve, shooter, indexer, agitator);
+  }
+
+  @Override
+  public void initialize() {
+    headingController.reset();
+    reachedSpeed = false;
+    feeding = false;
+    underShootingSince = -1;
+
+    // start spinning early with flat RPM, execute() will switch to LUT RPM
+    shooter.moveToVelocityWithPID(shooter.getTunableTargetRPM());
+    // quick reverse to clear any jammed balls before we start feeding
+    agitator.move(-0.35);
+
+    if (autoFinish) {
+      autoTimer.restart();
+    }
+  }
+
+  @Override
+  public void execute() {
+    // aim: point rear at hub
+    ShotCalculator shotCalc = ShotCalculator.getInstance();
+    ShotCalculator.LaunchParameters params = shotCalc.getParameters();
+    Rotation2d targetHeading = params.isValid() ? params.driveAngle() : computeFallbackAim();
+
+    double maxOmega = swerve.getSwerveDrive().getMaximumChassisAngularVelocity();
+    double distToHub = swerve.getPose().getTranslation().getDistance(getHubCenter());
+
+    double omega =
+        headingController.calculate(
+            swerve.getHeading(),
+            targetHeading,
+            params.isValid() ? params.driveAngularVelocityRadPerSec() : 0,
+            distToHub,
+            maxOmega);
+
+    // drive: let the driver translate while we control heading
+    double maxVel = swerve.getSwerveDrive().getMaximumChassisVelocity();
+    double fwd = forwardInput.getAsDouble() * maxVel;
+    double str = strafeInput.getAsDouble() * maxVel;
+
+    // cap driver speed so we don't outrun the aim compensation
+    if (params.isValid()) {
+      double polarLimit = shotCalc.getPolarSpeedLimitMps();
+      if (polarLimit > 0 && polarLimit < maxVel) {
+        double speed = Math.hypot(fwd, str);
+        if (speed > polarLimit) {
+          double scale = polarLimit / speed;
+          fwd *= scale;
+          str *= scale;
+        }
+      }
+    }
+
+    // X-lock if we're basically standing still so we don't drift while shooting
+    if (Math.hypot(fwd, str) < OLOCK_TRANSLATION_THRESHOLD
+        && Math.abs(omega) < OLOCK_OMEGA_THRESHOLD) {
+      swerve.lock();
+    } else {
+      // blend COR: launcher offset when close to aimed, robot center when whipping around
+      double headingErrorRad = Math.abs(targetHeading.minus(swerve.getHeading()).getRadians());
+      double corScalar =
+          MathUtil.clamp(
+              (headingErrorRad - COR_MIN_ERROR_RAD) / (COR_MAX_ERROR_RAD - COR_MIN_ERROR_RAD),
+              0,
+              1);
+      Translation2d cor = LAUNCHER_OFFSET.times(1.0 - corScalar);
+
+      ChassisSpeeds speeds =
+          ChassisSpeeds.fromFieldRelativeSpeeds(fwd, str, omega, swerve.getHeading());
+      swerve.drive(speeds, cor);
+    }
+
+    // RPMOverride takes priority, then LUT RPM, then flat dashboard RPM
+    double overrideRPM = shotCalc.getRpmOverride();
+    double targetRPM;
+    if (overrideRPM > 0) {
+      targetRPM = overrideRPM;
+    } else if (params.isValid()) {
+      targetRPM = params.rpm();
+    } else {
+      targetRPM = shooter.getTunableTargetRPM();
+    }
+    shooter.moveToVelocityWithPID(targetRPM);
+
+    boolean atSpeed = shooter.isAtSpeed();
+    if (atSpeed && !reachedSpeed) {
+      reachedSpeed = true;
+      feeding = true;
+    }
+
+    // if RPM tanks for too long, stop feeding until it recovers
+    if (reachedSpeed) {
+      double velocity = shooter.getVelocityRPM();
+      double target = shooter.getTargetRPM();
+      double threshold = target * underShootPct.get();
+
+      if (velocity < threshold) {
+        double now = Timer.getFPGATimestamp();
+        if (underShootingSince < 0) {
+          underShootingSince = now;
+        } else if ((now - underShootingSince) * 1000.0 > underShootDebounceMs.get()) {
+          feeding = false;
+        }
+      } else {
+        underShootingSince = -1;
+        if (!feeding) {
+          feeding = true;
+        }
+      }
+    }
+
+    if (feeding) {
+      double targetRpm = shooter.getTargetRPM();
+      double rpmRatio = (targetRpm > 0) ? Math.min(1.0, shooter.getVelocityRPM() / targetRpm) : 0;
+      rpmRatio = Math.max(feedRatioFloor.get(), rpmRatio);
+      indexer.moveToVelocityWithPID(indexer.getTunableTargetSpeed() * rpmRatio);
+      agitator.move(0.35);
+    } else {
+      indexer.move(0);
+      agitator.move(0);
+    }
+
+    // progressive aim haptic: operator feels heading error converge
+    try {
+      double errorDeg = Math.toDegrees(Math.abs(headingController.getPositionError()));
+      frc.robot.util.DriverFeedback.getInstance().setProgressiveAim(errorDeg);
+    } catch (Throwable t) {
+    }
+
+    // telemetry
+    SafeLog.put("AimAndShoot/Active", true);
+    SafeLog.put(
+        "AimAndShoot/HeadingErrorDeg", Math.toDegrees(headingController.getPositionError()));
+    SafeLog.put("AimAndShoot/Feeding", feeding);
+    SafeLog.put("AimAndShoot/ShooterAtSpeed", reachedSpeed);
+    if (autoFinish) {
+      SafeLog.put("AimAndShoot/AutoTimerSec", autoTimer.get());
+    }
+  }
+
+  @Override
+  public void end(boolean interrupted) {
+    shooter.move(0);
+    indexer.move(0);
+    agitator.move(0);
+    try {
+      frc.robot.util.DriverFeedback.getInstance().clearProgressiveAim();
+    } catch (Throwable t) {
+    }
+    SafeLog.put("AimAndShoot/Active", false);
+  }
+
+  @Override
+  public boolean isFinished() {
+    if (autoFinish) {
+      return autoTimer.hasElapsed(autoTimeoutSec.get());
+    }
+    return false;
+  }
+
+  /** Simple angle-to-hub when ShotCalculator can't solve (out of range, behind hub, etc). */
+  private Rotation2d computeFallbackAim() {
+    Translation2d hub = getHubCenter();
+    Translation2d robot = swerve.getPose().getTranslation();
+    if (Double.isNaN(robot.getX()) || Double.isNaN(robot.getY())) {
+      return swerve.getHeading(); // hold current heading if pose is corrupt
+    }
+    // rear-mounted shooter: aim the back of the robot at the hub
+    return robot
+        .minus(hub)
+        .getAngle()
+        .plus(new Rotation2d(ShotCalculatorConstants.SHOOTER_ANGLE_OFFSET_RAD));
+  }
+
+  private Translation2d getHubCenter() {
+    var alliance = DriverStation.getAlliance();
+    if (alliance.isPresent() && alliance.get() == Alliance.Red) {
+      return HubScoringConstants.RED_HUB_CENTER;
+    }
+    return HubScoringConstants.BLUE_HUB_CENTER;
+  }
+}

--- a/src/main/java/frc/robot/subsystems/Hanger.java
+++ b/src/main/java/frc/robot/subsystems/Hanger.java
@@ -32,7 +32,11 @@ public class Hanger extends Actuator {
 
   @Override
   public void periodic() {
-    TunableNumber.ifChanged(() -> updatePID(kP.get(), 0, kD.get(), 0), kP, kD);
+    try {
+      TunableNumber.ifChanged(() -> updatePID(kP.get(), 0, kD.get(), 0), kP, kD);
+    } catch (Throwable t) {
+      // CAN fault during PID update must not kill scheduler
+    }
   }
 
   @Override

--- a/src/main/java/frc/robot/subsystems/Indexer.java
+++ b/src/main/java/frc/robot/subsystems/Indexer.java
@@ -70,8 +70,12 @@ public class Indexer extends FlexActuator {
 
   @Override
   public void periodic() {
-    TunableNumber.ifChanged(
-        () -> updatePID(kP.get(), kI.get(), kD.get(), kF.get()), kP, kI, kD, kF);
+    try {
+      TunableNumber.ifChanged(
+          () -> updatePID(kP.get(), kI.get(), kD.get(), kF.get()), kP, kI, kD, kF);
+    } catch (Throwable t) {
+      // CAN fault during PID update must not kill scheduler
+    }
 
     // JamProtection detects and reports only. It never overrides the motor.
     // Telemetry reads the state; the driver decides what to do about it.

--- a/src/main/java/frc/robot/subsystems/Shooter.java
+++ b/src/main/java/frc/robot/subsystems/Shooter.java
@@ -145,8 +145,12 @@ public class Shooter extends Actuator {
 
   @Override
   public void periodic() {
-    TunableNumber.ifChanged(
-        () -> updatePID(kP.get(), kI.get(), kD.get(), kF.get()), kP, kI, kD, kF);
+    try {
+      TunableNumber.ifChanged(
+          () -> updatePID(kP.get(), kI.get(), kD.get(), kF.get()), kP, kI, kD, kF);
+    } catch (Throwable t) {
+      // CAN fault during PID update must not kill scheduler
+    }
   }
 
   public void move(double speed) {

--- a/src/main/java/frc/robot/subsystems/swervedrive/SwerveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/swervedrive/SwerveSubsystem.java
@@ -721,6 +721,11 @@ public class SwerveSubsystem extends SubsystemBase {
     return swerveDrive;
   }
 
+  /** Drive with a custom center of rotation for COR-blended shooting. */
+  public void drive(ChassisSpeeds velocity, Translation2d centerOfRotation) {
+    swerveDrive.drive(velocity, centerOfRotation);
+  }
+
   public Vision getVision() {
     return vision;
   }

--- a/src/main/java/frc/robot/telemetry/TelemetryManager.java
+++ b/src/main/java/frc/robot/telemetry/TelemetryManager.java
@@ -395,14 +395,17 @@ public class TelemetryManager {
   }
 
   public boolean isHubActive() {
-    return getSafely(() -> scoringTelemetry.isHubActive(), true);
+    return getSafely(
+        () -> frc.robot.util.HubShiftEngine.getInstance().getOfficialInfo().hubActive(), true);
   }
 
   public double getTimeToNextShiftSec() {
-    return getSafely(() -> scoringTelemetry.getTimeToNextShiftSec(), 0.0);
+    return getSafely(
+        () -> frc.robot.util.HubShiftEngine.getInstance().getOfficialInfo().remainingInState(),
+        0.0);
   }
 
   public boolean isWonAuto() {
-    return getSafely(() -> scoringTelemetry.isWonAuto(), false);
+    return getSafely(() -> frc.robot.util.HubShiftEngine.getInstance().isWonAuto(), false);
   }
 }

--- a/src/main/java/frc/robot/util/DriverFeedback.java
+++ b/src/main/java/frc/robot/util/DriverFeedback.java
@@ -11,8 +11,7 @@ import frc.robot.telemetry.TelemetryManager;
 public class DriverFeedback {
   private static DriverFeedback instance;
 
-  // --- Inner types ---
-
+  // Inner types
   public record Step(double left, double right, double durationSec) {}
 
   public enum HapticTarget {
@@ -30,8 +29,7 @@ public class DriverFeedback {
     CRITICAL
   }
 
-  // --- Haptic patterns ---
-
+  // Haptic patterns
   // CRITICAL: auto result at teleop start -> BOTH controllers
   // Both start with a strong buzz (teleop started!), then indicate win/loss.
   // Right follow-up = won auto (right side = scoring/positive in our pattern language)
@@ -162,7 +160,7 @@ public class DriverFeedback {
     HUB_COUNTDOWN_5, HUB_COUNTDOWN_4, HUB_COUNTDOWN_3, HUB_COUNTDOWN_2, HUB_COUNTDOWN_1
   };
 
-  // --- Test pattern table (indexed 1-9 from Elastic slider) ---
+  // Test pattern table (indexed 1-9 from Elastic slider)
   private static final HapticPattern[] TEST_PATTERNS = {
     AUTO_WON,
     AUTO_LOST,
@@ -192,7 +190,7 @@ public class DriverFeedback {
       new TunableNumber("DriverFeedback/TestPattern", 0);
   private int lastTestPatternValue = 0;
 
-  // --- Playback engine state ---
+  // Playback engine state
   private HapticPattern activePattern = null;
   private HapticTarget activeTarget = HapticTarget.BOTH;
   private int stepIndex = 0;
@@ -201,30 +199,30 @@ public class DriverFeedback {
   private double currentRight = 0;
   private int patternCount = 0;
 
-  // --- Edge detection state ---
+  // Edge detection state
   private boolean prevReadyToShoot = false;
   private boolean prevHubActive = true; // default true (safe: no false trigger on startup)
   private boolean endgameWarningPlayed = false;
   private boolean prevEnabled = false;
   private boolean prevAutonomous = false;
 
-  // --- Jam protection edge detection ---
+  // Jam protection edge detection
   private boolean prevJamIntervening = false;
   private String lastJamSource = "none";
 
-  // --- Progressive aim ---
+  // Progressive aim
   private boolean progressiveAimActive = false;
   private double progressiveAimError = -1;
   private static final double PROGRESSIVE_AIM_STALE_TIMEOUT_SEC = 0.25;
   private double lastProgressiveAimUpdateSec = -1;
 
-  // --- Spin-up rumble (continuous background on DRIVER) ---
+  // Spin-up rumble (continuous background on DRIVER)
   private double spinUpPercent = 0;
 
-  // --- Hub graduated countdown ---
+  // Hub graduated countdown
   private int prevCountdownSecond = -1;
 
-  // --- Game data missing alert (repeats during transition) ---
+  // Game data missing alert (repeats during transition)
   // Transition period is ~10s from teleop start. If FMS is attached but hasn't
   // sent the 'R'/'B' auto-winner message, hub shift logic is running blind.
   private static final double GAME_DATA_TRANSITION_SEC = 10.0;
@@ -232,11 +230,11 @@ public class DriverFeedback {
   private double lastGameDataAlertTime = 0;
   private double teleopStartTime = -1;
 
-  // --- Accessibility ---
+  // Accessibility
   private static final TunableNumber hapticScale =
       new TunableNumber("DriverFeedback/hapticScale", 1.0);
 
-  // --- Controllers ---
+  // Controllers
   private GenericHID controller = null;
   private GenericHID copilotController = null;
 
@@ -309,7 +307,7 @@ public class DriverFeedback {
       prevHubActive = hubActive;
     }
 
-    // --- No haptics while disabled ---
+    // No haptics while disabled
     if (!isEnabled) {
       // Keep edge state in sync so we don't get false triggers on re-enable
       prevReadyToShoot = readyToShoot;
@@ -324,7 +322,7 @@ public class DriverFeedback {
       return;
     }
 
-    // --- Match phase events (CRITICAL -> BOTH) ---
+    // Match phase events (CRITICAL -> BOTH)
     // At auto-to-teleop transition, signal whether we won or lost auto.
     // FMS sends 'R' or 'B' via game-specific message; ScoringTelemetry parses it.
     // Won auto = our hub inactive first (collect/defend), lost = hub active (score NOW).
@@ -339,7 +337,7 @@ public class DriverFeedback {
       }
     }
 
-    // --- Game data missing alert (CRITICAL -> BOTH, repeats every 2s) ---
+    // Game data missing alert (CRITICAL -> BOTH, repeats every 2s)
     // FMS attached but no auto-winner data during transition period = hub logic is guessing
     if (isEnabled && !isAutonomous && teleopStartTime > 0) {
       double teleopElapsed = now - teleopStartTime;
@@ -357,7 +355,7 @@ public class DriverFeedback {
       }
     }
 
-    // --- Hub shift events (HIGH -> COPILOT) ---
+    // Hub shift events (HIGH -> COPILOT)
     if (hubActive && !prevHubActive) {
       playPattern(HUB_ACTIVATED);
     }
@@ -365,7 +363,7 @@ public class DriverFeedback {
       playPattern(HUB_DEACTIVATED);
     }
 
-    // --- Graduated hub countdown (5s to 1s, MEDIUM -> BOTH) ---
+    // Graduated hub countdown (5s to 1s, MEDIUM -> BOTH)
     int countdownSec =
         (timeToNextShift > 0 && timeToNextShift <= 5.5) ? (int) Math.ceil(timeToNextShift) : -1;
     if (countdownSec >= 1 && countdownSec <= 5 && countdownSec != prevCountdownSecond) {
@@ -373,12 +371,12 @@ public class DriverFeedback {
     }
     prevCountdownSecond = (timeToNextShift > 0) ? countdownSec : -1;
 
-    // --- Scoring events (HIGH -> COPILOT) ---
+    // Scoring events (HIGH -> COPILOT)
     if (readyToShoot && !prevReadyToShoot) {
       playPattern(READY_TO_SHOOT);
     }
 
-    // --- Jam protection events (HIGH -> COPILOT) ---
+    // Jam protection events (HIGH -> COPILOT)
     if (jamIntervening && !prevJamIntervening) {
       playPattern(JAM_DETECTED);
       // Capture which subsystem triggered so pit crew can see it in telemetry
@@ -398,7 +396,7 @@ public class DriverFeedback {
     prevEnabled = isEnabled;
     prevAutonomous = isAutonomous;
 
-    // --- Pattern playback ---
+    // Pattern playback
     if (activePattern != null) {
       Step step = activePattern.steps()[stepIndex];
       double elapsed = now - stepStartTime;
@@ -422,7 +420,7 @@ public class DriverFeedback {
       }
     }
 
-    // --- Progressive aim (only when no pattern active, routes to COPILOT) ---
+    // Progressive aim (only when no pattern active, routes to COPILOT)
     HapticTarget rumbleTarget = activeTarget;
     if (activePattern == null && progressiveAimActive && progressiveAimError >= 0) {
       rumbleTarget = HapticTarget.COPILOT;
@@ -444,8 +442,27 @@ public class DriverFeedback {
       currentLeft = normalized * maxIntensity;
       currentRight = 0;
     } else if (activePattern == null && !progressiveAimActive) {
-      currentLeft = 0;
-      currentRight = 0;
+      // Hub deactivation urgency: increasing left rumble when hub window is closing
+      double deactTime = 0;
+      try {
+        var info = HubShiftEngine.getInstance().getOfficialInfo();
+        if (info.hubActive()
+            && info.timeUntilDeactivation() < 8.0
+            && info.timeUntilDeactivation() > 0
+            && DriverStation.isTeleop()) {
+          deactTime = info.timeUntilDeactivation();
+        }
+      } catch (RuntimeException e) {
+        // fail-open: no urgency rumble if HubShiftEngine unavailable
+      }
+      if (deactTime > 0 && deactTime < 8.0) {
+        double urgency = 1.0 - (deactTime / 8.0);
+        urgency = Math.max(0, Math.min(1, urgency));
+        currentLeft = urgency * hapticScale.get();
+      } else {
+        currentLeft = 0;
+        currentRight = 0;
+      }
     }
 
     // Apply scale and clamp
@@ -530,8 +547,7 @@ public class DriverFeedback {
     applyRumble(copilotController, 0, 0);
   }
 
-  // --- Accessors for telemetry ---
-
+  // Accessors for telemetry
   public String getActivePatternName() {
     return activePattern != null ? activePattern.name() : "none";
   }

--- a/src/main/java/frc/robot/util/HeadingController.java
+++ b/src/main/java/frc/robot/util/HeadingController.java
@@ -1,0 +1,205 @@
+package frc.robot.util;
+
+import edu.wpi.first.math.MathUtil;
+import edu.wpi.first.math.controller.PIDController;
+import edu.wpi.first.math.filter.LinearFilter;
+import edu.wpi.first.math.geometry.Rotation2d;
+import frc.robot.Constants.HeadingLockConstants;
+
+/**
+ * Heading controller for SOTM and hub arc drive. PID + optional feedforward + optional lookahead.
+ * Each layer has a TunableNumber kill switch. Falls back to P-only if both PID and FF are off. Each
+ * command should own its own instance and call reset() in initialize().
+ */
+public class HeadingController {
+
+  // PID gains
+  private final TunableNumber kP = new TunableNumber("HeadingLock/kP", HeadingLockConstants.P);
+  private final TunableNumber kI = new TunableNumber("HeadingLock/kI", HeadingLockConstants.I);
+  private final TunableNumber kD = new TunableNumber("HeadingLock/kD", HeadingLockConstants.D);
+
+  // Feedforward gains
+  private final TunableNumber kS =
+      new TunableNumber("HeadingLock/FF/kS", HeadingLockConstants.FF_KS);
+  private final TunableNumber kV =
+      new TunableNumber("HeadingLock/FF/kV", HeadingLockConstants.FF_KV);
+  private final TunableNumber kA =
+      new TunableNumber("HeadingLock/FF/kA", HeadingLockConstants.FF_KA);
+
+  // Lookahead
+  private final TunableNumber kLookaheadSec =
+      new TunableNumber("HeadingLock/lookaheadSec", HeadingLockConstants.LOOKAHEAD_SEC);
+
+  // FF distance scaling
+  private final TunableNumber kFFMinDist =
+      new TunableNumber("HeadingLock/FF/minDistM", HeadingLockConstants.FF_MIN_DIST_M);
+  private final TunableNumber kFFMaxDist =
+      new TunableNumber("HeadingLock/FF/maxDistM", HeadingLockConstants.FF_MAX_DIST_M);
+
+  // Per-layer kill switches
+  private final TunableNumber kEnablePID = new TunableNumber("HeadingLock/enablePID", 1.0);
+  private final TunableNumber kEnableFF = new TunableNumber("HeadingLock/enableFF", 0.0);
+  private final TunableNumber kEnableLookahead =
+      new TunableNumber("HeadingLock/enableLookahead", 0.0);
+
+  private final PIDController pid;
+  private final LinearFilter omegaFilter = LinearFilter.movingAverage(5);
+
+  private double filteredOmega = 0;
+  private double previousFilteredOmega = 0;
+  private double lastPIDOutput = 0;
+  private double lastFFOutput = 0;
+  private double lastTotalOutput = 0;
+
+  // Hysteresis: once at setpoint, widen tolerance 4x so brief oscillations
+  // near the boundary don't flicker ReadyToShoot.
+  private static final double HYSTERESIS_FACTOR = 4.0;
+  private boolean stickyAtSetpoint = false;
+
+  public HeadingController() {
+    pid = new PIDController(kP.get(), kI.get(), kD.get());
+    pid.enableContinuousInput(-Math.PI, Math.PI);
+    pid.setTolerance(Math.toRadians(1.0));
+  }
+
+  /** Returns omega (rad/s) to drive heading toward target. */
+  public double calculate(
+      Rotation2d currentHeading,
+      Rotation2d targetHeading,
+      double desiredOmegaRadPerSec,
+      double distanceToTargetM,
+      double maxOmegaRadPerSec) {
+
+    // Update PID gains if changed on dashboard
+    TunableNumber.ifChanged(() -> pid.setPID(kP.get(), kI.get(), kD.get()), kP, kI, kD);
+
+    // Filter desired omega to reduce noise (5-sample = 100ms at 50Hz)
+    filteredOmega = omegaFilter.calculate(desiredOmegaRadPerSec);
+
+    boolean pidEnabled = kEnablePID.get() > 0.5;
+    boolean ffEnabled = kEnableFF.get() > 0.5;
+    boolean lookaheadEnabled = kEnableLookahead.get() > 0.5;
+
+    double headingSpeed = 0;
+
+    // Layer 1: PID
+    if (pidEnabled) {
+      double target = targetHeading.getRadians();
+
+      // Layer 3: Lookahead (shifts the target the PID aims at)
+      if (lookaheadEnabled && kLookaheadSec.get() > 0) {
+        double dt = kLookaheadSec.get();
+        target = target + filteredOmega * dt;
+      }
+
+      lastPIDOutput = pid.calculate(currentHeading.getRadians(), target);
+      headingSpeed = lastPIDOutput;
+    } else {
+      lastPIDOutput = 0;
+    }
+
+    // base omega so PID only corrects error, not the full tracking rate
+    headingSpeed += filteredOmega;
+
+    // Layer 2: Feedforward
+    if (ffEnabled) {
+      double distScale = computeDistanceScale(distanceToTargetM);
+
+      // Angular acceleration from filtered omega (finite difference at 50Hz)
+      double alpha = (filteredOmega - previousFilteredOmega) / 0.02;
+
+      lastFFOutput =
+          (kS.get() * Math.signum(filteredOmega) + kV.get() * filteredOmega + kA.get() * alpha)
+              * distScale;
+
+      headingSpeed += lastFFOutput;
+    } else {
+      lastFFOutput = 0;
+    }
+
+    // Fallback: legacy P-only when both PID and FF disabled
+    if (!pidEnabled && !ffEnabled) {
+      double error =
+          MathUtil.angleModulus(targetHeading.getRadians() - currentHeading.getRadians());
+      headingSpeed = error * 2.0 + desiredOmegaRadPerSec;
+      lastPIDOutput = 0;
+      lastFFOutput = 0;
+    }
+
+    previousFilteredOmega = filteredOmega;
+
+    lastTotalOutput = MathUtil.clamp(headingSpeed, -maxOmegaRadPerSec, maxOmegaRadPerSec);
+    return lastTotalOutput;
+  }
+
+  /** FF scales 0..1 by distance so it doesn't overcorrect up close. */
+  double computeDistanceScale(double distance) {
+    double minD = kFFMinDist.get();
+    double maxD = kFFMaxDist.get();
+    if (distance <= minD) return 0.0;
+    if (distance >= maxD) return 1.0;
+    return (distance - minD) / (maxD - minD);
+  }
+
+  /** Reset all state. Call in command initialize(). */
+  public void reset() {
+    pid.reset();
+    omegaFilter.reset();
+    filteredOmega = 0;
+    previousFilteredOmega = 0;
+    lastPIDOutput = 0;
+    lastFFOutput = 0;
+    lastTotalOutput = 0;
+    stickyAtSetpoint = false;
+  }
+
+  // Telemetry accessors
+  public double getFilteredOmega() {
+    return filteredOmega;
+  }
+
+  public double getPositionError() {
+    return pid.getPositionError();
+  }
+
+  public double getPIDOutput() {
+    return lastPIDOutput;
+  }
+
+  public double getFFOutput() {
+    return lastFFOutput;
+  }
+
+  public double getTotalOutput() {
+    return lastTotalOutput;
+  }
+
+  /** Sticky setpoint with 4x hysteresis band so it doesn't flicker near the edge. */
+  public boolean atSetpoint() {
+    double errorRad = Math.abs(pid.getPositionError());
+    double toleranceRad = Math.toRadians(1.0);
+
+    if (!stickyAtSetpoint) {
+      if (errorRad <= toleranceRad) {
+        stickyAtSetpoint = true;
+      }
+    } else {
+      if (errorRad > toleranceRad * HYSTERESIS_FACTOR) {
+        stickyAtSetpoint = false;
+      }
+    }
+    return stickyAtSetpoint;
+  }
+
+  public boolean isPIDEnabled() {
+    return kEnablePID.get() > 0.5;
+  }
+
+  public boolean isFFEnabled() {
+    return kEnableFF.get() > 0.5;
+  }
+
+  public boolean isLookaheadEnabled() {
+    return kEnableLookahead.get() > 0.5;
+  }
+}

--- a/src/main/java/frc/robot/util/HubShiftEngine.java
+++ b/src/main/java/frc/robot/util/HubShiftEngine.java
@@ -1,0 +1,358 @@
+package frc.robot.util;
+
+import edu.wpi.first.wpilibj.DriverStation;
+import edu.wpi.first.wpilibj.Timer;
+import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
+import frc.robot.Constants.HubTimingConstants;
+import frc.robot.telemetry.SafeLog;
+
+/**
+ * Tracks which hub is active based on the shift schedule, auto winner, and TOF-shifted boundaries.
+ * Call initializeTeleop() at teleop start, update() every robotPeriodic().
+ */
+public class HubShiftEngine {
+  private static HubShiftEngine instance;
+
+  public enum ShiftPhase {
+    DISABLED,
+    AUTO,
+    TRANSITION,
+    SHIFT1,
+    SHIFT2,
+    SHIFT3,
+    SHIFT4,
+    ENDGAME
+  }
+
+  public enum ScheduleConfidence {
+    HIGH,
+    LOW,
+    FALLBACK
+  }
+
+  public record ShiftInfo(
+      ShiftPhase phase,
+      boolean hubActive,
+      double elapsedInPhase,
+      double remainingInState,
+      double timeToNextActive,
+      double timeUntilDeactivation) {}
+
+  private static final double[] PHASE_STARTS = {
+    0.0,
+    HubTimingConstants.TRANSITION_END,
+    HubTimingConstants.SHIFT1_END,
+    HubTimingConstants.SHIFT2_END,
+    HubTimingConstants.SHIFT3_END,
+    HubTimingConstants.SHIFT4_END
+  };
+  private static final double[] PHASE_ENDS = {
+    HubTimingConstants.TRANSITION_END,
+    HubTimingConstants.SHIFT1_END,
+    HubTimingConstants.SHIFT2_END,
+    HubTimingConstants.SHIFT3_END,
+    HubTimingConstants.SHIFT4_END,
+    HubTimingConstants.ENDGAME_END
+  };
+  private static final ShiftPhase[] PHASES = {
+    ShiftPhase.TRANSITION,
+    ShiftPhase.SHIFT1,
+    ShiftPhase.SHIFT2,
+    ShiftPhase.SHIFT3,
+    ShiftPhase.SHIFT4,
+    ShiftPhase.ENDGAME
+  };
+
+  // won auto = our hub was active first, so inactive in shift1
+  private static final boolean[] WON_SCHEDULE = {true, false, true, false, true, true};
+  private static final boolean[] LOST_SCHEDULE = {true, true, false, true, false, true};
+
+  private final Timer teleopTimer = new Timer();
+  private boolean teleopStarted = false;
+
+  private boolean wonAuto = false;
+  private boolean wonAutoFromFMS = false;
+  private boolean wonAutoOverrideSet = false;
+  private boolean wonAutoOverrideValue = false;
+  private ScheduleConfidence confidence = ScheduleConfidence.FALLBACK;
+  private boolean scheduleLocked = false;
+
+  private final TunableNumber hubTrackingEnabled =
+      new TunableNumber("HubShift/TrackingEnabled", 1.0);
+  private final TunableNumber featureEnabled = new TunableNumber("HubShift/FireAuthEnabled", 1.0);
+
+  private final TunableNumber fuelCountDelayMin =
+      new TunableNumber("HubShift/FuelDelayMinSec", HubTimingConstants.FUEL_COUNT_DELAY_MIN_SEC);
+  private final TunableNumber fuelCountDelayMax =
+      new TunableNumber("HubShift/FuelDelayMaxSec", HubTimingConstants.FUEL_COUNT_DELAY_MAX_SEC);
+  private final TunableNumber fuelCountExtension =
+      new TunableNumber("HubShift/FuelExtensionSec", HubTimingConstants.FUEL_COUNT_EXTENSION_SEC);
+
+  private ShiftInfo officialInfo;
+  private ShiftInfo shiftedInfo;
+
+  // pre-allocated to avoid GC pressure in the 20ms loop
+  private final double[] shiftedStartsBuf = new double[PHASE_STARTS.length];
+  private final double[] shiftedEndsBuf = new double[PHASE_ENDS.length];
+  private double currentTOF = 0;
+  private boolean gameDataMissing = false;
+
+  private HubShiftEngine() {
+    officialInfo = new ShiftInfo(ShiftPhase.DISABLED, true, 0, 0, 0, 0);
+    shiftedInfo = officialInfo;
+  }
+
+  public static HubShiftEngine getInstance() {
+    if (instance == null) {
+      instance = new HubShiftEngine();
+    }
+    return instance;
+  }
+
+  /** Call at teleop start (from Robot.teleopInit()). */
+  public void initializeTeleop() {
+    teleopTimer.restart();
+    teleopStarted = true;
+    scheduleLocked = false;
+    parseAutoWinner();
+  }
+
+  /** Call every robotPeriodic(). Pass current TOF from ShotCalculator. */
+  public void update(double shotTOF) {
+    currentTOF = Math.max(0, shotTOF);
+
+    if (!teleopStarted || !DriverStation.isTeleop()) {
+      officialInfo =
+          new ShiftInfo(
+              DriverStation.isAutonomous() ? ShiftPhase.AUTO : ShiftPhase.DISABLED,
+              true,
+              0,
+              0,
+              0,
+              Double.MAX_VALUE);
+      shiftedInfo = officialInfo;
+      gameDataMissing = false;
+      return;
+    }
+
+    if (!scheduleLocked) {
+      parseAutoWinner();
+    }
+
+    double elapsed = teleopTimer.get();
+    boolean[] schedule = wonAuto ? WON_SCHEDULE : LOST_SCHEDULE;
+
+    officialInfo = computeShiftInfo(schedule, PHASE_STARTS, PHASE_ENDS, elapsed);
+
+    if (isFeatureEnabled() && currentTOF > 0) {
+      double approachingOffset = -(currentTOF + fuelCountDelayMin.get());
+      double endingOffset = fuelCountExtension.get() - (currentTOF + fuelCountDelayMax.get());
+      fillShiftedBoundaries(
+          shiftedStartsBuf, PHASE_STARTS, schedule, approachingOffset, endingOffset);
+      fillShiftedBoundaries(shiftedEndsBuf, PHASE_ENDS, schedule, approachingOffset, endingOffset);
+      shiftedInfo = computeShiftInfo(schedule, shiftedStartsBuf, shiftedEndsBuf, elapsed);
+    } else {
+      shiftedInfo = officialInfo;
+    }
+
+    gameDataMissing =
+        DriverStation.isFMSAttached()
+            && !wonAutoFromFMS
+            && !wonAutoOverrideSet
+            && elapsed < HubTimingConstants.TRANSITION_END;
+
+    logTelemetry();
+  }
+
+  private void parseAutoWinner() {
+    if (wonAutoOverrideSet) {
+      wonAuto = wonAutoOverrideValue;
+      wonAutoFromFMS = false;
+      confidence = ScheduleConfidence.LOW;
+      scheduleLocked = true;
+      return;
+    }
+
+    String message = DriverStation.getGameSpecificMessage();
+    if (message != null && !message.isEmpty()) {
+      char winner = message.charAt(0);
+      var ourAlliance = DriverStation.getAlliance();
+      if (ourAlliance.isPresent()) {
+        boolean redWon = (winner == 'R');
+        boolean weAreRed = (ourAlliance.get() == DriverStation.Alliance.Red);
+        wonAuto = (redWon == weAreRed);
+        wonAutoFromFMS = true;
+        confidence = ScheduleConfidence.HIGH;
+        scheduleLocked = true;
+        return;
+      }
+    }
+
+    if (!DriverStation.isFMSAttached()) {
+      wonAuto = SmartDashboard.getBoolean("WonAuto", false);
+      wonAutoFromFMS = false;
+      confidence = ScheduleConfidence.LOW;
+      return;
+    }
+
+    wonAuto = false;
+    wonAutoFromFMS = false;
+    confidence = ScheduleConfidence.FALLBACK;
+  }
+
+  private ShiftInfo computeShiftInfo(
+      boolean[] schedule, double[] starts, double[] ends, double elapsed) {
+    int phaseIndex = -1;
+    for (int i = 0; i < starts.length; i++) {
+      if (elapsed >= starts[i] && elapsed < ends[i]) {
+        phaseIndex = i;
+        break;
+      }
+    }
+    if (phaseIndex < 0) {
+      phaseIndex = starts.length - 1;
+    }
+
+    ShiftPhase phase = PHASES[phaseIndex];
+    boolean hubActive = isHubTrackingEnabled() ? schedule[phaseIndex] : true;
+    double elapsedInPhase = elapsed - starts[phaseIndex];
+    double remainingInPhase = ends[phaseIndex] - elapsed;
+
+    double remainingInState = remainingInPhase;
+    if (phaseIndex < ends.length - 1 && schedule[phaseIndex] == schedule[phaseIndex + 1]) {
+      remainingInState = ends[phaseIndex + 1] - elapsed;
+    }
+
+    double timeToNextActive = 0;
+    if (!hubActive) {
+      for (int i = phaseIndex + 1; i < schedule.length; i++) {
+        if (schedule[i]) {
+          timeToNextActive = starts[i] - elapsed;
+          break;
+        }
+      }
+    }
+
+    double timeUntilDeactivation = Double.MAX_VALUE;
+    if (hubActive) {
+      for (int i = phaseIndex; i < schedule.length; i++) {
+        if (!schedule[i] || i == schedule.length - 1) {
+          timeUntilDeactivation =
+              (i < schedule.length && !schedule[i]) ? starts[i] - elapsed : ends[i] - elapsed;
+          break;
+        }
+      }
+    }
+
+    return new ShiftInfo(
+        phase,
+        hubActive,
+        elapsedInPhase,
+        remainingInState,
+        timeToNextActive,
+        timeUntilDeactivation);
+  }
+
+  private void fillShiftedBoundaries(
+      double[] out,
+      double[] boundaries,
+      boolean[] schedule,
+      double approachingOffset,
+      double endingOffset) {
+    out[0] = boundaries[0];
+
+    for (int i = 1; i < boundaries.length; i++) {
+      boolean prevActive = schedule[Math.min(i - 1, schedule.length - 1)];
+      boolean nextActive = schedule[Math.min(i, schedule.length - 1)];
+
+      if (!prevActive && nextActive) {
+        out[i] = boundaries[i] + approachingOffset;
+      } else if (prevActive && !nextActive) {
+        out[i] = boundaries[i] + endingOffset;
+      } else {
+        out[i] = boundaries[i];
+      }
+    }
+  }
+
+  private void logTelemetry() {
+    SafeLog.put("HubShift/Phase", officialInfo.phase().name());
+    SafeLog.put("HubShift/OfficialActive", officialInfo.hubActive());
+    SafeLog.put("HubShift/ShiftedActive", shiftedInfo.hubActive());
+    SafeLog.put("HubShift/ElapsedInPhase", officialInfo.elapsedInPhase());
+    SafeLog.put("HubShift/RemainingInState", officialInfo.remainingInState());
+    SafeLog.put("HubShift/TimeToNextActive", officialInfo.timeToNextActive());
+    SafeLog.put("HubShift/TimeUntilDeactivation", officialInfo.timeUntilDeactivation());
+    SafeLog.put("HubShift/WonAuto", wonAuto);
+    SafeLog.put("HubShift/WonAutoFromFMS", wonAutoFromFMS);
+    SafeLog.put("HubShift/ScheduleConfidence", confidence.name());
+    SafeLog.put("HubShift/GameDataMissing", gameDataMissing);
+    SafeLog.put("HubShift/TrackingEnabled", isHubTrackingEnabled());
+    SafeLog.put("HubShift/CurrentTOF", currentTOF);
+  }
+
+  public ShiftInfo getOfficialInfo() {
+    return officialInfo;
+  }
+
+  public ShiftInfo getShiftedInfo() {
+    return shiftedInfo;
+  }
+
+  public ScheduleConfidence getConfidence() {
+    return confidence;
+  }
+
+  public boolean isGameDataMissing() {
+    return gameDataMissing;
+  }
+
+  public boolean isHubTrackingEnabled() {
+    return hubTrackingEnabled.get() >= 0.5;
+  }
+
+  public boolean isFeatureEnabled() {
+    return featureEnabled.get() >= 0.5;
+  }
+
+  public boolean isWonAuto() {
+    return wonAuto;
+  }
+
+  public boolean isWonAutoFromFMS() {
+    return wonAutoFromFMS;
+  }
+
+  public void setWonAutoOverride(boolean won) {
+    wonAutoOverrideSet = true;
+    wonAutoOverrideValue = won;
+    wonAuto = won;
+    confidence = ScheduleConfidence.LOW;
+    scheduleLocked = true;
+  }
+
+  public void clearWonAutoOverride() {
+    wonAutoOverrideSet = false;
+    scheduleLocked = false;
+  }
+
+  public double getTeleopElapsed() {
+    return teleopStarted ? teleopTimer.get() : 0;
+  }
+
+  public double getFuelCountDelayMin() {
+    return fuelCountDelayMin.get();
+  }
+
+  public double getFuelCountDelayMax() {
+    return fuelCountDelayMax.get();
+  }
+
+  public double getFuelCountExtension() {
+    return fuelCountExtension.get();
+  }
+
+  static void resetInstance() {
+    instance = null;
+  }
+}

--- a/src/main/java/frc/robot/util/ShotCalculator.java
+++ b/src/main/java/frc/robot/util/ShotCalculator.java
@@ -1,0 +1,445 @@
+package frc.robot.util;
+
+import edu.wpi.first.math.MathUtil;
+import edu.wpi.first.math.geometry.Pose2d;
+import edu.wpi.first.math.geometry.Rotation2d;
+import edu.wpi.first.math.geometry.Translation2d;
+import edu.wpi.first.math.geometry.Twist2d;
+import edu.wpi.first.math.kinematics.ChassisSpeeds;
+import edu.wpi.first.wpilibj.DriverStation;
+import edu.wpi.first.wpilibj.Timer;
+import frc.robot.Constants.HubScoringConstants;
+import frc.robot.Constants.ShotCalculatorConstants;
+import frc.robot.subsystems.swervedrive.SwerveSubsystem;
+import frc.robot.telemetry.SafeLog;
+
+/**
+ * Ballistic fire control for competition. Newton TOF solver, LUT lookup, band multipliers, and SOTM
+ * heading compensation. calculate() runs once per robotPeriodic(), commands read the cache.
+ */
+public class ShotCalculator {
+
+  public record LaunchParameters(
+      double rpm,
+      double hoodAngleDeg,
+      double timeOfFlightSec,
+      Rotation2d driveAngle,
+      double driveAngularVelocityRadPerSec,
+      boolean isValid,
+      double confidence,
+      boolean passing) {
+    public static final LaunchParameters INVALID =
+        new LaunchParameters(0, 0, 0, new Rotation2d(), 0, false, 0, false);
+  }
+
+  private static ShotCalculator instance;
+
+  public static ShotCalculator getInstance() {
+    if (instance == null) {
+      instance = new ShotCalculator();
+    }
+    return instance;
+  }
+
+  // Tunable parameters
+  private final TunableNumber kMinSOTMSpeed =
+      new TunableNumber("ShotCalc/minSOTMSpeed", ShotCalculatorConstants.MIN_SOTM_SPEED);
+  private final TunableNumber kPhaseDelayMs =
+      new TunableNumber("ShotCalc/phaseDelayMs", ShotCalculatorConstants.PHASE_DELAY_MS);
+  private final TunableNumber kMechLatencyMs =
+      new TunableNumber("ShotCalc/mechLatencyMs", ShotCalculatorConstants.MECH_LATENCY_MS);
+  private final TunableNumber kMaxIterations =
+      new TunableNumber("ShotCalc/maxIterations", ShotCalculatorConstants.MAX_ITERATIONS);
+  private final TunableNumber kConvergenceTolerance =
+      new TunableNumber(
+          "ShotCalc/convergenceTolerance", ShotCalculatorConstants.CONVERGENCE_TOLERANCE);
+  private final TunableNumber kMaxSOTMSpeed =
+      new TunableNumber("ShotCalc/maxSOTMSpeed", ShotCalculatorConstants.MAX_SOTM_SPEED);
+  private final TunableNumber kSOTMDragCoeff =
+      new TunableNumber("ShotCalc/sotmDragCoeff", ShotCalculatorConstants.SOTM_DRAG_COEFF);
+
+  // Per-distance band RPM multipliers for field-day calibration
+  private final TunableNumber kRpmMultShort = new TunableNumber("ShotCalc/RPMMultShort", 1.0);
+  private final TunableNumber kRpmMultMedium = new TunableNumber("ShotCalc/RPMMultMedium", 1.0);
+  private final TunableNumber kRpmMultLong = new TunableNumber("ShotCalc/RPMMultLong", 1.0);
+
+  // nonzero = bypass LUT and use this RPM for every shot
+  private final TunableNumber kRpmOverride = new TunableNumber("ShotCalc/RPMOverride", 0);
+
+  private final ShotLUT baseLUT = new ShotLUT();
+
+  // Solver state (reused across cycles)
+  private double previousTOF = -1;
+  private int iterationsUsed = 0;
+  private boolean warmStartUsed = false;
+  private boolean velocityFiltered = false;
+  private boolean behindHub = false;
+  private boolean speedCapped = false;
+  private double solvedDistance = 0;
+
+  // Previous robot-relative velocity for acceleration estimation
+  private double prevRobotVx = 0;
+  private double prevRobotVy = 0;
+  private double prevRobotOmega = 0;
+  private double prevTimestamp = -1;
+
+  private double polarSpeedLimitMps = 0;
+  private LaunchParameters cachedParameters = LaunchParameters.INVALID;
+  private SwerveSubsystem swerve;
+
+  private ShotCalculator() {
+    initializeBaselineLUT();
+  }
+
+  /** Starting LUT from physics sim. Needs real-robot calibration. */
+  private void initializeBaselineLUT() {
+    double angle = ShotCalculatorConstants.FIXED_LAUNCH_ANGLE_DEG;
+    baseLUT.put(0.50, 2800.0, angle, 0.42);
+    baseLUT.put(1.00, 3200.0, angle, 0.62);
+    baseLUT.put(1.20, 3400.0, angle, 0.70);
+    baseLUT.put(1.50, 3550.0, angle, 0.80);
+    baseLUT.put(2.00, 3750.0, angle, 0.93);
+    baseLUT.put(2.50, 3950.0, angle, 1.07);
+    baseLUT.put(3.00, 4150.0, angle, 1.22);
+    baseLUT.put(3.50, 4350.0, angle, 1.40);
+    baseLUT.put(4.00, 4550.0, angle, 1.59);
+    baseLUT.put(4.50, 4750.0, angle, 1.80);
+    baseLUT.put(5.00, 4950.0, angle, 2.03);
+  }
+
+  /** Set swerve reference. Called from RobotContainer during init. */
+  public void setSwerve(SwerveSubsystem swerve) {
+    this.swerve = swerve;
+  }
+
+  // LUT access with per-distance band multiplier
+  double effectiveRPM(double distance) {
+    return baseLUT.getRPM(distance) * getDistanceBandMultiplier(distance);
+  }
+
+  private double getDistanceBandMultiplier(double distance) {
+    if (distance < ShotCalculatorConstants.RPM_BAND_SHORT_END) return kRpmMultShort.get();
+    if (distance < ShotCalculatorConstants.RPM_BAND_MEDIUM_END) return kRpmMultMedium.get();
+    return kRpmMultLong.get();
+  }
+
+  double effectiveTOF(double distance) {
+    return baseLUT.getTOF(distance);
+  }
+
+  double effectiveAngle(double distance) {
+    return baseLUT.getAngle(distance);
+  }
+
+  /** TOF adjusted for inherited velocity drag decay. Reduces to raw tof when drag coeff ~ 0. */
+  private double dragCompensatedTOF(double tof) {
+    double c = kSOTMDragCoeff.get();
+    if (c < 1e-6) return tof;
+    return (1.0 - Math.exp(-c * tof)) / c;
+  }
+
+  private static final double DERIV_H = 0.01;
+
+  double tofMapDerivative(double d) {
+    double tHigh = effectiveTOF(d + DERIV_H);
+    double tLow = effectiveTOF(d - DERIV_H);
+    return (tHigh - tLow) / (2.0 * DERIV_H);
+  }
+
+  /** Run once per robotPeriodic(). Caches the result for commands to read. */
+  public LaunchParameters calculate() {
+    if (swerve == null) {
+      cachedParameters = LaunchParameters.INVALID;
+      return cachedParameters;
+    }
+
+    try {
+      cachedParameters = computeSolution();
+    } catch (Throwable t) {
+      cachedParameters = LaunchParameters.INVALID;
+    }
+
+    logTelemetry();
+    return cachedParameters;
+  }
+
+  private LaunchParameters computeSolution() {
+    Pose2d rawPose = swerve.getPose();
+    ChassisSpeeds robotVel = swerve.getRobotVelocity();
+
+    if (rawPose == null || robotVel == null) {
+      return LaunchParameters.INVALID;
+    }
+    double poseX = rawPose.getX();
+    double poseY = rawPose.getY();
+    if (Double.isNaN(poseX)
+        || Double.isNaN(poseY)
+        || Double.isInfinite(poseX)
+        || Double.isInfinite(poseY)) {
+      return LaunchParameters.INVALID;
+    }
+
+    // Second-order pose prediction
+    double now = Timer.getFPGATimestamp();
+    double cycleDt = (prevTimestamp > 0) ? MathUtil.clamp(now - prevTimestamp, 0.005, 0.1) : 0.02;
+    prevTimestamp = now;
+    double dt = kPhaseDelayMs.get() / 1000.0;
+    double ax = (robotVel.vxMetersPerSecond - prevRobotVx) / cycleDt;
+    double ay = (robotVel.vyMetersPerSecond - prevRobotVy) / cycleDt;
+    double aOmega = (robotVel.omegaRadiansPerSecond - prevRobotOmega) / cycleDt;
+    Pose2d compensatedPose =
+        rawPose.exp(
+            new Twist2d(
+                robotVel.vxMetersPerSecond * dt + 0.5 * ax * dt * dt,
+                robotVel.vyMetersPerSecond * dt + 0.5 * ay * dt * dt,
+                robotVel.omegaRadiansPerSecond * dt + 0.5 * aOmega * dt * dt));
+    prevRobotVx = robotVel.vxMetersPerSecond;
+    prevRobotVy = robotVel.vyMetersPerSecond;
+    prevRobotOmega = robotVel.omegaRadiansPerSecond;
+
+    double robotX = compensatedPose.getX();
+    double robotY = compensatedPose.getY();
+    double heading = compensatedPose.getRotation().getRadians();
+
+    Translation2d hubCenter = getHubCenter();
+    double hubX = hubCenter.getX();
+    double hubY = hubCenter.getY();
+
+    // Behind-hub detection
+    Translation2d hubForward = getHubForward();
+    double dot = (hubX - robotX) * hubForward.getX() + (hubY - robotY) * hubForward.getY();
+    behindHub = dot < 0;
+    if (behindHub) {
+      return LaunchParameters.INVALID;
+    }
+
+    // Transform robot center to launcher position
+    double cosH = Math.cos(heading);
+    double sinH = Math.sin(heading);
+    double launcherX =
+        robotX
+            + ShotCalculatorConstants.LAUNCHER_OFFSET_X * cosH
+            - ShotCalculatorConstants.LAUNCHER_OFFSET_Y * sinH;
+    double launcherY =
+        robotY
+            + ShotCalculatorConstants.LAUNCHER_OFFSET_X * sinH
+            + ShotCalculatorConstants.LAUNCHER_OFFSET_Y * cosH;
+
+    // Robot field velocity from measured robot-relative velocity
+    double robotFieldVx = robotVel.vxMetersPerSecond * cosH - robotVel.vyMetersPerSecond * sinH;
+    double robotFieldVy = robotVel.vxMetersPerSecond * sinH + robotVel.vyMetersPerSecond * cosH;
+
+    // Launcher velocity: v_robot_field + omega x r_launcher
+    double launcherFieldOffX =
+        ShotCalculatorConstants.LAUNCHER_OFFSET_X * cosH
+            - ShotCalculatorConstants.LAUNCHER_OFFSET_Y * sinH;
+    double launcherFieldOffY =
+        ShotCalculatorConstants.LAUNCHER_OFFSET_X * sinH
+            + ShotCalculatorConstants.LAUNCHER_OFFSET_Y * cosH;
+    double omega = robotVel.omegaRadiansPerSecond;
+    double vx = robotFieldVx + (-launcherFieldOffY) * omega;
+    double vy = robotFieldVy + launcherFieldOffX * omega;
+
+    // Displacement from launcher to hub
+    double rx = hubX - launcherX;
+    double ry = hubY - launcherY;
+    double distance = Math.hypot(rx, ry);
+    solvedDistance = distance;
+
+    if (distance < ShotCalculatorConstants.MIN_SCORING_DISTANCE
+        || distance > ShotCalculatorConstants.MAX_SCORING_DISTANCE) {
+      return LaunchParameters.INVALID;
+    }
+
+    double robotSpeed = Math.hypot(vx, vy);
+
+    // Speed cap
+    speedCapped = robotSpeed > kMaxSOTMSpeed.get();
+    if (speedCapped) {
+      return LaunchParameters.INVALID;
+    }
+
+    velocityFiltered = robotSpeed < kMinSOTMSpeed.get();
+
+    double solvedTOF;
+    double projDist;
+
+    if (velocityFiltered) {
+      // Static shot: no velocity compensation
+      solvedTOF = effectiveTOF(distance);
+      projDist = distance;
+      iterationsUsed = 0;
+      warmStartUsed = false;
+    } else {
+      // Newton TOF solver
+      int maxIter = (int) kMaxIterations.get();
+      double convTol = kConvergenceTolerance.get();
+
+      double tof;
+      if (previousTOF > 0) {
+        tof = previousTOF;
+        warmStartUsed = true;
+      } else {
+        tof = effectiveTOF(distance);
+        warmStartUsed = false;
+      }
+
+      projDist = distance;
+      iterationsUsed = 0;
+
+      for (int i = 0; i < maxIter; i++) {
+        double prevTOF = tof;
+
+        double driftTOF = dragCompensatedTOF(tof);
+        double prx = rx - vx * driftTOF;
+        double pry = ry - vy * driftTOF;
+        projDist = Math.hypot(prx, pry);
+
+        if (projDist < 0.01) {
+          tof = effectiveTOF(distance);
+          iterationsUsed = maxIter + 1;
+          break;
+        }
+
+        double lookupTOF = effectiveTOF(projDist);
+
+        // Analytical derivative
+        double dragDeriv = Math.exp(-kSOTMDragCoeff.get() * tof);
+        double dPrime = -dragDeriv * (prx * vx + pry * vy) / projDist;
+        double gPrime = tofMapDerivative(projDist);
+        double f = lookupTOF - tof;
+        double fPrime = gPrime * dPrime - 1.0;
+
+        if (Math.abs(fPrime) > 0.01) {
+          tof = tof - f / fPrime;
+        } else {
+          tof = lookupTOF;
+        }
+
+        tof = MathUtil.clamp(tof, ShotCalculatorConstants.TOF_MIN, ShotCalculatorConstants.TOF_MAX);
+        iterationsUsed = i + 1;
+
+        if (Math.abs(tof - prevTOF) < convTol) {
+          break;
+        }
+      }
+
+      // Divergence guard
+      if (tof > ShotCalculatorConstants.TOF_MAX || tof < 0.0 || Double.isNaN(tof)) {
+        tof = effectiveTOF(distance);
+        iterationsUsed = (int) kMaxIterations.get() + 1;
+      }
+
+      solvedTOF = tof;
+    }
+
+    previousTOF = solvedTOF;
+    double effectiveTOFValue = solvedTOF + kMechLatencyMs.get() / 1000.0;
+    double overrideRPM = kRpmOverride.get();
+    double effectiveRPMValue = (overrideRPM > 0) ? overrideRPM : effectiveRPM(projDist);
+
+    // Drive angle: aim at velocity-compensated target position
+    double compTargetX;
+    double compTargetY;
+    if (velocityFiltered) {
+      compTargetX = hubX;
+      compTargetY = hubY;
+    } else {
+      double headingDriftTOF = dragCompensatedTOF(solvedTOF);
+      compTargetX = hubX - vx * headingDriftTOF;
+      compTargetY = hubY - vy * headingDriftTOF;
+    }
+
+    double aimX = compTargetX - robotX;
+    double aimY = compTargetY - robotY;
+    Rotation2d driveAngle =
+        new Rotation2d(aimX, aimY)
+            .plus(new Rotation2d(ShotCalculatorConstants.SHOOTER_ANGLE_OFFSET_RAD));
+
+    // Angular velocity feedforward
+    double driveAngularVelocity = 0;
+    if (!velocityFiltered && distance > 0.1) {
+      double tangentialVel = (ry * vx - rx * vy) / distance;
+      driveAngularVelocity = tangentialVel / distance;
+    }
+
+    // Simple polar speed limit
+    polarSpeedLimitMps = computePolarSpeedLimit(distance, 2.0);
+
+    // Stripped confidence: valid = 100, invalid = 0
+    double confidence = 100.0;
+    boolean passing = false;
+    boolean isValid = true;
+
+    double hoodAngle = effectiveAngle(projDist);
+
+    return new LaunchParameters(
+        effectiveRPMValue,
+        hoodAngle,
+        effectiveTOFValue,
+        driveAngle,
+        driveAngularVelocity,
+        isValid,
+        confidence,
+        passing);
+  }
+
+  /** Max driver speed before the aim can't keep up with the angular rate. */
+  public static double computePolarSpeedLimit(double distanceM, double maxAngularRateRadPerSec) {
+    if (distanceM < 0.5) return 0.5;
+    return maxAngularRateRadPerSec * distanceM;
+  }
+
+  public Translation2d getHubCenter() {
+    var alliance = DriverStation.getAlliance();
+    if (alliance.isPresent() && alliance.get() == DriverStation.Alliance.Red) {
+      return HubScoringConstants.RED_HUB_CENTER;
+    }
+    return HubScoringConstants.BLUE_HUB_CENTER;
+  }
+
+  /** Hub forward vector points from hub toward the scoring side. */
+  public Translation2d getHubForward() {
+    var alliance = DriverStation.getAlliance();
+    if (alliance.isPresent() && alliance.get() == DriverStation.Alliance.Red) {
+      return new Translation2d(-1, 0);
+    }
+    return new Translation2d(1, 0);
+  }
+
+  private void logTelemetry() {
+    SafeLog.put("ShotCalc/EffectiveRPM", cachedParameters.rpm());
+    SafeLog.put("ShotCalc/HoodAngleDeg", cachedParameters.hoodAngleDeg());
+    SafeLog.put("ShotCalc/EffectiveTOF", cachedParameters.timeOfFlightSec());
+    SafeLog.put("ShotCalc/Distance", solvedDistance);
+    SafeLog.put(
+        "ShotCalc/DriveAngleDeg", Math.toDegrees(cachedParameters.driveAngle().getRadians()));
+    SafeLog.put("ShotCalc/IsValid", cachedParameters.isValid());
+    SafeLog.put("ShotCalc/ConvergenceIterations", iterationsUsed);
+    SafeLog.put("ShotCalc/WarmStartUsed", warmStartUsed);
+    SafeLog.put("ShotCalc/VelocityFiltered", velocityFiltered);
+    SafeLog.put("ShotCalc/BehindHub", behindHub);
+    SafeLog.put("ShotCalc/SpeedCapped", speedCapped);
+    SafeLog.put("ShotCalc/HubCenterX", getHubCenter().getX());
+    SafeLog.put("ShotCalc/HubCenterY", getHubCenter().getY());
+    SafeLog.put("ShotCalc/PolarSpeedLimitMps", polarSpeedLimitMps);
+    SafeLog.put("ShotCalc/RPMOverrideActive", kRpmOverride.get() > 0);
+  }
+
+  public LaunchParameters getParameters() {
+    return cachedParameters;
+  }
+
+  public double getSolvedDistance() {
+    return solvedDistance;
+  }
+
+  public double getPolarSpeedLimitMps() {
+    return polarSpeedLimitMps;
+  }
+
+  /** Returns the dashboard RPM override, or 0 if not set. */
+  public double getRpmOverride() {
+    return kRpmOverride.get();
+  }
+}

--- a/src/main/java/frc/robot/util/ShotLUT.java
+++ b/src/main/java/frc/robot/util/ShotLUT.java
@@ -1,0 +1,59 @@
+package frc.robot.util;
+
+import edu.wpi.first.math.interpolation.InterpolatingTreeMap;
+import edu.wpi.first.math.interpolation.InverseInterpolator;
+
+/** Distance-to-ShotParameters LUT with interpolation. Bundles RPM, angle, and TOF together. */
+public class ShotLUT {
+
+  private final InterpolatingTreeMap<Double, ShotParameters> map;
+  private int entryCount = 0;
+
+  public ShotLUT() {
+    map =
+        new InterpolatingTreeMap<>(InverseInterpolator.forDouble(), ShotParameters.interpolator());
+  }
+
+  /** Add or overwrite params at a distance. */
+  public void put(double distanceM, ShotParameters params) {
+    map.put(distanceM, params);
+    entryCount++;
+  }
+
+  /** Shorthand for individual fields. */
+  public void put(double distanceM, double rpm, double angleDeg, double tofSec) {
+    put(distanceM, new ShotParameters(rpm, angleDeg, tofSec));
+  }
+
+  /** Interpolated params at a distance, or ZERO if the map is empty. */
+  public ShotParameters get(double distanceM) {
+    ShotParameters result = map.get(distanceM);
+    return result != null ? result : ShotParameters.ZERO;
+  }
+
+  /** RPM at distance. */
+  public double getRPM(double distanceM) {
+    return get(distanceM).rpm();
+  }
+
+  /** Hood angle at distance. */
+  public double getAngle(double distanceM) {
+    return get(distanceM).angleDeg();
+  }
+
+  /** TOF at distance. */
+  public double getTOF(double distanceM) {
+    return get(distanceM).tofSec();
+  }
+
+  /** Remove all entries. */
+  public void clear() {
+    map.clear();
+    entryCount = 0;
+  }
+
+  /** Rough entry count (overcounts if you put the same distance twice). */
+  public int size() {
+    return entryCount;
+  }
+}

--- a/src/main/java/frc/robot/util/ShotParameters.java
+++ b/src/main/java/frc/robot/util/ShotParameters.java
@@ -1,0 +1,19 @@
+package frc.robot.util;
+
+import edu.wpi.first.math.interpolation.Interpolator;
+
+/** RPM, hood angle, and TOF for one distance. All three interpolate linearly for the LUT. */
+public record ShotParameters(double rpm, double angleDeg, double tofSec) {
+
+  /** All zeros, used when the map is empty. */
+  public static final ShotParameters ZERO = new ShotParameters(0, 0, 0);
+
+  /** Linear interpolator for InterpolatingTreeMap. */
+  public static Interpolator<ShotParameters> interpolator() {
+    return (start, end, t) ->
+        new ShotParameters(
+            start.rpm + t * (end.rpm - start.rpm),
+            start.angleDeg + t * (end.angleDeg - start.angleDeg),
+            start.tofSec + t * (end.tofSec - start.tofSec));
+  }
+}


### PR DESCRIPTION
Fixes #106 

## What this does
- AimAndShootCommand: locks heading toward hub, spins shooter to LUT RPM, feeds when at speed. Driver keeps
 translation control. COR blending for smoother rotation near target.
- HubShiftEngine: tracks the 25s shift schedule, parses auto winner from FMS, TOF-compensated boundaries.
- HeadingController: PID + optional FF + optional lookahead, each layer has a dashboard kill switch.
- Pre-spin trigger spins shooter 5s before hub goes active.
- Emergency dump on POV down bypasses everything.
- Hub deactivation urgency rumble in DriverFeedback.
- try-catch around PID updates in Shooter, Indexer, Hanger periodic().

## New files
- `commands/AimAndShootCommand.java`
- `util/ShotCalculator.java`, `ShotLUT.java`, `ShotParameters.java`
- `util/HubShiftEngine.java`, `util/HeadingController.java`
- `dashboards/elastic/rebuilt_tuning_session.json`
