### PR TITLE
Electrical team dashboards

### DIFF
--- a/dashboards/elastic/electrical.json
+++ b/dashboards/elastic/electrical.json
@@ -1,0 +1,842 @@
+{
+  "version": 1.0,
+  "grid_size": 128,
+  "tabs": [
+    {
+      "name": "Answer",
+      "grid_layout": {
+        "layouts": [],
+        "containers": [
+          {
+            "title": "Status",
+            "x": 0.0,
+            "y": 0.0,
+            "width": 1500.0,
+            "height": 180.0,
+            "type": "Boolean Box",
+            "properties": {
+              "topic": "/AdvantageKit/RealOutputs/CANHealth/MissingCritical",
+              "period": 0.033,
+              "true_color": 4294901760,
+              "false_color": 4278233600,
+              "true_icon": "None",
+              "false_icon": "None"
+            }
+          },
+          {
+            "title": "Status Message",
+            "x": 0.0,
+            "y": 180.0,
+            "width": 1500.0,
+            "height": 80.0,
+            "type": "Text Display",
+            "properties": {
+              "topic": "/AdvantageKit/RealOutputs/CANHealth/StatusMessage",
+              "period": 0.033
+            }
+          },
+          {
+            "title": "Battery",
+            "x": 0.0,
+            "y": 260.0,
+            "width": 500.0,
+            "height": 140.0,
+            "type": "Voltage View",
+            "properties": {
+              "topic": "/AdvantageKit/RealOutputs/SystemHealth/BatteryVoltage",
+              "period": 0.033,
+              "min_value": 8.0,
+              "max_value": 13.0,
+              "divisions": 5,
+              "inverted": false,
+              "orientation": "horizontal"
+            }
+          },
+          {
+            "title": "Devices Online",
+            "x": 500.0,
+            "y": 260.0,
+            "width": 400.0,
+            "height": 140.0,
+            "type": "Number Bar",
+            "properties": {
+              "topic": "/AdvantageKit/RealOutputs/CANHealth/ConnectedCount",
+              "period": 0.033,
+              "min_value": 0.0,
+              "max_value": 21.0,
+              "divisions": 3,
+              "inverted": false,
+              "orientation": "horizontal"
+            }
+          },
+          {
+            "title": "Coprocessor Reboots",
+            "x": 900.0,
+            "y": 260.0,
+            "width": 300.0,
+            "height": 140.0,
+            "type": "Number Bar",
+            "properties": {
+              "topic": "/AdvantageKit/RealOutputs/Vision/Coprocessor/TotalRebootCount",
+              "period": 0.033,
+              "min_value": 0.0,
+              "max_value": 10.0,
+              "divisions": 5,
+              "inverted": true,
+              "orientation": "horizontal"
+            }
+          },
+          {
+            "title": "CAN TxError Peak",
+            "x": 1200.0,
+            "y": 260.0,
+            "width": 300.0,
+            "height": 140.0,
+            "type": "Number Bar",
+            "properties": {
+              "topic": "/AdvantageKit/RealOutputs/CANHealth/TxErrorPeak",
+              "period": 0.033,
+              "min_value": 0.0,
+              "max_value": 150.0,
+              "divisions": 5,
+              "inverted": true,
+              "orientation": "horizontal"
+            }
+          },
+          {
+            "title": "Shooter",
+            "x": 0.0,
+            "y": 400.0,
+            "width": 500.0,
+            "height": 100.0,
+            "type": "Text Display",
+            "properties": {
+              "topic": "/AdvantageKit/RealOutputs/Shooter/Fault/Summary",
+              "period": 0.033
+            }
+          },
+          {
+            "title": "Indexer",
+            "x": 500.0,
+            "y": 400.0,
+            "width": 500.0,
+            "height": 100.0,
+            "type": "Text Display",
+            "properties": {
+              "topic": "/AdvantageKit/RealOutputs/Indexer/Fault/Summary",
+              "period": 0.033
+            }
+          },
+          {
+            "title": "Hanger",
+            "x": 1000.0,
+            "y": 400.0,
+            "width": 500.0,
+            "height": 100.0,
+            "type": "Text Display",
+            "properties": {
+              "topic": "/AdvantageKit/RealOutputs/Hanger/Fault/Summary",
+              "period": 0.033
+            }
+          },
+          {
+            "title": "Intake",
+            "x": 0.0,
+            "y": 500.0,
+            "width": 500.0,
+            "height": 100.0,
+            "type": "Text Display",
+            "properties": {
+              "topic": "/AdvantageKit/RealOutputs/Intake/Fault/Summary",
+              "period": 0.033
+            }
+          },
+          {
+            "title": "IntakeActuator",
+            "x": 500.0,
+            "y": 500.0,
+            "width": 500.0,
+            "height": 100.0,
+            "type": "Text Display",
+            "properties": {
+              "topic": "/AdvantageKit/RealOutputs/IntakeActuator/Fault/Summary",
+              "period": 0.033
+            }
+          },
+          {
+            "title": "Agitator",
+            "x": 1000.0,
+            "y": 500.0,
+            "width": 500.0,
+            "height": 100.0,
+            "type": "Text Display",
+            "properties": {
+              "topic": "/AdvantageKit/RealOutputs/Agitator/Fault/Summary",
+              "period": 0.033
+            }
+          },
+          {
+            "title": "Missing Devices",
+            "x": 0.0,
+            "y": 600.0,
+            "width": 1500.0,
+            "height": 100.0,
+            "type": "Text Display",
+            "properties": {
+              "topic": "/AdvantageKit/RealOutputs/CANHealth/MissingNamesJoined",
+              "period": 0.033
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "Diagnose",
+      "grid_layout": {
+        "layouts": [],
+        "containers": [
+          {
+            "title": "Shooter OK",
+            "x": 0.0,
+            "y": 0.0,
+            "width": 250.0,
+            "height": 100.0,
+            "type": "Boolean Box",
+            "properties": {
+              "topic": "/AdvantageKit/RealOutputs/Shooter/Device/Connected",
+              "period": 0.033,
+              "true_color": 4278233600,
+              "false_color": 4294901760,
+              "true_icon": "None",
+              "false_icon": "None"
+            }
+          },
+          {
+            "title": "Shooter Current A",
+            "x": 250.0,
+            "y": 0.0,
+            "width": 375.0,
+            "height": 100.0,
+            "type": "Number Bar",
+            "properties": {
+              "topic": "/AdvantageKit/RealOutputs/Shooter/CurrentAmps",
+              "period": 0.033,
+              "min_value": 0.0,
+              "max_value": 80.0,
+              "divisions": 5,
+              "inverted": false,
+              "orientation": "horizontal"
+            }
+          },
+          {
+            "title": "Shooter V Drop",
+            "x": 625.0,
+            "y": 0.0,
+            "width": 375.0,
+            "height": 100.0,
+            "type": "Number Bar",
+            "properties": {
+              "topic": "/AdvantageKit/RealOutputs/Shooter/VoltageDropVolts",
+              "period": 0.033,
+              "min_value": 0.0,
+              "max_value": 3.0,
+              "divisions": 3,
+              "inverted": true,
+              "orientation": "horizontal"
+            }
+          },
+          {
+            "title": "Shooter Faults",
+            "x": 1000.0,
+            "y": 0.0,
+            "width": 500.0,
+            "height": 100.0,
+            "type": "Text Display",
+            "properties": {
+              "topic": "/AdvantageKit/RealOutputs/Shooter/Fault/Summary",
+              "period": 0.033
+            }
+          },
+          {
+            "title": "Indexer OK",
+            "x": 0.0,
+            "y": 100.0,
+            "width": 250.0,
+            "height": 100.0,
+            "type": "Boolean Box",
+            "properties": {
+              "topic": "/AdvantageKit/RealOutputs/Indexer/Device/Connected",
+              "period": 0.033,
+              "true_color": 4278233600,
+              "false_color": 4294901760,
+              "true_icon": "None",
+              "false_icon": "None"
+            }
+          },
+          {
+            "title": "Indexer Current A",
+            "x": 250.0,
+            "y": 100.0,
+            "width": 375.0,
+            "height": 100.0,
+            "type": "Number Bar",
+            "properties": {
+              "topic": "/AdvantageKit/RealOutputs/Indexer/CurrentAmps",
+              "period": 0.033,
+              "min_value": 0.0,
+              "max_value": 80.0,
+              "divisions": 5,
+              "inverted": false,
+              "orientation": "horizontal"
+            }
+          },
+          {
+            "title": "Indexer V Drop",
+            "x": 625.0,
+            "y": 100.0,
+            "width": 375.0,
+            "height": 100.0,
+            "type": "Number Bar",
+            "properties": {
+              "topic": "/AdvantageKit/RealOutputs/Indexer/VoltageDropVolts",
+              "period": 0.033,
+              "min_value": 0.0,
+              "max_value": 3.0,
+              "divisions": 3,
+              "inverted": true,
+              "orientation": "horizontal"
+            }
+          },
+          {
+            "title": "Indexer Faults",
+            "x": 1000.0,
+            "y": 100.0,
+            "width": 500.0,
+            "height": 100.0,
+            "type": "Text Display",
+            "properties": {
+              "topic": "/AdvantageKit/RealOutputs/Indexer/Fault/Summary",
+              "period": 0.033
+            }
+          },
+          {
+            "title": "Intake OK",
+            "x": 0.0,
+            "y": 200.0,
+            "width": 250.0,
+            "height": 100.0,
+            "type": "Boolean Box",
+            "properties": {
+              "topic": "/AdvantageKit/RealOutputs/Intake/Device/Connected",
+              "period": 0.033,
+              "true_color": 4278233600,
+              "false_color": 4294901760,
+              "true_icon": "None",
+              "false_icon": "None"
+            }
+          },
+          {
+            "title": "Intake Current A",
+            "x": 250.0,
+            "y": 200.0,
+            "width": 375.0,
+            "height": 100.0,
+            "type": "Number Bar",
+            "properties": {
+              "topic": "/AdvantageKit/RealOutputs/Intake/CurrentAmps",
+              "period": 0.033,
+              "min_value": 0.0,
+              "max_value": 80.0,
+              "divisions": 5,
+              "inverted": false,
+              "orientation": "horizontal"
+            }
+          },
+          {
+            "title": "Intake V Drop",
+            "x": 625.0,
+            "y": 200.0,
+            "width": 375.0,
+            "height": 100.0,
+            "type": "Number Bar",
+            "properties": {
+              "topic": "/AdvantageKit/RealOutputs/Intake/VoltageDropVolts",
+              "period": 0.033,
+              "min_value": 0.0,
+              "max_value": 3.0,
+              "divisions": 3,
+              "inverted": true,
+              "orientation": "horizontal"
+            }
+          },
+          {
+            "title": "Intake Faults",
+            "x": 1000.0,
+            "y": 200.0,
+            "width": 500.0,
+            "height": 100.0,
+            "type": "Text Display",
+            "properties": {
+              "topic": "/AdvantageKit/RealOutputs/Intake/Fault/Summary",
+              "period": 0.033
+            }
+          },
+          {
+            "title": "IntakeActuator OK",
+            "x": 0.0,
+            "y": 300.0,
+            "width": 250.0,
+            "height": 100.0,
+            "type": "Boolean Box",
+            "properties": {
+              "topic": "/AdvantageKit/RealOutputs/IntakeActuator/Device/Connected",
+              "period": 0.033,
+              "true_color": 4278233600,
+              "false_color": 4294901760,
+              "true_icon": "None",
+              "false_icon": "None"
+            }
+          },
+          {
+            "title": "IntakeActuator Current A",
+            "x": 250.0,
+            "y": 300.0,
+            "width": 375.0,
+            "height": 100.0,
+            "type": "Number Bar",
+            "properties": {
+              "topic": "/AdvantageKit/RealOutputs/IntakeActuator/CurrentAmps",
+              "period": 0.033,
+              "min_value": 0.0,
+              "max_value": 80.0,
+              "divisions": 5,
+              "inverted": false,
+              "orientation": "horizontal"
+            }
+          },
+          {
+            "title": "IntakeActuator V Drop",
+            "x": 625.0,
+            "y": 300.0,
+            "width": 375.0,
+            "height": 100.0,
+            "type": "Number Bar",
+            "properties": {
+              "topic": "/AdvantageKit/RealOutputs/IntakeActuator/VoltageDropVolts",
+              "period": 0.033,
+              "min_value": 0.0,
+              "max_value": 3.0,
+              "divisions": 3,
+              "inverted": true,
+              "orientation": "horizontal"
+            }
+          },
+          {
+            "title": "IntakeActuator Faults",
+            "x": 1000.0,
+            "y": 300.0,
+            "width": 500.0,
+            "height": 100.0,
+            "type": "Text Display",
+            "properties": {
+              "topic": "/AdvantageKit/RealOutputs/IntakeActuator/Fault/Summary",
+              "period": 0.033
+            }
+          },
+          {
+            "title": "Hanger OK",
+            "x": 0.0,
+            "y": 400.0,
+            "width": 250.0,
+            "height": 100.0,
+            "type": "Boolean Box",
+            "properties": {
+              "topic": "/AdvantageKit/RealOutputs/Hanger/Device/Connected",
+              "period": 0.033,
+              "true_color": 4278233600,
+              "false_color": 4294901760,
+              "true_icon": "None",
+              "false_icon": "None"
+            }
+          },
+          {
+            "title": "Hanger Current A",
+            "x": 250.0,
+            "y": 400.0,
+            "width": 375.0,
+            "height": 100.0,
+            "type": "Number Bar",
+            "properties": {
+              "topic": "/AdvantageKit/RealOutputs/Hanger/CurrentAmps",
+              "period": 0.033,
+              "min_value": 0.0,
+              "max_value": 80.0,
+              "divisions": 5,
+              "inverted": false,
+              "orientation": "horizontal"
+            }
+          },
+          {
+            "title": "Hanger V Drop",
+            "x": 625.0,
+            "y": 400.0,
+            "width": 375.0,
+            "height": 100.0,
+            "type": "Number Bar",
+            "properties": {
+              "topic": "/AdvantageKit/RealOutputs/Hanger/VoltageDropVolts",
+              "period": 0.033,
+              "min_value": 0.0,
+              "max_value": 3.0,
+              "divisions": 3,
+              "inverted": true,
+              "orientation": "horizontal"
+            }
+          },
+          {
+            "title": "Hanger Faults",
+            "x": 1000.0,
+            "y": 400.0,
+            "width": 500.0,
+            "height": 100.0,
+            "type": "Text Display",
+            "properties": {
+              "topic": "/AdvantageKit/RealOutputs/Hanger/Fault/Summary",
+              "period": 0.033
+            }
+          },
+          {
+            "title": "Agitator OK",
+            "x": 0.0,
+            "y": 500.0,
+            "width": 250.0,
+            "height": 100.0,
+            "type": "Boolean Box",
+            "properties": {
+              "topic": "/AdvantageKit/RealOutputs/Agitator/Device/Connected",
+              "period": 0.033,
+              "true_color": 4278233600,
+              "false_color": 4294901760,
+              "true_icon": "None",
+              "false_icon": "None"
+            }
+          },
+          {
+            "title": "Agitator Current A",
+            "x": 250.0,
+            "y": 500.0,
+            "width": 375.0,
+            "height": 100.0,
+            "type": "Number Bar",
+            "properties": {
+              "topic": "/AdvantageKit/RealOutputs/Agitator/CurrentAmps",
+              "period": 0.033,
+              "min_value": 0.0,
+              "max_value": 80.0,
+              "divisions": 5,
+              "inverted": false,
+              "orientation": "horizontal"
+            }
+          },
+          {
+            "title": "Agitator V Drop",
+            "x": 625.0,
+            "y": 500.0,
+            "width": 375.0,
+            "height": 100.0,
+            "type": "Number Bar",
+            "properties": {
+              "topic": "/AdvantageKit/RealOutputs/Agitator/VoltageDropVolts",
+              "period": 0.033,
+              "min_value": 0.0,
+              "max_value": 3.0,
+              "divisions": 3,
+              "inverted": true,
+              "orientation": "horizontal"
+            }
+          },
+          {
+            "title": "Agitator Faults",
+            "x": 1000.0,
+            "y": 500.0,
+            "width": 500.0,
+            "height": 100.0,
+            "type": "Text Display",
+            "properties": {
+              "topic": "/AdvantageKit/RealOutputs/Agitator/Fault/Summary",
+              "period": 0.033
+            }
+          },
+          {
+            "title": "Gyro",
+            "x": 0.0,
+            "y": 600.0,
+            "width": 250.0,
+            "height": 100.0,
+            "type": "Boolean Box",
+            "properties": {
+              "topic": "/AdvantageKit/RealOutputs/Drive/Gyro/Connected",
+              "period": 0.033,
+              "true_color": 4278233600,
+              "false_color": 4294901760,
+              "true_icon": "None",
+              "false_icon": "None"
+            }
+          },
+          {
+            "title": "OrangePi1",
+            "x": 250.0,
+            "y": 600.0,
+            "width": 250.0,
+            "height": 100.0,
+            "type": "Boolean Box",
+            "properties": {
+              "topic": "/AdvantageKit/RealOutputs/Vision/Coprocessor/OrangePi1/Alive",
+              "period": 0.033,
+              "true_color": 4278233600,
+              "false_color": 4294901760,
+              "true_icon": "None",
+              "false_icon": "None"
+            }
+          },
+          {
+            "title": "OrangePi2",
+            "x": 500.0,
+            "y": 600.0,
+            "width": 250.0,
+            "height": 100.0,
+            "type": "Boolean Box",
+            "properties": {
+              "topic": "/AdvantageKit/RealOutputs/Vision/Coprocessor/OrangePi2/Alive",
+              "period": 0.033,
+              "true_color": 4278233600,
+              "false_color": 4294901760,
+              "true_icon": "None",
+              "false_icon": "None"
+            }
+          },
+          {
+            "title": "Total Current A",
+            "x": 750.0,
+            "y": 600.0,
+            "width": 375.0,
+            "height": 100.0,
+            "type": "Number Bar",
+            "properties": {
+              "topic": "/AdvantageKit/RealOutputs/SystemHealth/TotalCurrentAmps",
+              "period": 0.033,
+              "min_value": 0.0,
+              "max_value": 250.0,
+              "divisions": 5,
+              "inverted": false,
+              "orientation": "horizontal"
+            }
+          },
+          {
+            "title": "Browned Out",
+            "x": 1125.0,
+            "y": 600.0,
+            "width": 375.0,
+            "height": 100.0,
+            "type": "Boolean Box",
+            "properties": {
+              "topic": "/AdvantageKit/RealOutputs/SystemHealth/BrownedOut",
+              "period": 0.033,
+              "true_color": 4294901760,
+              "false_color": 4278233600,
+              "true_icon": "None",
+              "false_icon": "None"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "Evidence",
+      "grid_layout": {
+        "layouts": [],
+        "containers": [
+          {
+            "title": "Battery Voltage",
+            "x": 0.0,
+            "y": 0.0,
+            "width": 750.0,
+            "height": 230.0,
+            "type": "Graph",
+            "properties": {
+              "topic": "/AdvantageKit/RealOutputs/SystemHealth/BatteryVoltage",
+              "period": 0.033,
+              "time_displayed": 30.0,
+              "color": 4278238420,
+              "line_width": 2.0
+            }
+          },
+          {
+            "title": "Total Current",
+            "x": 750.0,
+            "y": 0.0,
+            "width": 750.0,
+            "height": 230.0,
+            "type": "Graph",
+            "properties": {
+              "topic": "/AdvantageKit/RealOutputs/SystemHealth/TotalCurrentAmps",
+              "period": 0.033,
+              "time_displayed": 30.0,
+              "color": 4294901760,
+              "line_width": 2.0
+            }
+          },
+          {
+            "title": "Voltage Slope V/s",
+            "x": 0.0,
+            "y": 230.0,
+            "width": 750.0,
+            "height": 230.0,
+            "type": "Graph",
+            "properties": {
+              "topic": "/AdvantageKit/RealOutputs/SystemHealth/VoltageSlope",
+              "period": 0.033,
+              "time_displayed": 30.0,
+              "color": 4294944000,
+              "line_width": 2.0
+            }
+          },
+          {
+            "title": "Shooter Current",
+            "x": 750.0,
+            "y": 230.0,
+            "width": 750.0,
+            "height": 230.0,
+            "type": "Graph",
+            "properties": {
+              "topic": "/AdvantageKit/RealOutputs/Shooter/CurrentAmps",
+              "period": 0.033,
+              "time_displayed": 30.0,
+              "color": 4278238420,
+              "line_width": 2.0
+            }
+          },
+          {
+            "title": "CAN Tx Error Peak",
+            "x": 0.0,
+            "y": 460.0,
+            "width": 375.0,
+            "height": 120.0,
+            "type": "Number Bar",
+            "properties": {
+              "topic": "/AdvantageKit/RealOutputs/CANHealth/TxErrorPeak",
+              "period": 0.033,
+              "min_value": 0.0,
+              "max_value": 150.0,
+              "divisions": 5,
+              "inverted": true,
+              "orientation": "horizontal"
+            }
+          },
+          {
+            "title": "CAN Rx Error Peak",
+            "x": 375.0,
+            "y": 460.0,
+            "width": 375.0,
+            "height": 120.0,
+            "type": "Number Bar",
+            "properties": {
+              "topic": "/AdvantageKit/RealOutputs/CANHealth/RxErrorPeak",
+              "period": 0.033,
+              "min_value": 0.0,
+              "max_value": 150.0,
+              "divisions": 5,
+              "inverted": true,
+              "orientation": "horizontal"
+            }
+          },
+          {
+            "title": "TxFull Events",
+            "x": 750.0,
+            "y": 460.0,
+            "width": 375.0,
+            "height": 120.0,
+            "type": "Number Bar",
+            "properties": {
+              "topic": "/AdvantageKit/RealOutputs/CANHealth/TxFullEvents",
+              "period": 0.033,
+              "min_value": 0.0,
+              "max_value": 10.0,
+              "divisions": 5,
+              "inverted": true,
+              "orientation": "horizontal"
+            }
+          },
+          {
+            "title": "Error Passive Events",
+            "x": 1125.0,
+            "y": 460.0,
+            "width": 375.0,
+            "height": 120.0,
+            "type": "Number Bar",
+            "properties": {
+              "topic": "/AdvantageKit/RealOutputs/CANHealth/ErrorPassiveEvents",
+              "period": 0.033,
+              "min_value": 0.0,
+              "max_value": 10.0,
+              "divisions": 5,
+              "inverted": true,
+              "orientation": "horizontal"
+            }
+          },
+          {
+            "title": "Rio CPU Temp",
+            "x": 0.0,
+            "y": 580.0,
+            "width": 500.0,
+            "height": 120.0,
+            "type": "Number Bar",
+            "properties": {
+              "topic": "/AdvantageKit/RealOutputs/SystemHealth/RioCPUTemp",
+              "period": 0.033,
+              "min_value": 30.0,
+              "max_value": 90.0,
+              "divisions": 5,
+              "inverted": false,
+              "orientation": "horizontal"
+            }
+          },
+          {
+            "title": "Rio 6V Rail",
+            "x": 500.0,
+            "y": 580.0,
+            "width": 500.0,
+            "height": 120.0,
+            "type": "Number Bar",
+            "properties": {
+              "topic": "/AdvantageKit/RealOutputs/SystemHealth/Rio6VRail",
+              "period": 0.033,
+              "min_value": 5.0,
+              "max_value": 6.5,
+              "divisions": 5,
+              "inverted": false,
+              "orientation": "horizontal"
+            }
+          },
+          {
+            "title": "Loop Time Ms",
+            "x": 1000.0,
+            "y": 580.0,
+            "width": 500.0,
+            "height": 120.0,
+            "type": "Number Bar",
+            "properties": {
+              "topic": "/AdvantageKit/RealOutputs/SystemHealth/LoopTimeMs",
+              "period": 0.033,
+              "min_value": 0.0,
+              "max_value": 50.0,
+              "divisions": 5,
+              "inverted": true,
+              "orientation": "horizontal"
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/dashboards/elastic/pit_check.json
+++ b/dashboards/elastic/pit_check.json
@@ -1,0 +1,261 @@
+{
+  "version": 1.0,
+  "grid_size": 128,
+  "tabs": [
+    {
+      "name": "Pit Check",
+      "grid_layout": {
+        "layouts": [],
+        "containers": [
+          {
+            "title": "Status",
+            "x": 0.0,
+            "y": 0.0,
+            "width": 1500.0,
+            "height": 180.0,
+            "type": "Boolean Box",
+            "properties": {
+              "topic": "/AdvantageKit/RealOutputs/CANHealth/MissingCritical",
+              "period": 0.033,
+              "true_color": 4294901760,
+              "false_color": 4278233600,
+              "true_icon": "None",
+              "false_icon": "None"
+            }
+          },
+          {
+            "title": "Status Message",
+            "x": 0.0,
+            "y": 180.0,
+            "width": 1500.0,
+            "height": 100.0,
+            "type": "Text Display",
+            "properties": {
+              "topic": "/AdvantageKit/RealOutputs/CANHealth/StatusMessage",
+              "period": 0.033
+            }
+          },
+          {
+            "title": "Battery",
+            "x": 0.0,
+            "y": 280.0,
+            "width": 500.0,
+            "height": 160.0,
+            "type": "Voltage View",
+            "properties": {
+              "topic": "/AdvantageKit/RealOutputs/SystemHealth/BatteryVoltage",
+              "period": 0.033,
+              "min_value": 8.0,
+              "max_value": 13.0,
+              "divisions": 5,
+              "inverted": false,
+              "orientation": "horizontal"
+            }
+          },
+          {
+            "title": "Devices Online",
+            "x": 500.0,
+            "y": 280.0,
+            "width": 500.0,
+            "height": 160.0,
+            "type": "Number Bar",
+            "properties": {
+              "topic": "/AdvantageKit/RealOutputs/CANHealth/ConnectedCount",
+              "period": 0.033,
+              "min_value": 0.0,
+              "max_value": 21.0,
+              "divisions": 3,
+              "inverted": false,
+              "orientation": "horizontal"
+            }
+          },
+          {
+            "title": "Coprocessor Reboots",
+            "x": 1000.0,
+            "y": 280.0,
+            "width": 500.0,
+            "height": 160.0,
+            "type": "Number Bar",
+            "properties": {
+              "topic": "/AdvantageKit/RealOutputs/Vision/Coprocessor/TotalRebootCount",
+              "period": 0.033,
+              "min_value": 0.0,
+              "max_value": 10.0,
+              "divisions": 5,
+              "inverted": true,
+              "orientation": "horizontal"
+            }
+          },
+          {
+            "title": "Shooter",
+            "x": 0.0,
+            "y": 440.0,
+            "width": 250.0,
+            "height": 80.0,
+            "type": "Boolean Box",
+            "properties": {
+              "topic": "/AdvantageKit/RealOutputs/Shooter/Device/Connected",
+              "period": 0.033,
+              "true_color": 4278233600,
+              "false_color": 4294901760,
+              "true_icon": "None",
+              "false_icon": "None"
+            }
+          },
+          {
+            "title": "Shooter Fault",
+            "x": 250.0,
+            "y": 440.0,
+            "width": 500.0,
+            "height": 80.0,
+            "type": "Text Display",
+            "properties": {
+              "topic": "/AdvantageKit/RealOutputs/Shooter/Fault/Summary",
+              "period": 0.033
+            }
+          },
+          {
+            "title": "Indexer",
+            "x": 750.0,
+            "y": 440.0,
+            "width": 250.0,
+            "height": 80.0,
+            "type": "Boolean Box",
+            "properties": {
+              "topic": "/AdvantageKit/RealOutputs/Indexer/Device/Connected",
+              "period": 0.033,
+              "true_color": 4278233600,
+              "false_color": 4294901760,
+              "true_icon": "None",
+              "false_icon": "None"
+            }
+          },
+          {
+            "title": "Indexer Fault",
+            "x": 1000.0,
+            "y": 440.0,
+            "width": 500.0,
+            "height": 80.0,
+            "type": "Text Display",
+            "properties": {
+              "topic": "/AdvantageKit/RealOutputs/Indexer/Fault/Summary",
+              "period": 0.033
+            }
+          },
+          {
+            "title": "Intake",
+            "x": 0.0,
+            "y": 520.0,
+            "width": 250.0,
+            "height": 80.0,
+            "type": "Boolean Box",
+            "properties": {
+              "topic": "/AdvantageKit/RealOutputs/Intake/Device/Connected",
+              "period": 0.033,
+              "true_color": 4278233600,
+              "false_color": 4294901760,
+              "true_icon": "None",
+              "false_icon": "None"
+            }
+          },
+          {
+            "title": "Intake Fault",
+            "x": 250.0,
+            "y": 520.0,
+            "width": 500.0,
+            "height": 80.0,
+            "type": "Text Display",
+            "properties": {
+              "topic": "/AdvantageKit/RealOutputs/Intake/Fault/Summary",
+              "period": 0.033
+            }
+          },
+          {
+            "title": "IntakeActuator",
+            "x": 750.0,
+            "y": 520.0,
+            "width": 250.0,
+            "height": 80.0,
+            "type": "Boolean Box",
+            "properties": {
+              "topic": "/AdvantageKit/RealOutputs/IntakeActuator/Device/Connected",
+              "period": 0.033,
+              "true_color": 4278233600,
+              "false_color": 4294901760,
+              "true_icon": "None",
+              "false_icon": "None"
+            }
+          },
+          {
+            "title": "IntakeActuator Fault",
+            "x": 1000.0,
+            "y": 520.0,
+            "width": 500.0,
+            "height": 80.0,
+            "type": "Text Display",
+            "properties": {
+              "topic": "/AdvantageKit/RealOutputs/IntakeActuator/Fault/Summary",
+              "period": 0.033
+            }
+          },
+          {
+            "title": "Hanger",
+            "x": 0.0,
+            "y": 600.0,
+            "width": 250.0,
+            "height": 80.0,
+            "type": "Boolean Box",
+            "properties": {
+              "topic": "/AdvantageKit/RealOutputs/Hanger/Device/Connected",
+              "period": 0.033,
+              "true_color": 4278233600,
+              "false_color": 4294901760,
+              "true_icon": "None",
+              "false_icon": "None"
+            }
+          },
+          {
+            "title": "Hanger Fault",
+            "x": 250.0,
+            "y": 600.0,
+            "width": 500.0,
+            "height": 80.0,
+            "type": "Text Display",
+            "properties": {
+              "topic": "/AdvantageKit/RealOutputs/Hanger/Fault/Summary",
+              "period": 0.033
+            }
+          },
+          {
+            "title": "Agitator",
+            "x": 750.0,
+            "y": 600.0,
+            "width": 250.0,
+            "height": 80.0,
+            "type": "Boolean Box",
+            "properties": {
+              "topic": "/AdvantageKit/RealOutputs/Agitator/Device/Connected",
+              "period": 0.033,
+              "true_color": 4278233600,
+              "false_color": 4294901760,
+              "true_icon": "None",
+              "false_icon": "None"
+            }
+          },
+          {
+            "title": "Agitator Fault",
+            "x": 1000.0,
+            "y": 600.0,
+            "width": 500.0,
+            "height": 80.0,
+            "type": "Text Display",
+            "properties": {
+              "topic": "/AdvantageKit/RealOutputs/Agitator/Fault/Summary",
+              "period": 0.033
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/src/main/java/frc/robot/Cameras.java
+++ b/src/main/java/frc/robot/Cameras.java
@@ -42,7 +42,8 @@ public enum Cameras {
       new Rotation3d(0, Math.toRadians(-15), Math.toRadians(135)),
       new Translation3d(-0.293, 0.293, 0.229),
       VecBuilder.fill(0.3, 0.3, 0.6),
-      VecBuilder.fill(0.1, 0.1, 0.2)),
+      VecBuilder.fill(0.1, 0.1, 0.2),
+      "OrangePi1"),
 
   /** Right Camera */
   RIGHT_CAM(
@@ -50,7 +51,8 @@ public enum Cameras {
       new Rotation3d(0, Math.toRadians(-15), Math.toRadians(-135)),
       new Translation3d(-0.293, -0.293, 0.229),
       VecBuilder.fill(0.3, 0.3, 0.6),
-      VecBuilder.fill(0.1, 0.1, 0.2)),
+      VecBuilder.fill(0.1, 0.1, 0.2),
+      "OrangePi1"),
   // Front-left camera, angled 45 deg outward */
   FRONT_LEFT_CAM(
       "front-left",
@@ -58,7 +60,8 @@ public enum Cameras {
       new Translation3d(
           Units.inchesToMeters(6.0), Units.inchesToMeters(13.5), Units.inchesToMeters(12)),
       VecBuilder.fill(0.3, 0.3, 0.6),
-      VecBuilder.fill(0.1, 0.1, 0.2)),
+      VecBuilder.fill(0.1, 0.1, 0.2),
+      "OrangePi2"),
 
   /** Front-right camera, angled 45 deg outward (mirrored from front-left) */
   FRONT_RIGHT_CAM(
@@ -67,7 +70,8 @@ public enum Cameras {
       new Translation3d(
           Units.inchesToMeters(6.0), Units.inchesToMeters(-13.5), Units.inchesToMeters(12)),
       VecBuilder.fill(0.3, 0.3, 0.6),
-      VecBuilder.fill(0.1, 0.1, 0.2));
+      VecBuilder.fill(0.1, 0.1, 0.2),
+      "OrangePi2");
 
   /** Latency alert to use when high latency is detected. */
   public final Alert latencyAlert;
@@ -86,6 +90,13 @@ public enum Cameras {
 
   /** Transform of the camera rotation and translation relative to the center of the robot */
   private final Transform3d robotToCamTransform;
+
+  /**
+   * Name of the coprocessor this camera is attached to. Cameras on the same coprocessor share a
+   * power rail and a USB hub, so they fail together. CoprocessorHealth rolls them up into one alive
+   * boolean so the pit crew sees "Orange Pi 1 rebooted" instead of two independent camera flickers.
+   */
+  public final String coprocessorGroup;
 
   /** Current standard deviations used. */
   public Matrix<N3, N1> curStdDevs;
@@ -118,7 +129,9 @@ public enum Cameras {
       Rotation3d robotToCamRotation,
       Translation3d robotToCamTranslation,
       Matrix<N3, N1> singleTagStdDevs,
-      Matrix<N3, N1> multiTagStdDevsMatrix) {
+      Matrix<N3, N1> multiTagStdDevsMatrix,
+      String coprocessorGroup) {
+    this.coprocessorGroup = coprocessorGroup;
     latencyAlert =
         new Alert("'" + name + "' Camera is experiencing high latency.", AlertType.kWarning);
 

--- a/src/main/java/frc/robot/subsystems/Actuator.java
+++ b/src/main/java/frc/robot/subsystems/Actuator.java
@@ -13,5 +13,13 @@ public interface Actuator {
 
   public int getStickyFaultsRaw();
 
+  /**
+   * Sticky warnings as raw bits (REVLib warning word). TalonFX has no separate warning register, so
+   * the Talon-backed implementation returns 0 and the decoder skips that path.
+   */
+  public default int getStickyWarningsRaw() {
+    return 0;
+  }
+
   public void updatePID(double kP, double kI, double kD, double kF);
 }

--- a/src/main/java/frc/robot/subsystems/Agitator.java
+++ b/src/main/java/frc/robot/subsystems/Agitator.java
@@ -68,6 +68,10 @@ public class Agitator extends TalonActuator {
     return getMotor().getStatorCurrent().getValueAsDouble();
   }
 
+  public double getBusVoltage() {
+    return getMotor().getSupplyVoltage().getValueAsDouble();
+  }
+
   public double getVelocityRPM() {
     return getMotor().getVelocity().getValueAsDouble() * 60.0;
   }

--- a/src/main/java/frc/robot/subsystems/FlexActuator.java
+++ b/src/main/java/frc/robot/subsystems/FlexActuator.java
@@ -133,6 +133,16 @@ public abstract class FlexActuator extends SubsystemBase implements Actuator {
     }
   }
 
+  /** Sticky warnings as raw bits. Paired with getStickyFaultsRaw for the fault decoder. */
+  @Override
+  public int getStickyWarningsRaw() {
+    try {
+      return (int) motor.getStickyWarnings().rawBits;
+    } catch (Throwable t) {
+      return -1;
+    }
+  }
+
   /** Hot-reload PID values. Creates new config, takes a few ms. */
   public void updatePID(double kP, double kI, double kD, double kF) {
     SparkFlexConfig config = new SparkFlexConfig();

--- a/src/main/java/frc/robot/subsystems/Hanger.java
+++ b/src/main/java/frc/robot/subsystems/Hanger.java
@@ -62,6 +62,10 @@ public class Hanger extends MaxActuator {
     return getMotor().getOutputCurrent();
   }
 
+  public double getBusVoltage() {
+    return getMotor().getBusVoltage();
+  }
+
   public double getTemperature() {
     return getMotor().getMotorTemperature();
   }

--- a/src/main/java/frc/robot/subsystems/Indexer.java
+++ b/src/main/java/frc/robot/subsystems/Indexer.java
@@ -98,6 +98,10 @@ public class Indexer extends FlexActuator {
     return motor.getOutputCurrent();
   }
 
+  public double getBusVoltage() {
+    return motor.getBusVoltage();
+  }
+
   public double getVelocityRPM() {
     return getMotorVelocity();
   }

--- a/src/main/java/frc/robot/subsystems/IntakePivot.java
+++ b/src/main/java/frc/robot/subsystems/IntakePivot.java
@@ -48,9 +48,10 @@ public class IntakePivot extends TalonActuator {
     return Math.abs(getPosition() - targetPosition) < POSITION_TOLERANCE_ROTATIONS;
   }
 
-  // public double getTemperature() {
-  //   return getMotor().getMotorTemperature();
-  // }
+  /** Kraken device temperature in Celsius. */
+  public double getTemperature() {
+    return getMotor().getDeviceTemp().getValueAsDouble();
+  }
 
   // Hardware accessors
   public double getTargetPosition() {
@@ -65,13 +66,20 @@ public class IntakePivot extends TalonActuator {
     getMotor().setPosition(-0.4);
   }
 
-  // public double getAppliedOutput() {
-  //   return getMotor().getAppliedOutput();
-  // }
+  /** Duty-cycle output, normalized -1 to 1, for parity with the Spark-based accessors. */
+  public double getAppliedOutput() {
+    return getMotor().getDutyCycle().getValueAsDouble();
+  }
 
-  // public double getOutputCurrent() {
-  //   return getMotor().getOutputCurrent();
-  // }
+  /** Motor stator current in amps, read directly from the Kraken. */
+  public double getOutputCurrent() {
+    return getMotor().getStatorCurrent().getValueAsDouble();
+  }
+
+  /** Kraken supply voltage in volts. Used by telemetry to compute voltage drop. */
+  public double getBusVoltage() {
+    return getMotor().getSupplyVoltage().getValueAsDouble();
+  }
 
   public double getTunableKP() {
     return kP.get();

--- a/src/main/java/frc/robot/subsystems/IntakeRoller.java
+++ b/src/main/java/frc/robot/subsystems/IntakeRoller.java
@@ -84,6 +84,10 @@ public class IntakeRoller extends FlexActuator {
     return motor.getOutputCurrent();
   }
 
+  public double getBusVoltage() {
+    return motor.getBusVoltage();
+  }
+
   public double getVelocityRPM() {
     return motor.getEncoder().getVelocity();
   }

--- a/src/main/java/frc/robot/subsystems/MaxActuator.java
+++ b/src/main/java/frc/robot/subsystems/MaxActuator.java
@@ -133,6 +133,16 @@ public abstract class MaxActuator extends SubsystemBase implements Actuator {
     }
   }
 
+  /** Sticky warnings as raw bits. Paired with getStickyFaultsRaw for the fault decoder. */
+  @Override
+  public int getStickyWarningsRaw() {
+    try {
+      return (int) motor.getStickyWarnings().rawBits;
+    } catch (Throwable t) {
+      return -1;
+    }
+  }
+
   /** Hot-reload PID values. Creates new config, takes a few ms. */
   public void updatePID(double kP, double kI, double kD, double kF) {
     SparkMaxConfig config = new SparkMaxConfig();

--- a/src/main/java/frc/robot/telemetry/AgitatorTelemetry.java
+++ b/src/main/java/frc/robot/telemetry/AgitatorTelemetry.java
@@ -6,6 +6,9 @@ import edu.wpi.first.wpilibj2.command.Command;
 import frc.robot.Constants;
 import frc.robot.Constants.DeviceHealthConstants;
 import frc.robot.subsystems.Agitator;
+import frc.robot.util.DeviceFaultDecoder;
+import frc.robot.util.DeviceFaultDecoder.DecodedFaults;
+import frc.robot.util.DeviceFaultDecoder.DeviceType;
 import frc.robot.util.JamProtection;
 
 /** Agitator telemetry: device health, stall detection, running state. */
@@ -22,11 +25,18 @@ public class AgitatorTelemetry implements SubsystemTelemetry {
   private double currentAmps = 0;
   private double temperatureCelsius = 0;
   private double velocityRPM = 0;
+  private double busVoltage = 0;
+  private double voltageDropVolts = 0;
 
   private final Debouncer connectDebouncer =
       new Debouncer(DeviceHealthConstants.DISCONNECT_DEBOUNCE_SEC, Debouncer.DebounceType.kFalling);
   private boolean deviceConnected = false;
   private int deviceFaultsRaw = 0;
+  private int deviceWarningsRaw = 0;
+  private int lastRawFaults = 0;
+  private int lastRawWarnings = 0;
+  private int faultTransitionCount = 0;
+  private DecodedFaults decodedFaults = DeviceFaultDecoder.empty();
 
   private boolean stalled = false;
   private boolean wasStalled = false;
@@ -65,12 +75,27 @@ public class AgitatorTelemetry implements SubsystemTelemetry {
       currentAmps = agitator.getOutputCurrent();
       temperatureCelsius = agitator.getTemperature();
       velocityRPM = agitator.getVelocityRPM();
+      busVoltage = agitator.getBusVoltage();
+      voltageDropVolts = SystemHealthTelemetry.computeVoltageDrop(busVoltage);
 
       deviceConnected = connectDebouncer.calculate(true);
-      // deviceFaultsRaw = agitator.getStickyFaultsRaw();
+      deviceFaultsRaw = agitator.getStickyFaultsRaw();
+      deviceWarningsRaw = agitator.getStickyWarningsRaw();
+
+      if (deviceFaultsRaw != lastRawFaults || deviceWarningsRaw != lastRawWarnings) {
+        decodedFaults =
+            DeviceFaultDecoder.decode(DeviceType.SPARK_MAX, deviceFaultsRaw, deviceWarningsRaw);
+        lastRawFaults = deviceFaultsRaw;
+        lastRawWarnings = deviceWarningsRaw;
+        if (decodedFaults.anyActive()) {
+          faultTransitionCount++;
+        }
+      }
     } catch (Throwable t) {
       deviceConnected = connectDebouncer.calculate(false);
       deviceFaultsRaw = -1;
+      deviceWarningsRaw = -1;
+      decodedFaults = DeviceFaultDecoder.empty();
       setDefaultValues();
       return;
     }
@@ -118,6 +143,8 @@ public class AgitatorTelemetry implements SubsystemTelemetry {
     currentAmps = 0;
     temperatureCelsius = 0;
     velocityRPM = 0;
+    busVoltage = 0;
+    voltageDropVolts = 0;
     stalled = false;
     stallDurationMs = 0;
     inStallCondition = false;
@@ -128,14 +155,17 @@ public class AgitatorTelemetry implements SubsystemTelemetry {
     SafeLog.put("Agitator/Available", subsystemAvailable);
     SafeLog.put("Agitator/VelocityRPM", velocityRPM);
     SafeLog.put("Agitator/Device/Connected", deviceConnected);
+    DeviceFaultDecoder.publish(
+        "Agitator", decodedFaults, deviceFaultsRaw, deviceWarningsRaw, faultTransitionCount);
     SafeLog.put("Agitator/CurrentAmps", currentAmps);
+    SafeLog.put("Agitator/BusVoltage", busVoltage);
+    SafeLog.put("Agitator/VoltageDropVolts", voltageDropVolts);
     SafeLog.put("Agitator/Stalled", stalled);
 
     if (Constants.TUNING_MODE) {
       SafeLog.put("Agitator/Running", running);
       SafeLog.put("Agitator/AppliedOutput", appliedOutput);
       SafeLog.put("Agitator/TemperatureCelsius", temperatureCelsius);
-      SafeLog.put("Agitator/Device/FaultsRaw", deviceFaultsRaw);
       SafeLog.put("Agitator/StallDurationMs", stallDurationMs);
       SafeLog.put("Agitator/ActiveCommand", activeCommandName);
       SafeLog.put("Agitator/JamProtection/State", jamProtectionState);

--- a/src/main/java/frc/robot/telemetry/CANHealthTelemetry.java
+++ b/src/main/java/frc/robot/telemetry/CANHealthTelemetry.java
@@ -1,34 +1,75 @@
 package frc.robot.telemetry;
 
+import frc.robot.Constants;
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * Aggregates device connectivity and fault status across all CAN devices. Reads from existing
  * telemetry classes only, no additional CAN reads.
+ *
+ * <p>Beyond the aggregate connected/disconnected rollup, this class owns the device inventory
+ * contract the Pit Check page uses: an expected list of motor controllers, sensors, and cameras
+ * with CAN IDs, subsystem names, and a device class. Missing devices are published as parallel
+ * arrays so a dashboard can render "17 of 18 devices online, missing CAN 42 (IntakeActuator)"
+ * without any source side lookup.
  */
 public class CANHealthTelemetry implements SubsystemTelemetry {
-  private static final int TOTAL_DEVICES = 21; // 6 motors + gyro + 2 cameras + 12 swerve
-  private static final String[] DEVICE_NAMES = {
-    "Shooter",
-    "Indexer",
-    "Intake",
-    "IntakeActuator",
-    "Hanger",
-    "Agitator",
-    "Gyro",
-    "LeftCam",
-    "RightCam",
-    "FL-Drive",
-    "FL-Turn",
-    "FL-Encoder",
-    "FR-Drive",
-    "FR-Turn",
-    "FR-Encoder",
-    "BL-Drive",
-    "BL-Turn",
-    "BL-Encoder",
-    "BR-Drive",
-    "BR-Turn",
-    "BR-Encoder"
-  };
+
+  /** Coarse grouping for the dashboard. Motor controllers are "critical", cameras are not. */
+  public enum DeviceClass {
+    MOTOR_CONTROLLER,
+    SENSOR,
+    CAMERA,
+    OTHER
+  }
+
+  /**
+   * An expected device in the robot's hardware inventory. {@code canId} is -1 when the device is
+   * not on CAN (gyro over MXP, cameras over NetworkTables).
+   */
+  private record ExpectedDevice(String name, int canId, DeviceClass deviceClass) {}
+
+  private static final List<ExpectedDevice> EXPECTED =
+      List.of(
+          new ExpectedDevice(
+              "Shooter", Constants.CANDeviceIDs.kShooterID, DeviceClass.MOTOR_CONTROLLER),
+          new ExpectedDevice(
+              "Indexer", Constants.CANDeviceIDs.kIndexerID, DeviceClass.MOTOR_CONTROLLER),
+          new ExpectedDevice(
+              "Intake", Constants.CANDeviceIDs.kIntakeRollerID, DeviceClass.MOTOR_CONTROLLER),
+          new ExpectedDevice(
+              "IntakeActuator",
+              Constants.CANDeviceIDs.kIntakePivotID,
+              DeviceClass.MOTOR_CONTROLLER),
+          new ExpectedDevice(
+              "Hanger", Constants.CANDeviceIDs.kHangerID, DeviceClass.MOTOR_CONTROLLER),
+          new ExpectedDevice(
+              "Agitator", Constants.CANDeviceIDs.kAgitatorID, DeviceClass.MOTOR_CONTROLLER),
+          new ExpectedDevice("Gyro", -1, DeviceClass.SENSOR),
+          new ExpectedDevice("LeftCam", -1, DeviceClass.CAMERA),
+          new ExpectedDevice("RightCam", -1, DeviceClass.CAMERA),
+          new ExpectedDevice("FL-Drive", -1, DeviceClass.MOTOR_CONTROLLER),
+          new ExpectedDevice("FL-Turn", -1, DeviceClass.MOTOR_CONTROLLER),
+          new ExpectedDevice("FL-Encoder", -1, DeviceClass.SENSOR),
+          new ExpectedDevice("FR-Drive", -1, DeviceClass.MOTOR_CONTROLLER),
+          new ExpectedDevice("FR-Turn", -1, DeviceClass.MOTOR_CONTROLLER),
+          new ExpectedDevice("FR-Encoder", -1, DeviceClass.SENSOR),
+          new ExpectedDevice("BL-Drive", -1, DeviceClass.MOTOR_CONTROLLER),
+          new ExpectedDevice("BL-Turn", -1, DeviceClass.MOTOR_CONTROLLER),
+          new ExpectedDevice("BL-Encoder", -1, DeviceClass.SENSOR),
+          new ExpectedDevice("BR-Drive", -1, DeviceClass.MOTOR_CONTROLLER),
+          new ExpectedDevice("BR-Turn", -1, DeviceClass.MOTOR_CONTROLLER),
+          new ExpectedDevice("BR-Encoder", -1, DeviceClass.SENSOR));
+
+  private static final int TOTAL_DEVICES = EXPECTED.size();
+
+  // Pre-sized. Lists reuse their backing array across cycles; the final
+  // String[]/int[] at publish time are new each cycle because they become
+  // the logged snapshot and must not share state with next cycle's scratch.
+  private final boolean[] connected = new boolean[TOTAL_DEVICES];
+  private final List<String> missingNamesScratch = new ArrayList<>(TOTAL_DEVICES);
+  private final List<Integer> missingIdsScratch = new ArrayList<>(TOTAL_DEVICES);
 
   private final ShooterTelemetry shooterTelemetry;
   private final IndexerTelemetry indexerTelemetry;
@@ -41,9 +82,23 @@ public class CANHealthTelemetry implements SubsystemTelemetry {
 
   private boolean allConnected = false;
   private int connectedCount = 0;
+  private int missingCount = 0;
+  private boolean missingCritical = false;
+  private String[] missingNames = new String[0];
+  private int[] missingIds = new int[0];
+  private String missingNamesJoined = "";
+  private String statusMessage = "READY";
   private String disconnectedList = "";
+
   private int totalFaults = 0;
   private boolean hasFaults = false;
+
+  private int txErrorPeak = 0;
+  private int rxErrorPeak = 0;
+  private int txFullEvents = 0;
+  private int errorPassiveEvents = 0;
+  private int lastTxFullCount = 0;
+  private boolean wasErrorPassive = false;
 
   public CANHealthTelemetry(
       ShooterTelemetry shooterTelemetry,
@@ -66,8 +121,6 @@ public class CANHealthTelemetry implements SubsystemTelemetry {
 
   @Override
   public void update() {
-    boolean[] connected = new boolean[TOTAL_DEVICES];
-
     connected[0] = shooterTelemetry != null && shooterTelemetry.isDeviceConnected();
     connected[1] = indexerTelemetry != null && indexerTelemetry.isDeviceConnected();
     connected[2] = intakeTelemetry != null && intakeTelemetry.isDeviceConnected();
@@ -85,24 +138,51 @@ public class CANHealthTelemetry implements SubsystemTelemetry {
       connected[base + 2] = driveTelemetry != null && driveTelemetry.isEncoderOk(m);
     }
 
+    missingNamesScratch.clear();
+    missingIdsScratch.clear();
     int count = 0;
     StringBuilder disconnected = new StringBuilder();
+    boolean critical = false;
+
     for (int i = 0; i < TOTAL_DEVICES; i++) {
+      ExpectedDevice dev = EXPECTED.get(i);
       if (connected[i]) {
         count++;
       } else {
+        missingNamesScratch.add(dev.name());
+        missingIdsScratch.add(dev.canId());
+        if (dev.deviceClass() == DeviceClass.MOTOR_CONTROLLER) {
+          critical = true;
+        }
         if (disconnected.length() > 0) {
           disconnected.append(", ");
         }
-        disconnected.append(DEVICE_NAMES[i]);
+        disconnected.append(dev.name());
       }
     }
 
     connectedCount = count;
+    missingCount = TOTAL_DEVICES - count;
+    missingCritical = critical;
     allConnected = (count == TOTAL_DEVICES);
     disconnectedList = disconnected.toString();
+    missingNamesJoined = disconnectedList.isEmpty() ? "none" : disconnectedList;
+    missingNames = missingNamesScratch.toArray(new String[0]);
+    missingIds = new int[missingIdsScratch.size()];
+    for (int i = 0; i < missingIdsScratch.size(); i++) {
+      missingIds[i] = missingIdsScratch.get(i);
+    }
 
-    // -1 means failed read, skip to avoid masking real faults
+    // Dashboard-friendly short status line that fits inside a Text Display tile.
+    if (allConnected) {
+      statusMessage = "READY - all 21 devices online";
+    } else if (critical) {
+      statusMessage = "DO NOT QUEUE - " + missingCount + " missing: " + missingNamesJoined;
+    } else {
+      statusMessage = "WARNING - " + missingCount + " non-critical missing: " + missingNamesJoined;
+    }
+
+    // Sum fault bits. -1 means failed read, skip to avoid masking real faults.
     int faults = 0;
     if (shooterTelemetry != null) faults += Math.max(0, shooterTelemetry.getDeviceFaultsRaw());
     if (indexerTelemetry != null) faults += Math.max(0, indexerTelemetry.getDeviceFaultsRaw());
@@ -119,10 +199,51 @@ public class CANHealthTelemetry implements SubsystemTelemetry {
     }
     totalFaults = faults;
     hasFaults = (faults > 0);
+
+    // CAN error peak tracking: read whatever SystemHealthTelemetry already
+    // captured. Defensive: if the shared values have not been seen yet, skip.
+    int currentTx = SystemHealthTelemetry.getCanTxErrorsSafely();
+    int currentRx = SystemHealthTelemetry.getCanRxErrorsSafely();
+    int currentTxFull = SystemHealthTelemetry.getCanTxFullSafely();
+    if (currentTx >= 0) {
+      if (currentTx > txErrorPeak) txErrorPeak = currentTx;
+      // Entered error-passive when TxError crosses 127. Edge-triggered counter.
+      boolean nowPassive = currentTx > 127;
+      if (nowPassive && !wasErrorPassive) {
+        errorPassiveEvents++;
+      }
+      wasErrorPassive = nowPassive;
+    }
+    if (currentRx >= 0 && currentRx > rxErrorPeak) {
+      rxErrorPeak = currentRx;
+    }
+    if (currentTxFull >= 0) {
+      if (currentTxFull > lastTxFullCount) {
+        txFullEvents++;
+      }
+      lastTxFullCount = currentTxFull;
+    }
   }
 
   @Override
   public void log() {
+    SafeLog.put("CANHealth/AllConnected", allConnected);
+    SafeLog.put("CANHealth/ExpectedCount", TOTAL_DEVICES);
+    SafeLog.put("CANHealth/ConnectedCount", connectedCount);
+    SafeLog.put("CANHealth/MissingCount", missingCount);
+    SafeLog.put("CANHealth/MissingCritical", missingCritical);
+    SafeLog.put("CANHealth/MissingNames", missingNames);
+    SafeLog.put("CANHealth/MissingIds", missingIds);
+    SafeLog.put("CANHealth/MissingNamesJoined", missingNamesJoined);
+    SafeLog.put("CANHealth/StatusMessage", statusMessage);
+    SafeLog.put("CANHealth/TotalFaults", totalFaults);
+    SafeLog.put("CANHealth/HasFaults", hasFaults);
+    SafeLog.put("CANHealth/TxErrorPeak", txErrorPeak);
+    SafeLog.put("CANHealth/RxErrorPeak", rxErrorPeak);
+    SafeLog.put("CANHealth/TxFullEvents", txFullEvents);
+    SafeLog.put("CANHealth/ErrorPassiveEvents", errorPassiveEvents);
+
+    // Legacy signals kept for backward compatibility with existing dashboards.
     SafeLog.put("SystemHealth/CAN/AllDevicesConnected", allConnected);
     SafeLog.put("SystemHealth/CAN/ConnectedCount", connectedCount);
     SafeLog.put("SystemHealth/CAN/TotalDevices", TOTAL_DEVICES);
@@ -146,11 +267,43 @@ public class CANHealthTelemetry implements SubsystemTelemetry {
     return connectedCount;
   }
 
+  public int getMissingCount() {
+    return missingCount;
+  }
+
+  public boolean isMissingCritical() {
+    return missingCritical;
+  }
+
+  public String[] getMissingNames() {
+    return missingNames;
+  }
+
+  public int[] getMissingIds() {
+    return missingIds;
+  }
+
   public String getDisconnectedList() {
     return disconnectedList;
   }
 
   public boolean hasFaults() {
     return hasFaults;
+  }
+
+  public int getTxErrorPeak() {
+    return txErrorPeak;
+  }
+
+  public int getRxErrorPeak() {
+    return rxErrorPeak;
+  }
+
+  public int getTxFullEvents() {
+    return txFullEvents;
+  }
+
+  public int getErrorPassiveEvents() {
+    return errorPassiveEvents;
   }
 }

--- a/src/main/java/frc/robot/telemetry/DriveTelemetry.java
+++ b/src/main/java/frc/robot/telemetry/DriveTelemetry.java
@@ -16,7 +16,16 @@ import swervelib.telemetry.SwerveDriveTelemetry;
 /** Drive telemetry: pose, module states, chassis speeds, gyro, encoder health. */
 public class DriveTelemetry implements SubsystemTelemetry {
   private static final String[] MODULE_NAMES = {"FL", "FR", "BL", "BR"};
-  private static final double ENCODER_DISAGREEMENT_THRESHOLD_RAD = 0.05;
+
+  // 10 degrees in radians. Picked against the real steady-state noise floor,
+  // where a healthy module sits under 0.05 rad and a settling transient briefly
+  // touches 0.15 rad. The debounce below catches sustained drift while ignoring
+  // the short post-command oscillation.
+  private static final double ENCODER_DISAGREEMENT_THRESHOLD_RAD = 0.175;
+
+  // A real calibration event stays high for seconds, not milliseconds.
+  private static final double ENCODER_FAULT_DEBOUNCE_SEC = 1.0;
+  private static final double LOOP_PERIOD_SEC = 0.02;
 
   private SwerveSubsystem swerveSubsystem;
   private SwerveDrive swerveDrive;
@@ -40,6 +49,8 @@ public class DriveTelemetry implements SubsystemTelemetry {
 
   private boolean[] encoderAbsoluteOk = {true, true, true, true};
   private double[] encoderDisagreementRad = {0, 0, 0, 0};
+  private double[] encoderFaultDebounceSec = {0, 0, 0, 0};
+  private boolean[] encoderFaultLatched = {false, false, false, false};
 
   private static final int SWERVE_HEALTH_DECIMATION = 25;
   private int swerveHealthCounter = 0;
@@ -158,6 +169,23 @@ public class DriveTelemetry implements SubsystemTelemetry {
     }
   }
 
+  /**
+   * Pure math for the encoder disagreement signal. Takes absolute and relative angles in DEGREES
+   * (as YAGSL reports them), returns the short-arc disagreement in radians. NaN on either input
+   * short-circuits to 0 so no garbage values can leak into the log.
+   *
+   * <p>Public-package for unit testing. Do not call from hot paths other than {@link
+   * #updateEncoderHealth()} because it allocates nothing and the test uses it directly.
+   */
+  static double computeDisagreementRad(double absAngleDeg, double relAngleDeg) {
+    if (Double.isNaN(absAngleDeg) || Double.isNaN(relAngleDeg)) {
+      return 0.0;
+    }
+    double absRad = Math.toRadians(absAngleDeg);
+    double relRad = Math.toRadians(relAngleDeg);
+    return Math.abs(MathUtil.angleModulus(absRad - relRad));
+  }
+
   private void updateEncoderHealth() {
     try {
       SwerveModule[] modules = swerveDrive.getModules();
@@ -168,15 +196,28 @@ public class DriveTelemetry implements SubsystemTelemetry {
         if (mod == null) continue;
 
         try {
-          double absAngle = mod.getAbsolutePosition();
-          encoderAbsoluteOk[i] = !Double.isNaN(absAngle);
+          double absAngleDeg = mod.getAbsolutePosition();
+          double relAngleDeg = mod.getRelativePosition();
+          boolean absOk = !Double.isNaN(absAngleDeg);
+          encoderAbsoluteOk[i] = absOk;
 
-          double relAngle = mod.getRelativePosition();
-          double disagreement = Math.abs(MathUtil.angleModulus(absAngle - relAngle));
+          double disagreement = computeDisagreementRad(absAngleDeg, relAngleDeg);
           encoderDisagreementRad[i] = disagreement;
+
+          // Debounce: a real drift stays high across many cycles. A settling
+          // transient clears on the next cycle. Latch only after the fault
+          // window fills up, so short spikes don't fire the alert.
+          if (absOk && disagreement > ENCODER_DISAGREEMENT_THRESHOLD_RAD) {
+            encoderFaultDebounceSec[i] += LOOP_PERIOD_SEC;
+          } else {
+            encoderFaultDebounceSec[i] = 0;
+          }
+          encoderFaultLatched[i] = encoderFaultDebounceSec[i] >= ENCODER_FAULT_DEBOUNCE_SEC;
         } catch (Throwable t) {
           encoderAbsoluteOk[i] = false;
           encoderDisagreementRad[i] = 0;
+          encoderFaultDebounceSec[i] = 0;
+          encoderFaultLatched[i] = false;
         }
       }
     } catch (Throwable t) {
@@ -281,6 +322,16 @@ public class DriveTelemetry implements SubsystemTelemetry {
     SafeLog.put("Drive/Auto/IsFollowing", isFollowingPath);
     SafeLog.put("Drive/Auto/PathName", currentPathName);
 
+    // Always on. These four arrays are tiny and catching a module drift
+    // matters every match, not just when tuning. The log bandwidth cost
+    // is under 0.1 percent of the total stream.
+    for (int i = 0; i < 4; i++) {
+      String name = MODULE_NAMES[i];
+      SafeLog.put("Drive/Encoder/" + name + "/AbsoluteOk", encoderAbsoluteOk[i]);
+      SafeLog.put("Drive/Encoder/" + name + "/DisagreementRad", encoderDisagreementRad[i]);
+      SafeLog.put("Drive/Encoder/" + name + "/EncoderIssue", encoderFaultLatched[i]);
+    }
+
     // Debug-only signals gated behind TUNING_MODE to reduce CAN/log bandwidth in competition
     if (Constants.TUNING_MODE) {
       for (int i = 0; i < 4; i++) {
@@ -290,16 +341,6 @@ public class DriveTelemetry implements SubsystemTelemetry {
               "Drive/ModuleSetpoints/" + name + "/Angle", moduleSetpoints[i].angle.getRadians());
           SafeLog.put(
               "Drive/ModuleSetpoints/" + name + "/Speed", moduleSetpoints[i].speedMetersPerSecond);
-        }
-      }
-
-      for (int i = 0; i < 4; i++) {
-        String name = MODULE_NAMES[i];
-        SafeLog.put("Drive/Encoder/" + name + "/AbsoluteOk", encoderAbsoluteOk[i]);
-        if (encoderDisagreementRad[i] > ENCODER_DISAGREEMENT_THRESHOLD_RAD) {
-          SafeLog.put("Drive/Encoder/" + name + "/DisagreementRad", encoderDisagreementRad[i]);
-        } else {
-          SafeLog.put("Drive/Encoder/" + name + "/DisagreementRad", 0.0);
         }
       }
 

--- a/src/main/java/frc/robot/telemetry/HangerTelemetry.java
+++ b/src/main/java/frc/robot/telemetry/HangerTelemetry.java
@@ -7,6 +7,9 @@ import frc.robot.Constants.DeviceHealthConstants;
 import frc.robot.Constants.HangerConstants;
 import frc.robot.Constants.MotorConstants;
 import frc.robot.subsystems.Hanger;
+import frc.robot.util.DeviceFaultDecoder;
+import frc.robot.util.DeviceFaultDecoder.DecodedFaults;
+import frc.robot.util.DeviceFaultDecoder.DeviceType;
 
 /** Hanger telemetry: position, deploy/climb state, motor health. */
 public class HangerTelemetry implements SubsystemTelemetry {
@@ -19,6 +22,8 @@ public class HangerTelemetry implements SubsystemTelemetry {
   private boolean atPosition = false;
   private double appliedOutput = 0;
   private double currentAmps = 0;
+  private double busVoltage = 0;
+  private double voltageDropVolts = 0;
   private double temperatureCelsius = 0;
   private boolean isDeployed = false;
   private boolean isClimbing = false;
@@ -27,6 +32,11 @@ public class HangerTelemetry implements SubsystemTelemetry {
       new Debouncer(DeviceHealthConstants.DISCONNECT_DEBOUNCE_SEC, Debouncer.DebounceType.kFalling);
   private boolean deviceConnected = false;
   private int deviceFaultsRaw = 0;
+  private int deviceWarningsRaw = 0;
+  private int lastRawFaults = 0;
+  private int lastRawWarnings = 0;
+  private int faultTransitionCount = 0;
+  private DecodedFaults decodedFaults = DeviceFaultDecoder.empty();
 
   private double climbProgress = 0;
   private String controlMode = "UNKNOWN";
@@ -59,6 +69,8 @@ public class HangerTelemetry implements SubsystemTelemetry {
       atPosition = hanger.isAtPosition();
       appliedOutput = hanger.getAppliedOutput();
       currentAmps = hanger.getOutputCurrent();
+      busVoltage = hanger.getBusVoltage();
+      voltageDropVolts = SystemHealthTelemetry.computeVoltageDrop(busVoltage);
       temperatureCelsius = hanger.getTemperature();
 
       isDeployed =
@@ -73,6 +85,19 @@ public class HangerTelemetry implements SubsystemTelemetry {
 
       deviceConnected = connectDebouncer.calculate(true);
       deviceFaultsRaw = hanger.getStickyFaultsRaw();
+      deviceWarningsRaw = hanger.getStickyWarningsRaw();
+
+      // Only re-decode when the raw integers change so the hot loop stays allocation-light
+      // during a clean match.
+      if (deviceFaultsRaw != lastRawFaults || deviceWarningsRaw != lastRawWarnings) {
+        decodedFaults =
+            DeviceFaultDecoder.decode(DeviceType.SPARK_MAX, deviceFaultsRaw, deviceWarningsRaw);
+        lastRawFaults = deviceFaultsRaw;
+        lastRawWarnings = deviceWarningsRaw;
+        if (decodedFaults.anyActive()) {
+          faultTransitionCount++;
+        }
+      }
 
       controlMode = (targetPosition != 0) ? "POSITION" : "OPEN_LOOP";
       softLimitActive =
@@ -81,6 +106,8 @@ public class HangerTelemetry implements SubsystemTelemetry {
     } catch (Throwable t) {
       deviceConnected = connectDebouncer.calculate(false);
       deviceFaultsRaw = -1;
+      deviceWarningsRaw = -1;
+      decodedFaults = DeviceFaultDecoder.empty();
       setDefaultValues();
     }
 
@@ -99,6 +126,8 @@ public class HangerTelemetry implements SubsystemTelemetry {
     atPosition = false;
     appliedOutput = 0;
     currentAmps = 0;
+    busVoltage = 0;
+    voltageDropVolts = 0;
     temperatureCelsius = 0;
     isDeployed = false;
     isClimbing = false;
@@ -113,12 +142,15 @@ public class HangerTelemetry implements SubsystemTelemetry {
     SafeLog.put("Hanger/AtPosition", atPosition);
     SafeLog.put("Hanger/AppliedOutput", appliedOutput);
     SafeLog.put("Hanger/CurrentAmps", currentAmps);
+    SafeLog.put("Hanger/BusVoltage", busVoltage);
+    SafeLog.put("Hanger/VoltageDropVolts", voltageDropVolts);
     SafeLog.put("Hanger/TemperatureCelsius", temperatureCelsius);
     SafeLog.put("Hanger/IsDeployed", isDeployed);
     SafeLog.put("Hanger/IsClimbing", isClimbing);
 
     SafeLog.put("Hanger/Device/Connected", deviceConnected);
-    SafeLog.put("Hanger/Device/FaultsRaw", deviceFaultsRaw);
+    DeviceFaultDecoder.publish(
+        "Hanger", decodedFaults, deviceFaultsRaw, deviceWarningsRaw, faultTransitionCount);
     SafeLog.put("Hanger/ClimbProgress", climbProgress);
     SafeLog.put("Hanger/ControlMode", controlMode);
     SafeLog.put("Hanger/SoftLimitActive", softLimitActive);

--- a/src/main/java/frc/robot/telemetry/IndexerTelemetry.java
+++ b/src/main/java/frc/robot/telemetry/IndexerTelemetry.java
@@ -7,6 +7,9 @@ import frc.robot.Constants;
 import frc.robot.Constants.DeviceHealthConstants;
 import frc.robot.Constants.StallDetectionConstants;
 import frc.robot.subsystems.Indexer;
+import frc.robot.util.DeviceFaultDecoder;
+import frc.robot.util.DeviceFaultDecoder.DecodedFaults;
+import frc.robot.util.DeviceFaultDecoder.DeviceType;
 import frc.robot.util.EventMarker;
 import frc.robot.util.JamProtection;
 
@@ -27,6 +30,8 @@ public class IndexerTelemetry implements SubsystemTelemetry {
   private double currentAmps = 0;
   private double temperatureCelsius = 0;
   private double velocityRPM = 0;
+  private double busVoltage = 0;
+  private double voltageDropVolts = 0;
 
   private boolean feederActive = false;
   private double jamFrequencyPerMin = 0;
@@ -38,6 +43,11 @@ public class IndexerTelemetry implements SubsystemTelemetry {
       new Debouncer(DeviceHealthConstants.DISCONNECT_DEBOUNCE_SEC, Debouncer.DebounceType.kFalling);
   private boolean deviceConnected = false;
   private int deviceFaultsRaw = 0;
+  private int deviceWarningsRaw = 0;
+  private int lastRawFaults = 0;
+  private int lastRawWarnings = 0;
+  private int faultTransitionCount = 0;
+  private DecodedFaults decodedFaults = DeviceFaultDecoder.empty();
 
   private boolean stalled = false;
   private double stallStartTime = 0;
@@ -84,13 +94,28 @@ public class IndexerTelemetry implements SubsystemTelemetry {
       currentAmps = indexer.getOutputCurrent();
       temperatureCelsius = indexer.getTemperature();
       velocityRPM = indexer.getVelocityRPM();
+      busVoltage = indexer.getBusVoltage();
+      voltageDropVolts = SystemHealthTelemetry.computeVoltageDrop(busVoltage);
 
       targetSpeed = indexer.getTunableTargetSpeed();
       deviceConnected = connectDebouncer.calculate(true);
       deviceFaultsRaw = indexer.getStickyFaultsRaw();
+      deviceWarningsRaw = indexer.getStickyWarningsRaw();
+
+      if (deviceFaultsRaw != lastRawFaults || deviceWarningsRaw != lastRawWarnings) {
+        decodedFaults =
+            DeviceFaultDecoder.decode(DeviceType.SPARK_FLEX, deviceFaultsRaw, deviceWarningsRaw);
+        lastRawFaults = deviceFaultsRaw;
+        lastRawWarnings = deviceWarningsRaw;
+        if (decodedFaults.anyActive()) {
+          faultTransitionCount++;
+        }
+      }
     } catch (Throwable t) {
       deviceConnected = connectDebouncer.calculate(false);
       deviceFaultsRaw = -1;
+      deviceWarningsRaw = -1;
+      decodedFaults = DeviceFaultDecoder.empty();
       setDefaultValues();
       return;
     }
@@ -205,6 +230,8 @@ public class IndexerTelemetry implements SubsystemTelemetry {
     currentAmps = 0;
     temperatureCelsius = 0;
     velocityRPM = 0;
+    busVoltage = 0;
+    voltageDropVolts = 0;
     stalled = false;
     stallDurationMs = 0;
     inStallCondition = false;
@@ -220,9 +247,13 @@ public class IndexerTelemetry implements SubsystemTelemetry {
     SafeLog.put("Indexer/Running", running);
     SafeLog.put("Indexer/AppliedOutput", appliedOutput);
     SafeLog.put("Indexer/CurrentAmps", currentAmps);
+    SafeLog.put("Indexer/BusVoltage", busVoltage);
+    SafeLog.put("Indexer/VoltageDropVolts", voltageDropVolts);
     SafeLog.put("Indexer/TemperatureCelsius", temperatureCelsius);
     SafeLog.put("Indexer/VelocityRPM", velocityRPM);
     SafeLog.put("Indexer/Device/Connected", deviceConnected);
+    DeviceFaultDecoder.publish(
+        "Indexer", decodedFaults, deviceFaultsRaw, deviceWarningsRaw, faultTransitionCount);
     SafeLog.put("Indexer/Stalled", stalled);
     SafeLog.put("Indexer/JamDetected", jamDetected);
 
@@ -247,7 +278,6 @@ public class IndexerTelemetry implements SubsystemTelemetry {
       SafeLog.put("Indexer/TotalJamCount", totalJamCount);
       SafeLog.put("Indexer/JamFrequencyPerMin", jamFrequencyPerMin);
       SafeLog.put("Indexer/ActiveCommand", activeCommandName);
-      SafeLog.put("Indexer/Device/FaultsRaw", deviceFaultsRaw);
     }
   }
 

--- a/src/main/java/frc/robot/telemetry/IntakeActuatorTelemetry.java
+++ b/src/main/java/frc/robot/telemetry/IntakeActuatorTelemetry.java
@@ -5,6 +5,9 @@ import edu.wpi.first.wpilibj2.command.Command;
 import frc.robot.Constants;
 import frc.robot.Constants.DeviceHealthConstants;
 import frc.robot.subsystems.IntakePivot;
+import frc.robot.util.DeviceFaultDecoder;
+import frc.robot.util.DeviceFaultDecoder.DecodedFaults;
+import frc.robot.util.DeviceFaultDecoder.DeviceType;
 
 /** IntakeActuator telemetry: position and motor health. */
 public class IntakeActuatorTelemetry implements SubsystemTelemetry {
@@ -18,12 +21,17 @@ public class IntakeActuatorTelemetry implements SubsystemTelemetry {
   private boolean atTarget = false;
   private double appliedOutput = 0;
   private double currentAmps = 0;
+  private double busVoltage = 0;
+  private double voltageDropVolts = 0;
   private double temperatureCelsius = 0;
 
   private final Debouncer connectDebouncer =
       new Debouncer(DeviceHealthConstants.DISCONNECT_DEBOUNCE_SEC, Debouncer.DebounceType.kFalling);
   private boolean deviceConnected = false;
   private int deviceFaultsRaw = 0;
+  private int lastRawFaults = 0;
+  private int faultTransitionCount = 0;
+  private DecodedFaults decodedFaults = DeviceFaultDecoder.empty();
 
   private String activeCommandName = "none";
 
@@ -49,15 +57,26 @@ public class IntakeActuatorTelemetry implements SubsystemTelemetry {
       positionRotations = intakeActuator.getPosition();
       targetPosition = intakeActuator.getTargetPosition();
       atTarget = intakeActuator.isAtTarget();
-      // appliedOutput = intakeActuator.getAppliedOutput();
-      // currentAmps = intakeActuator.getOutputCurrent();
-      // temperatureCelsius = intakeActuator.getTemperature();
+      appliedOutput = intakeActuator.getAppliedOutput();
+      currentAmps = intakeActuator.getOutputCurrent();
+      busVoltage = intakeActuator.getBusVoltage();
+      voltageDropVolts = SystemHealthTelemetry.computeVoltageDrop(busVoltage);
+      temperatureCelsius = intakeActuator.getTemperature();
 
       deviceConnected = connectDebouncer.calculate(true);
       deviceFaultsRaw = intakeActuator.getStickyFaultsRaw();
+
+      if (deviceFaultsRaw != lastRawFaults) {
+        decodedFaults = DeviceFaultDecoder.decode(DeviceType.TALON_FX, deviceFaultsRaw, 0);
+        lastRawFaults = deviceFaultsRaw;
+        if (decodedFaults.anyActive()) {
+          faultTransitionCount++;
+        }
+      }
     } catch (Throwable t) {
       deviceConnected = connectDebouncer.calculate(false);
       deviceFaultsRaw = -1;
+      decodedFaults = DeviceFaultDecoder.empty();
       setDefaultValues();
     }
 
@@ -75,6 +94,8 @@ public class IntakeActuatorTelemetry implements SubsystemTelemetry {
     atTarget = false;
     appliedOutput = 0;
     currentAmps = 0;
+    busVoltage = 0;
+    voltageDropVolts = 0;
     temperatureCelsius = 0;
   }
 
@@ -84,13 +105,16 @@ public class IntakeActuatorTelemetry implements SubsystemTelemetry {
     SafeLog.put("IntakeActuator/AtTarget", atTarget);
     SafeLog.put("IntakeActuator/Device/Connected", deviceConnected);
     SafeLog.put("IntakeActuator/CurrentAmps", currentAmps);
+    SafeLog.put("IntakeActuator/BusVoltage", busVoltage);
+    SafeLog.put("IntakeActuator/VoltageDropVolts", voltageDropVolts);
+    SafeLog.put("IntakeActuator/TemperatureCelsius", temperatureCelsius);
     SafeLog.put("IntakeActuator/AppliedOutput", appliedOutput);
+    DeviceFaultDecoder.publish(
+        "IntakeActuator", decodedFaults, deviceFaultsRaw, 0, faultTransitionCount);
 
     if (Constants.TUNING_MODE) {
       SafeLog.put("IntakeActuator/Available", subsystemAvailable);
       SafeLog.put("IntakeActuator/TargetPosition", targetPosition);
-      SafeLog.put("IntakeActuator/TemperatureCelsius", temperatureCelsius);
-      SafeLog.put("IntakeActuator/Device/FaultsRaw", deviceFaultsRaw);
       SafeLog.put("IntakeActuator/ActiveCommand", activeCommandName);
     }
   }

--- a/src/main/java/frc/robot/telemetry/IntakeTelemetry.java
+++ b/src/main/java/frc/robot/telemetry/IntakeTelemetry.java
@@ -7,6 +7,9 @@ import frc.robot.Constants;
 import frc.robot.Constants.DeviceHealthConstants;
 import frc.robot.Constants.StallDetectionConstants;
 import frc.robot.subsystems.IntakeRoller;
+import frc.robot.util.DeviceFaultDecoder;
+import frc.robot.util.DeviceFaultDecoder.DecodedFaults;
+import frc.robot.util.DeviceFaultDecoder.DeviceType;
 import frc.robot.util.EventMarker;
 import frc.robot.util.JamProtection;
 
@@ -30,6 +33,8 @@ public class IntakeTelemetry implements SubsystemTelemetry {
   private double currentAmps = 0;
   private double temperatureCelsius = 0;
   private double velocityRPM = 0;
+  private double busVoltage = 0;
+  private double voltageDropVolts = 0;
 
   private double currentPerSpeedRatio = 0; // drag indicator
 
@@ -37,6 +42,11 @@ public class IntakeTelemetry implements SubsystemTelemetry {
       new Debouncer(DeviceHealthConstants.DISCONNECT_DEBOUNCE_SEC, Debouncer.DebounceType.kFalling);
   private boolean deviceConnected = false;
   private int deviceFaultsRaw = 0;
+  private int deviceWarningsRaw = 0;
+  private int lastRawFaults = 0;
+  private int lastRawWarnings = 0;
+  private int faultTransitionCount = 0;
+  private DecodedFaults decodedFaults = DeviceFaultDecoder.empty();
 
   private boolean stalled = false;
   private double stallStartTime = 0;
@@ -75,12 +85,27 @@ public class IntakeTelemetry implements SubsystemTelemetry {
       currentAmps = intake.getOutputCurrent();
       temperatureCelsius = intake.getTemperature();
       velocityRPM = intake.getVelocityRPM();
+      busVoltage = intake.getBusVoltage();
+      voltageDropVolts = SystemHealthTelemetry.computeVoltageDrop(busVoltage);
 
       deviceConnected = connectDebouncer.calculate(true);
       deviceFaultsRaw = intake.getStickyFaultsRaw();
+      deviceWarningsRaw = intake.getStickyWarningsRaw();
+
+      if (deviceFaultsRaw != lastRawFaults || deviceWarningsRaw != lastRawWarnings) {
+        decodedFaults =
+            DeviceFaultDecoder.decode(DeviceType.SPARK_MAX, deviceFaultsRaw, deviceWarningsRaw);
+        lastRawFaults = deviceFaultsRaw;
+        lastRawWarnings = deviceWarningsRaw;
+        if (decodedFaults.anyActive()) {
+          faultTransitionCount++;
+        }
+      }
     } catch (Throwable t) {
       deviceConnected = connectDebouncer.calculate(false);
       deviceFaultsRaw = -1;
+      deviceWarningsRaw = -1;
+      decodedFaults = DeviceFaultDecoder.empty();
       setDefaultValues();
       return;
     }
@@ -146,6 +171,8 @@ public class IntakeTelemetry implements SubsystemTelemetry {
     currentAmps = 0;
     temperatureCelsius = 0;
     velocityRPM = 0;
+    busVoltage = 0;
+    voltageDropVolts = 0;
     stalled = false;
     stallDurationMs = 0;
     inStallCondition = false;
@@ -158,7 +185,11 @@ public class IntakeTelemetry implements SubsystemTelemetry {
     SafeLog.put("Intake/Running", running);
     SafeLog.put("Intake/VelocityRPM", velocityRPM);
     SafeLog.put("Intake/CurrentAmps", currentAmps);
+    SafeLog.put("Intake/BusVoltage", busVoltage);
+    SafeLog.put("Intake/VoltageDropVolts", voltageDropVolts);
     SafeLog.put("Intake/Device/Connected", deviceConnected);
+    DeviceFaultDecoder.publish(
+        "Intake", decodedFaults, deviceFaultsRaw, deviceWarningsRaw, faultTransitionCount);
     SafeLog.put("Intake/Stalled", stalled);
     SafeLog.put("Intake/JamDetected", jamDetected);
 
@@ -168,7 +199,6 @@ public class IntakeTelemetry implements SubsystemTelemetry {
       SafeLog.put("Intake/TemperatureCelsius", temperatureCelsius);
       SafeLog.put("Intake/TotalJamCount", totalJamCount);
       SafeLog.put("Intake/CurrentPerSpeedRatio", currentPerSpeedRatio);
-      SafeLog.put("Intake/Device/FaultsRaw", deviceFaultsRaw);
       SafeLog.put("Intake/StallDurationMs", stallDurationMs);
       SafeLog.put("Intake/ActiveCommand", activeCommandName);
       SafeLog.put("Intake/JamProtection/State", jamProtectionState);

--- a/src/main/java/frc/robot/telemetry/ShooterTelemetry.java
+++ b/src/main/java/frc/robot/telemetry/ShooterTelemetry.java
@@ -9,6 +9,9 @@ import frc.robot.Constants.DeviceHealthConstants;
 import frc.robot.Constants.ShooterConstants;
 import frc.robot.Constants.StallDetectionConstants;
 import frc.robot.subsystems.Shooter;
+import frc.robot.util.DeviceFaultDecoder;
+import frc.robot.util.DeviceFaultDecoder.DecodedFaults;
+import frc.robot.util.DeviceFaultDecoder.DeviceType;
 import frc.robot.util.EventMarker;
 import java.util.ArrayDeque;
 import java.util.Deque;
@@ -49,6 +52,7 @@ public class ShooterTelemetry implements SubsystemTelemetry {
   private double currentAmps = 0;
   private double temperatureCelsius = 0;
   private double busVoltage = 0;
+  private double voltageDropVolts = 0;
   private boolean atSpeed = false;
   private double atSpeedPercent = 0;
   private boolean isSpinningUp = false;
@@ -66,6 +70,11 @@ public class ShooterTelemetry implements SubsystemTelemetry {
       new Debouncer(DeviceHealthConstants.DISCONNECT_DEBOUNCE_SEC, Debouncer.DebounceType.kFalling);
   private boolean deviceConnected = false;
   private int deviceFaultsRaw = 0;
+  private int deviceWarningsRaw = 0;
+  private int lastRawFaults = 0;
+  private int lastRawWarnings = 0;
+  private int faultTransitionCount = 0;
+  private DecodedFaults decodedFaults = DeviceFaultDecoder.empty();
 
   private boolean stalled = false;
   private boolean wasStalled = false;
@@ -119,15 +128,29 @@ public class ShooterTelemetry implements SubsystemTelemetry {
       currentAmps = shooter.getOutputCurrent();
       temperatureCelsius = shooter.getTemperature();
       busVoltage = shooter.getBusVoltage();
+      voltageDropVolts = SystemHealthTelemetry.computeVoltageDrop(busVoltage);
       // Compute atSpeed ourselves because the no-arg isAtSpeed() checks against
       // desiredRPM which may not be set when moveToVelocityWithPID is overridden
       atSpeed = (targetRPM > 0) && (Math.abs(targetRPM - velocityRPM) < shooter.getToleranceRPM());
 
       deviceConnected = connectDebouncer.calculate(true);
       deviceFaultsRaw = shooter.getStickyFaultsRaw();
+      deviceWarningsRaw = shooter.getStickyWarningsRaw();
+
+      if (deviceFaultsRaw != lastRawFaults || deviceWarningsRaw != lastRawWarnings) {
+        decodedFaults =
+            DeviceFaultDecoder.decode(DeviceType.SPARK_FLEX, deviceFaultsRaw, deviceWarningsRaw);
+        lastRawFaults = deviceFaultsRaw;
+        lastRawWarnings = deviceWarningsRaw;
+        if (decodedFaults.anyActive()) {
+          faultTransitionCount++;
+        }
+      }
     } catch (Throwable t) {
       deviceConnected = connectDebouncer.calculate(false);
       deviceFaultsRaw = -1;
+      deviceWarningsRaw = -1;
+      decodedFaults = DeviceFaultDecoder.empty();
       setDefaultValues();
       return;
     }
@@ -281,6 +304,7 @@ public class ShooterTelemetry implements SubsystemTelemetry {
     currentAmps = 0;
     temperatureCelsius = 0;
     busVoltage = 0;
+    voltageDropVolts = 0;
     atSpeed = false;
     atSpeedPercent = 0;
     filteredSpinUpPercent = 0;
@@ -319,12 +343,15 @@ public class ShooterTelemetry implements SubsystemTelemetry {
     SafeLog.put("Shooter/TemperatureCelsius", temperatureCelsius);
     SafeLog.put("Shooter/TemperatureWarning", temperatureWarning);
     SafeLog.put("Shooter/BusVoltage", busVoltage);
+    SafeLog.put("Shooter/VoltageDropVolts", voltageDropVolts);
     SafeLog.put("Shooter/ShotDetected", shotDetected);
     SafeLog.put("Shooter/TotalShots", totalShotCount);
     SafeLog.put("Shooter/LastShotVelocityRPM", lastShotVelocityRPM);
     SafeLog.put("Shooter/SpinUpTimeMs", lastSpinUpDurationMs);
     SafeLog.put("Shooter/Stalled", stalled);
     SafeLog.put("Shooter/Device/Connected", deviceConnected);
+    DeviceFaultDecoder.publish(
+        "Shooter", decodedFaults, deviceFaultsRaw, deviceWarningsRaw, faultTransitionCount);
     SafeLog.put("Shooter/State", shooterState);
 
     // Debug/tuning signals: only logged when tuning to reduce CAN and log bandwidth
@@ -348,7 +375,6 @@ public class ShooterTelemetry implements SubsystemTelemetry {
         SafeLog.put("Shooter/Config/kD", prevKD);
         SafeLog.put("Shooter/Config/FF", prevFF);
       }
-      SafeLog.put("Shooter/Device/FaultsRaw", deviceFaultsRaw);
       SafeLog.put("Shooter/StallDurationMs", stallDurationMs);
       SafeLog.put("Shooter/PreviousState", previousShooterState);
       SafeLog.put("Shooter/StateChanged", stateChangedThisCycle);

--- a/src/main/java/frc/robot/telemetry/SystemHealthTelemetry.java
+++ b/src/main/java/frc/robot/telemetry/SystemHealthTelemetry.java
@@ -9,6 +9,57 @@ import frc.robot.Constants.PDHChannelMap;
 
 /** System health: battery, CAN bus, roboRIO, loop timing, brownout prediction. */
 public class SystemHealthTelemetry implements SubsystemTelemetry {
+  // Shared snapshot so any subsystem telemetry class can subtract its bus voltage
+  // from the battery voltage without each one re-reading the RoboRIO API.
+  // Volatile because it is written in update() and read from other telemetry
+  // classes' update() on the same thread, but reordering would still produce
+  // a garbage voltage drop for one cycle.
+  private static volatile double sharedBatteryVoltage = Double.NaN;
+
+  // Shared CAN status snapshot used by CANHealthTelemetry for peak tracking.
+  // -1 is "not sampled yet", which callers treat as "skip" rather than "error".
+  private static volatile int sharedCanTxErrors = -1;
+  private static volatile int sharedCanRxErrors = -1;
+  private static volatile int sharedCanTxFull = -1;
+
+  /**
+   * Returns the most recent battery voltage snapshot, or NaN if no update cycle has run yet. Used
+   * by per-subsystem telemetry classes to compute VoltageDropVolts without redundant RoboRIO reads.
+   */
+  public static double getBatteryVoltageSafely() {
+    return sharedBatteryVoltage;
+  }
+
+  /** Returns the latest CAN TxError count, or -1 if no update has run yet. */
+  public static int getCanTxErrorsSafely() {
+    return sharedCanTxErrors;
+  }
+
+  /** Returns the latest CAN RxError count, or -1 if no update has run yet. */
+  public static int getCanRxErrorsSafely() {
+    return sharedCanRxErrors;
+  }
+
+  /** Returns the latest CAN TxFull count, or -1 if no update has run yet. */
+  public static int getCanTxFullSafely() {
+    return sharedCanTxFull;
+  }
+
+  /**
+   * Returns battery minus bus voltage, clamped at 0. A healthy wiring path shows under 0.5 V at
+   * moderate current. Anything consistently above 1.5 V is a bad crimp or an undersized feeder.
+   * Returns 0 if the battery voltage snapshot has not been taken yet (boot race) or if the bus
+   * voltage reading is NaN or garbage.
+   */
+  public static double computeVoltageDrop(double busVoltage) {
+    double battery = sharedBatteryVoltage;
+    if (Double.isNaN(battery) || Double.isNaN(busVoltage)) {
+      return 0.0;
+    }
+    double drop = battery - busVoltage;
+    return Math.max(0.0, drop);
+  }
+
   private static final double LOOP_OVERRUN_THRESHOLD_MS = 25.0;
 
   private static final int CAN_STATUS_DECIMATION = 10;
@@ -54,7 +105,16 @@ public class SystemHealthTelemetry implements SubsystemTelemetry {
   private double loopTimeMs = 0;
   private int loopOverrunCount = 0;
 
+  // Elastic cannot iterate Constants.PDHChannelMap.LABELS at render time, so we
+  // publish the labels as a structured signal once. Any future Constants change
+  // propagates to the dashboard on the next boot without a matching dashboard edit.
+  private final String[] pdhLabels = new String[PDHChannelMap.NUM_CHANNELS];
+  private boolean pdhLabelsPublished = false;
+
   public SystemHealthTelemetry() {
+    for (int i = 0; i < PDHChannelMap.NUM_CHANNELS; i++) {
+      pdhLabels[i] = PDHChannelMap.getLabel(i);
+    }
     try {
       pdh = new PowerDistribution();
     } catch (Throwable t) {
@@ -76,6 +136,7 @@ public class SystemHealthTelemetry implements SubsystemTelemetry {
       lastLoopTimestamp = currentTimestamp;
 
       batteryVoltage = RobotController.getBatteryVoltage();
+      sharedBatteryVoltage = batteryVoltage;
 
       double now = Timer.getFPGATimestamp();
       if (lastVoltageTimestamp > 0 && lastVoltage > 0) {
@@ -113,6 +174,9 @@ public class SystemHealthTelemetry implements SubsystemTelemetry {
         canTxErrors = canStatus.transmitErrorCount;
         canRxErrors = canStatus.receiveErrorCount;
         canBusOff = canStatus.busOffCount;
+        sharedCanTxErrors = canTxErrors;
+        sharedCanRxErrors = canRxErrors;
+        sharedCanTxFull = canStatus.txFullCount;
       }
 
       rioCPUTemp = RobotController.getCPUTemp();
@@ -195,8 +259,13 @@ public class SystemHealthTelemetry implements SubsystemTelemetry {
     SafeLog.put("SystemHealth/Rio5VRail", rio5VRail);
     SafeLog.put("SystemHealth/Rio6VRail", rio6VRail);
 
+    if (!pdhLabelsPublished) {
+      SafeLog.put("SystemHealth/PDH/Labels", pdhLabels);
+      pdhLabelsPublished = true;
+    }
+
     for (int i = 0; i < PDHChannelMap.NUM_CHANNELS; i++) {
-      String label = PDHChannelMap.getLabel(i);
+      String label = pdhLabels[i];
       SafeLog.put("PDH/" + label + "/Current", channelCurrents[i]);
     }
 

--- a/src/main/java/frc/robot/telemetry/VisionTelemetry.java
+++ b/src/main/java/frc/robot/telemetry/VisionTelemetry.java
@@ -5,6 +5,9 @@ import frc.robot.Cameras;
 import frc.robot.Constants;
 import frc.robot.subsystems.swervedrive.Vision;
 import frc.robot.subsystems.swervedrive.VisionFilter.RejectionReason;
+import frc.robot.util.CoprocessorHealth;
+import java.util.HashMap;
+import java.util.Map;
 
 /** Vision telemetry: target lock, tag ID stability, pose confidence. */
 public class VisionTelemetry implements SubsystemTelemetry {
@@ -63,7 +66,17 @@ public class VisionTelemetry implements SubsystemTelemetry {
   private int rejectHeadingDivergence = 0;
   private int rejectPoseJump = 0;
 
-  public VisionTelemetry() {}
+  private final CoprocessorHealth coprocessorHealth = new CoprocessorHealth();
+  private final Map<String, Boolean> cameraConnectivitySnapshot = new HashMap<>();
+
+  public VisionTelemetry() {
+    // Register each expected camera with its coprocessor group so paired-drop
+    // detection works on the first update cycle. The group strings come from
+    // the Cameras enum so any topology change propagates here automatically.
+    for (Cameras cam : Cameras.values()) {
+      coprocessorHealth.register(cam.name(), cam.coprocessorGroup);
+    }
+  }
 
   /** Called from RobotContainer */
   public void setVision(Vision vision) {
@@ -190,6 +203,19 @@ public class VisionTelemetry implements SubsystemTelemetry {
         frontRightCamConnected = false;
       }
 
+      // Feed the coprocessor rollup. The map is reused each cycle so there is
+      // no per-cycle allocation in the hot path.
+      cameraConnectivitySnapshot.clear();
+      cameraConnectivitySnapshot.put(Cameras.LEFT_CAM.name(), leftCamConnected);
+      cameraConnectivitySnapshot.put(Cameras.RIGHT_CAM.name(), rightCamConnected);
+      cameraConnectivitySnapshot.put(Cameras.FRONT_LEFT_CAM.name(), frontLeftCamConnected);
+      cameraConnectivitySnapshot.put(Cameras.FRONT_RIGHT_CAM.name(), frontRightCamConnected);
+      try {
+        coprocessorHealth.update(cameraConnectivitySnapshot);
+      } catch (Throwable t) {
+        // Rollup is a diagnostic; its failure must never stop vision processing.
+      }
+
       visionHealthy = true;
     } catch (Throwable t) {
       visionHealthy = false;
@@ -289,6 +315,7 @@ public class VisionTelemetry implements SubsystemTelemetry {
     SafeLog.put("Vision/Camera/RightCam/Connected", rightCamConnected);
     SafeLog.put("Vision/Camera/FrontLeftCam/Connected", frontLeftCamConnected);
     SafeLog.put("Vision/Camera/FrontRightCam/Connected", frontRightCamConnected);
+    publishCoprocessorHealth();
     SafeLog.put("Vision/Filter/AcceptRatePct", filterAcceptRatePct);
     SafeLog.put("Vision/Filter/Reject/Ambiguity", rejectAmbiguity);
     SafeLog.put("Vision/Filter/Reject/ZHeight", rejectZHeight);
@@ -317,6 +344,30 @@ public class VisionTelemetry implements SubsystemTelemetry {
       SafeLog.put("Vision/Filter/RejectedCount", filterRejected);
       SafeLog.put("Vision/Filter/LastRejection", lastRejectionReason);
     }
+  }
+
+  /**
+   * Publishes per-coprocessor alive, reboot count, and time-since-reboot signals plus a total
+   * reboot counter. The total is the one the Pit Check page reads for its warnings list.
+   */
+  private void publishCoprocessorHealth() {
+    int totalReboots = 0;
+    for (String group : coprocessorHealth.getGroupNames()) {
+      boolean alive = coprocessorHealth.isGroupAlive(group);
+      int reboots = coprocessorHealth.getRebootCount(group);
+      double lastReboot = coprocessorHealth.getLastRebootTimestamp(group);
+      double timeSince = coprocessorHealth.getTimeSinceLastRebootSec(group);
+      SafeLog.put("Vision/Coprocessor/" + group + "/Alive", alive);
+      SafeLog.put("Vision/Coprocessor/" + group + "/RebootCount", reboots);
+      SafeLog.put("Vision/Coprocessor/" + group + "/LastRebootSec", lastReboot);
+      SafeLog.put(
+          "Vision/Coprocessor/" + group + "/TimeSinceRebootSec",
+          Double.isInfinite(timeSince) ? -1.0 : timeSince);
+      totalReboots += reboots;
+    }
+    SafeLog.put("Vision/Coprocessor/TotalRebootCount", totalReboots);
+    SafeLog.put(
+        "Vision/Coprocessor/AnyRebootedRecently", coprocessorHealth.anyRebootedRecently(60.0));
   }
 
   @Override

--- a/src/main/java/frc/robot/util/CoprocessorHealth.java
+++ b/src/main/java/frc/robot/util/CoprocessorHealth.java
@@ -1,0 +1,171 @@
+package frc.robot.util;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.DoubleSupplier;
+
+/**
+ * Rolls multiple cameras that share a coprocessor into a single alive boolean, a reboot counter,
+ * and a last-reboot timestamp. Solves the WPI Day 1 symptom where both rear cameras disconnected
+ * together every few minutes and the dashboard showed two independent camera flickers instead of
+ * the real root cause (an Orange Pi power cycle).
+ *
+ * <p>The detector treats a group as rebooting when every camera in the group goes offline within a
+ * small time window. The recovery window is longer, which captures the real Orange Pi boot time of
+ * about 20 seconds. A single camera dropping on its own does not count as a coprocessor reboot.
+ *
+ * <p>Thread-safety: not thread-safe. All updates happen on the scheduler thread via
+ * VisionTelemetry.
+ */
+public final class CoprocessorHealth {
+
+  /** Cameras that drop within this window are considered a paired loss. */
+  private static final double PAIRED_DROP_WINDOW_SEC = 0.5;
+
+  /** After this much time alive again, the group is considered recovered from a reboot. */
+  private static final double RECOVERY_DWELL_SEC = 2.0;
+
+  private static final class GroupState {
+    final List<String> cameraNames = new ArrayList<>();
+    boolean alive = false;
+    boolean wasAlive = false;
+    double firstDropTimestamp = -1;
+    boolean rebootPending = false;
+    int rebootCount = 0;
+    double lastRebootTimestamp = 0;
+    double aliveSinceTimestamp = -1;
+  }
+
+  private final Map<String, GroupState> groups = new HashMap<>();
+  private final DoubleSupplier clock;
+
+  /** Production constructor uses the WPILib FPGA timestamp as the clock. */
+  public CoprocessorHealth() {
+    this(() -> edu.wpi.first.wpilibj.Timer.getFPGATimestamp());
+  }
+
+  /** Test constructor: inject a clock supplier to make reboot detection deterministic. */
+  public CoprocessorHealth(DoubleSupplier clock) {
+    this.clock = clock;
+  }
+
+  /**
+   * Registers a camera as a member of a coprocessor group. Call once at construction time for each
+   * expected camera. Unknown groups are created on first registration.
+   */
+  public void register(String cameraName, String coprocessorGroup) {
+    GroupState group = groups.computeIfAbsent(coprocessorGroup, k -> new GroupState());
+    if (!group.cameraNames.contains(cameraName)) {
+      group.cameraNames.add(cameraName);
+    }
+  }
+
+  /**
+   * Drives the detector with the current connectivity state of each camera. Called once per cycle
+   * from VisionTelemetry.update.
+   *
+   * @param cameraConnected a map of camera name to current connected boolean. Missing entries are
+   *     treated as disconnected.
+   */
+  public void update(Map<String, Boolean> cameraConnected) {
+    double now = clock.getAsDouble();
+    for (GroupState group : groups.values()) {
+      updateGroup(group, cameraConnected, now);
+    }
+  }
+
+  private void updateGroup(GroupState group, Map<String, Boolean> cameraConnected, double now) {
+    int aliveCount = 0;
+    int totalCount = group.cameraNames.size();
+    for (String cam : group.cameraNames) {
+      Boolean state = cameraConnected.get(cam);
+      if (state != null && state) {
+        aliveCount++;
+      }
+    }
+    group.wasAlive = group.alive;
+    group.alive = aliveCount > 0;
+
+    // Edge: alive -> dead, start the paired drop window.
+    if (group.wasAlive && !group.alive) {
+      group.firstDropTimestamp = now;
+      group.aliveSinceTimestamp = -1;
+    }
+
+    // All cameras in the group dropped within the paired window: flag a pending reboot.
+    // Single-camera drops (aliveCount == 0 but totalCount == 1) also count if the group has
+    // only one camera, because a single-camera group IS the coprocessor.
+    if (!group.alive
+        && group.firstDropTimestamp >= 0
+        && (now - group.firstDropTimestamp) <= PAIRED_DROP_WINDOW_SEC
+        && aliveCount == 0) {
+      group.rebootPending = true;
+    }
+
+    // Edge: dead -> alive, start the recovery dwell.
+    if (!group.wasAlive && group.alive) {
+      group.aliveSinceTimestamp = now;
+    }
+
+    // Recovery: group has been alive for long enough after a pending reboot.
+    if (group.rebootPending
+        && group.alive
+        && group.aliveSinceTimestamp >= 0
+        && (now - group.aliveSinceTimestamp) >= RECOVERY_DWELL_SEC) {
+      group.rebootCount++;
+      group.lastRebootTimestamp = now;
+      group.rebootPending = false;
+      group.firstDropTimestamp = -1;
+    }
+  }
+
+  public boolean isGroupAlive(String groupName) {
+    GroupState group = groups.get(groupName);
+    return group != null && group.alive;
+  }
+
+  public int getRebootCount(String groupName) {
+    GroupState group = groups.get(groupName);
+    return group != null ? group.rebootCount : 0;
+  }
+
+  public double getLastRebootTimestamp(String groupName) {
+    GroupState group = groups.get(groupName);
+    return group != null ? group.lastRebootTimestamp : 0;
+  }
+
+  public double getTimeSinceLastRebootSec(String groupName) {
+    GroupState group = groups.get(groupName);
+    if (group == null || group.lastRebootTimestamp == 0) {
+      return Double.POSITIVE_INFINITY;
+    }
+    return clock.getAsDouble() - group.lastRebootTimestamp;
+  }
+
+  /** Sum of reboot counts across all registered groups. */
+  public int getTotalRebootCount() {
+    int total = 0;
+    for (GroupState group : groups.values()) {
+      total += group.rebootCount;
+    }
+    return total;
+  }
+
+  /** True if any group has rebooted in the last {@code windowSec}. */
+  public boolean anyRebootedRecently(double windowSec) {
+    double now = clock.getAsDouble();
+    for (GroupState group : groups.values()) {
+      if (group.lastRebootTimestamp > 0 && (now - group.lastRebootTimestamp) <= windowSec) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /** Returns the set of group names currently registered. */
+  public Iterable<String> getGroupNames() {
+    return groups.keySet();
+  }
+}

--- a/src/main/java/frc/robot/util/DeviceFaultDecoder.java
+++ b/src/main/java/frc/robot/util/DeviceFaultDecoder.java
@@ -1,0 +1,313 @@
+package frc.robot.util;
+
+import frc.robot.telemetry.SafeLog;
+
+/**
+ * The pit crew and the electrical team cannot memorize a fault bit table under match pressure. A
+ * raw fault integer like {@code 0x0024} tells them nothing in the five minutes they have between
+ * matches. Sharing one place that turns vendor fault words into the phrase "gate driver, stall"
+ * lets every dashboard tile, every alert rule, and every telemetry class produce the same human
+ * readable output without each re-implementing bit masks that change when the vendor updates the
+ * firmware.
+ *
+ * <p>Pure and stateless so unit tests run in plain JUnit without sim fixtures. Allocation aware so
+ * the hot loop in each telemetry class can skip the decode step when the raw integer has not
+ * changed from last cycle.
+ */
+public final class DeviceFaultDecoder {
+
+  /** Which device family produced the raw integer. Controls how bits are interpreted. */
+  public enum DeviceType {
+    SPARK_MAX,
+    SPARK_FLEX,
+    TALON_FX
+  }
+
+  /**
+   * Union of the flags that matter across both vendor families. Fields that do not apply to a given
+   * device type stay false.
+   *
+   * <p>{@code hardwareFault} is the "replace the controller" flag (gate driver on REVLib, generic
+   * hardware on TalonFX). {@code critical} is the pit-crew rollup: true when brownout, overcurrent,
+   * hardwareFault, motorType, firmware, or a hardware-level sensor fault is set. {@code
+   * shortSummary} is the comma separated human readable list, capped at 80 characters so it fits
+   * inside an Elastic tile.
+   */
+  public record DecodedFaults(
+      boolean brownout,
+      boolean overcurrent,
+      boolean underVoltage,
+      boolean overVoltage,
+      boolean temperature,
+      boolean hardwareFault,
+      boolean sensorFault,
+      boolean motorType,
+      boolean firmware,
+      boolean eeprom,
+      boolean stall,
+      boolean hasReset,
+      boolean canError,
+      boolean bootDuringEnable,
+      int activeBitCount,
+      boolean anyActive,
+      boolean critical,
+      String shortSummary) {}
+
+  private static final DecodedFaults EMPTY =
+      new DecodedFaults(
+          false, false, false, false, false, false, false, false, false, false, false, false, false,
+          false, 0, false, false, "");
+
+  private DeviceFaultDecoder() {}
+
+  /** Returns a singleton empty record for use as a default when the device is unavailable. */
+  public static DecodedFaults empty() {
+    return EMPTY;
+  }
+
+  /**
+   * Decodes the REVLib fault and warning raw bit words into a DecodedFaults record. Fault bits and
+   * warning bits come from separate accessors on the underlying SparkBase, so both are passed in.
+   *
+   * <p>Bit positions come from {@code SparkBase.Faults} and {@code SparkBase.Warnings} in the 2026
+   * REVLib source.
+   *
+   * <p><b>Faults (hardware level, 8 bits):</b> other, motorType, sensor, can, temperature,
+   * gateDriver, escEeprom, firmware.
+   *
+   * <p><b>Warnings (operational level, 8 bits):</b> brownout, overcurrent, escEeprom, extEeprom,
+   * sensor, stall, hasReset, other.
+   */
+  public static DecodedFaults decodeRevlib(int faultsRaw, int warningsRaw) {
+    if (faultsRaw == 0 && warningsRaw == 0) {
+      return EMPTY;
+    }
+
+    boolean motorType = (faultsRaw & 0x02) != 0;
+    boolean faultSensor = (faultsRaw & 0x04) != 0;
+    boolean faultCan = (faultsRaw & 0x08) != 0;
+    boolean faultTemperature = (faultsRaw & 0x10) != 0;
+    boolean gateDriver = (faultsRaw & 0x20) != 0;
+    boolean faultEeprom = (faultsRaw & 0x40) != 0;
+    boolean firmware = (faultsRaw & 0x80) != 0;
+
+    boolean brownout = (warningsRaw & 0x01) != 0;
+    boolean overcurrent = (warningsRaw & 0x02) != 0;
+    boolean warnEscEeprom = (warningsRaw & 0x04) != 0;
+    boolean warnExtEeprom = (warningsRaw & 0x08) != 0;
+    boolean warnSensor = (warningsRaw & 0x10) != 0;
+    boolean stall = (warningsRaw & 0x20) != 0;
+    boolean hasReset = (warningsRaw & 0x40) != 0;
+
+    boolean sensorFault = faultSensor || warnSensor;
+    boolean eeprom = faultEeprom || warnEscEeprom || warnExtEeprom;
+    boolean hardwareFault = gateDriver;
+
+    int bitCount = Integer.bitCount(faultsRaw & 0xFF) + Integer.bitCount(warningsRaw & 0xFF);
+
+    boolean critical =
+        brownout
+            || overcurrent
+            || hardwareFault
+            || motorType
+            || firmware
+            || (faultSensor && !warnSensor); // hardware sensor fault, not just a warning
+
+    String summary =
+        buildSummary(
+            brownout,
+            overcurrent,
+            false,
+            false,
+            faultTemperature,
+            hardwareFault,
+            sensorFault,
+            motorType,
+            firmware,
+            eeprom,
+            stall,
+            hasReset,
+            faultCan,
+            false);
+
+    return new DecodedFaults(
+        brownout,
+        overcurrent,
+        false,
+        false,
+        faultTemperature,
+        hardwareFault,
+        sensorFault,
+        motorType,
+        firmware,
+        eeprom,
+        stall,
+        hasReset,
+        faultCan,
+        false,
+        bitCount,
+        true,
+        critical,
+        summary);
+  }
+
+  /**
+   * Decodes the Phoenix6 TalonFX {@code getFaultField()} bitfield. Bit positions follow the
+   * Phoenix6 2026 fault enum.
+   *
+   * <p>Only the electrical and safety bits that matter to the pit crew are mapped; limit-switch and
+   * soft-limit bits are not surfaced because they are part of normal operation and would flood the
+   * dashboard during every pivot move.
+   */
+  public static DecodedFaults decodeTalonFx(int faultsRaw) {
+    if (faultsRaw == 0) {
+      return EMPTY;
+    }
+
+    boolean hardware = (faultsRaw & (1 << 0)) != 0;
+    boolean procTemp = (faultsRaw & (1 << 1)) != 0;
+    boolean deviceTemp = (faultsRaw & (1 << 2)) != 0;
+    boolean underVoltage = (faultsRaw & (1 << 3)) != 0;
+    boolean bootDuringEnable = (faultsRaw & (1 << 4)) != 0;
+    boolean bridgeBrownout = (faultsRaw & (1 << 6)) != 0;
+    boolean remoteSensorReset = (faultsRaw & (1 << 7)) != 0;
+    boolean overSupplyV = (faultsRaw & (1 << 10)) != 0;
+    boolean unstableSupplyV = (faultsRaw & (1 << 11)) != 0;
+    boolean remoteSensorInvalid = (faultsRaw & (1 << 18)) != 0;
+    boolean statorLimit = (faultsRaw & (1 << 20)) != 0;
+
+    boolean temperature = procTemp || deviceTemp;
+    boolean hardwareFault = hardware;
+    boolean sensorFault = remoteSensorReset || remoteSensorInvalid;
+    boolean brownout = bridgeBrownout;
+    boolean overcurrent = statorLimit;
+
+    int bitCount = Integer.bitCount(faultsRaw);
+
+    boolean critical =
+        hardwareFault || brownout || underVoltage || overcurrent || bootDuringEnable || overSupplyV;
+
+    String summary =
+        buildSummary(
+            brownout,
+            overcurrent,
+            underVoltage,
+            overSupplyV || unstableSupplyV,
+            temperature,
+            hardwareFault,
+            sensorFault,
+            false,
+            false,
+            false,
+            false,
+            false,
+            false,
+            bootDuringEnable);
+
+    return new DecodedFaults(
+        brownout,
+        overcurrent,
+        underVoltage,
+        overSupplyV || unstableSupplyV,
+        temperature,
+        hardwareFault,
+        sensorFault,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        bootDuringEnable,
+        bitCount,
+        true,
+        critical,
+        summary);
+  }
+
+  /** REVLib needs the two-integer form; TalonFX reads only {@code faultsRaw}. */
+  public static DecodedFaults decode(DeviceType type, int faultsRaw, int warningsRaw) {
+    return switch (type) {
+      case SPARK_MAX, SPARK_FLEX -> decodeRevlib(faultsRaw, warningsRaw);
+      case TALON_FX -> decodeTalonFx(faultsRaw);
+    };
+  }
+
+  /**
+   * Order is load-bearing: the most actionable items come first so tile truncation still leaves the
+   * replace-the-controller keywords visible.
+   */
+  private static String buildSummary(
+      boolean brownout,
+      boolean overcurrent,
+      boolean underVoltage,
+      boolean overVoltage,
+      boolean temperature,
+      boolean hardwareFault,
+      boolean sensorFault,
+      boolean motorType,
+      boolean firmware,
+      boolean eeprom,
+      boolean stall,
+      boolean hasReset,
+      boolean canError,
+      boolean bootDuringEnable) {
+    StringBuilder sb = new StringBuilder(80);
+    appendIf(sb, hardwareFault, "gate driver");
+    appendIf(sb, motorType, "motor type");
+    appendIf(sb, firmware, "firmware lock");
+    appendIf(sb, sensorFault, "sensor");
+    appendIf(sb, brownout, "brownout");
+    appendIf(sb, overcurrent, "overcurrent");
+    appendIf(sb, underVoltage, "undervoltage");
+    appendIf(sb, overVoltage, "oversupply");
+    appendIf(sb, temperature, "overtemp");
+    appendIf(sb, stall, "stall");
+    appendIf(sb, eeprom, "eeprom");
+    appendIf(sb, canError, "can error");
+    appendIf(sb, hasReset, "reset");
+    appendIf(sb, bootDuringEnable, "boot-on-enable");
+
+    if (sb.length() > 80) {
+      sb.setLength(77);
+      sb.append("...");
+    }
+    return sb.toString();
+  }
+
+  /**
+   * One call per subsystem in {@code log()} so every telemetry class produces the same signal
+   * layout without repeating nineteen {@code SafeLog.put} calls by hand.
+   */
+  public static void publish(
+      String prefix, DecodedFaults decoded, int faultsRaw, int warningsRaw, int transitionCount) {
+    SafeLog.put(prefix + "/Device/FaultsRaw", faultsRaw);
+    SafeLog.put(prefix + "/Device/WarningsRaw", warningsRaw);
+    SafeLog.put(prefix + "/Fault/Brownout", decoded.brownout());
+    SafeLog.put(prefix + "/Fault/Overcurrent", decoded.overcurrent());
+    SafeLog.put(prefix + "/Fault/UnderVoltage", decoded.underVoltage());
+    SafeLog.put(prefix + "/Fault/OverVoltage", decoded.overVoltage());
+    SafeLog.put(prefix + "/Fault/Temperature", decoded.temperature());
+    SafeLog.put(prefix + "/Fault/Hardware", decoded.hardwareFault());
+    SafeLog.put(prefix + "/Fault/Sensor", decoded.sensorFault());
+    SafeLog.put(prefix + "/Fault/MotorType", decoded.motorType());
+    SafeLog.put(prefix + "/Fault/Firmware", decoded.firmware());
+    SafeLog.put(prefix + "/Fault/Eeprom", decoded.eeprom());
+    SafeLog.put(prefix + "/Fault/Stall", decoded.stall());
+    SafeLog.put(prefix + "/Fault/HasReset", decoded.hasReset());
+    SafeLog.put(prefix + "/Fault/CanError", decoded.canError());
+    SafeLog.put(prefix + "/Fault/BootDuringEnable", decoded.bootDuringEnable());
+    SafeLog.put(prefix + "/Fault/ActiveBits", decoded.activeBitCount());
+    SafeLog.put(prefix + "/Fault/Critical", decoded.critical());
+    SafeLog.put(prefix + "/Fault/Summary", decoded.shortSummary());
+    SafeLog.put(prefix + "/Fault/TransitionCount", transitionCount);
+  }
+
+  private static void appendIf(StringBuilder sb, boolean flag, String label) {
+    if (!flag) return;
+    if (sb.length() > 0) {
+      sb.append(", ");
+    }
+    sb.append(label);
+  }
+}

--- a/src/test/java/frc/robot/telemetry/CANHealthTelemetryTest.java
+++ b/src/test/java/frc/robot/telemetry/CANHealthTelemetryTest.java
@@ -120,6 +120,73 @@ class CANHealthTelemetryTest extends TelemetryTestBase {
     assertTrue(hasFaults);
   }
 
+  @Test
+  void testMissingCountAndCriticalWhenAllOnline() throws Exception {
+    setField(shooterTelemetry, "deviceConnected", true);
+    setField(indexerTelemetry, "deviceConnected", true);
+    setField(intakeTelemetry, "deviceConnected", true);
+    setField(intakeActuatorTelemetry, "deviceConnected", true);
+    setField(hangerTelemetry, "deviceConnected", true);
+    setField(agitatorTelemetry, "deviceConnected", true);
+    setField(driveTelemetry, "gyroConnected", true);
+    setField(visionTelemetry, "leftCamConnected", true);
+    setField(visionTelemetry, "rightCamConnected", true);
+    setField(driveTelemetry, "driveMotorConnected", new boolean[] {true, true, true, true});
+    setField(driveTelemetry, "turnMotorConnected", new boolean[] {true, true, true, true});
+    setField(driveTelemetry, "encoderReadIssue", new boolean[] {false, false, false, false});
+
+    telemetry.update();
+    assertEquals(0, telemetry.getMissingCount());
+    assertFalse(telemetry.isMissingCritical());
+    assertEquals(0, telemetry.getMissingNames().length);
+    assertEquals(0, telemetry.getMissingIds().length);
+  }
+
+  @Test
+  void testHangerMissingSetsCritical() throws Exception {
+    setField(shooterTelemetry, "deviceConnected", true);
+    setField(indexerTelemetry, "deviceConnected", true);
+    setField(intakeTelemetry, "deviceConnected", true);
+    setField(intakeActuatorTelemetry, "deviceConnected", true);
+    setField(hangerTelemetry, "deviceConnected", false);
+    setField(agitatorTelemetry, "deviceConnected", true);
+    setField(driveTelemetry, "gyroConnected", true);
+    setField(visionTelemetry, "leftCamConnected", true);
+    setField(visionTelemetry, "rightCamConnected", true);
+    setField(driveTelemetry, "driveMotorConnected", new boolean[] {true, true, true, true});
+    setField(driveTelemetry, "turnMotorConnected", new boolean[] {true, true, true, true});
+    setField(driveTelemetry, "encoderReadIssue", new boolean[] {false, false, false, false});
+
+    telemetry.update();
+    assertEquals(1, telemetry.getMissingCount());
+    assertTrue(telemetry.isMissingCritical());
+    String[] names = telemetry.getMissingNames();
+    assertEquals(1, names.length);
+    assertEquals("Hanger", names[0]);
+  }
+
+  @Test
+  void testOnlyCameraMissingIsNotCritical() throws Exception {
+    setField(shooterTelemetry, "deviceConnected", true);
+    setField(indexerTelemetry, "deviceConnected", true);
+    setField(intakeTelemetry, "deviceConnected", true);
+    setField(intakeActuatorTelemetry, "deviceConnected", true);
+    setField(hangerTelemetry, "deviceConnected", true);
+    setField(agitatorTelemetry, "deviceConnected", true);
+    setField(driveTelemetry, "gyroConnected", true);
+    setField(visionTelemetry, "leftCamConnected", false);
+    setField(visionTelemetry, "rightCamConnected", true);
+    setField(driveTelemetry, "driveMotorConnected", new boolean[] {true, true, true, true});
+    setField(driveTelemetry, "turnMotorConnected", new boolean[] {true, true, true, true});
+    setField(driveTelemetry, "encoderReadIssue", new boolean[] {false, false, false, false});
+
+    telemetry.update();
+    assertEquals(1, telemetry.getMissingCount());
+    assertFalse(telemetry.isMissingCritical(), "camera-only drop is not a critical flag");
+    String[] names = telemetry.getMissingNames();
+    assertEquals("LeftCam", names[0]);
+  }
+
   private void setField(Object obj, String fieldName, Object value) throws Exception {
     java.lang.reflect.Field f = obj.getClass().getDeclaredField(fieldName);
     f.setAccessible(true);

--- a/src/test/java/frc/robot/telemetry/DriveTelemetryEncoderHealthTest.java
+++ b/src/test/java/frc/robot/telemetry/DriveTelemetryEncoderHealthTest.java
@@ -1,0 +1,67 @@
+package frc.robot.telemetry;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression tests for the encoder disagreement math in DriveTelemetry. Each test guards one of the
+ * three failure modes the WPI Day 1 log surfaced: degrees mistaken for radians, NaN propagating
+ * through as a garbage value, and a wraparound case that must collapse to the short arc.
+ */
+class DriveTelemetryEncoderHealthTest {
+
+  private static final double TOLERANCE_RAD = 0.001;
+
+  @Test
+  void fiveDegreeDisagreementReadsAsFiveDegrees() {
+    double result = DriveTelemetry.computeDisagreementRad(45.0, 40.0);
+    assertEquals(Math.toRadians(5.0), result, TOLERANCE_RAD);
+  }
+
+  @Test
+  void nanAbsoluteReturnsZeroNotGarbage() {
+    double result = DriveTelemetry.computeDisagreementRad(Double.NaN, 90.0);
+    assertEquals(0.0, result, 0.0);
+    assertFalse(Double.isNaN(result));
+    assertFalse(Double.isInfinite(result));
+  }
+
+  @Test
+  void nanRelativeReturnsZeroNotGarbage() {
+    double result = DriveTelemetry.computeDisagreementRad(90.0, Double.NaN);
+    assertEquals(0.0, result, 0.0);
+    assertFalse(Double.isNaN(result));
+  }
+
+  @Test
+  void threeHundredSixtyDegreeWraparoundCollapsesToShortArc() {
+    double result = DriveTelemetry.computeDisagreementRad(359.0, 1.0);
+    assertEquals(Math.toRadians(2.0), result, TOLERANCE_RAD);
+  }
+
+  @Test
+  void oppositeHemispheresReadsAsPi() {
+    double result = DriveTelemetry.computeDisagreementRad(0.0, 180.0);
+    assertEquals(Math.PI, result, TOLERANCE_RAD);
+  }
+
+  @Test
+  void zeroDisagreementReadsAsZero() {
+    double result = DriveTelemetry.computeDisagreementRad(123.456, 123.456);
+    assertEquals(0.0, result, TOLERANCE_RAD);
+  }
+
+  @Test
+  void steadyStateNoiseStaysBelowOneTenthRadian() {
+    // Typical steady-state: a real robot sits within 1-2 degrees of agreement.
+    // None of these should approach the 0.175 rad (10 deg) alert threshold.
+    double[] realWorldSamples = {0.5, 1.2, 0.8, 2.1, 1.5, 0.3};
+    for (double deg : realWorldSamples) {
+      double result = DriveTelemetry.computeDisagreementRad(90.0 + deg, 90.0);
+      assertTrue(result < 0.1, "steady state sample " + deg + " deg should stay below 0.1 rad");
+    }
+  }
+}

--- a/src/test/java/frc/robot/telemetry/VoltageDropTest.java
+++ b/src/test/java/frc/robot/telemetry/VoltageDropTest.java
@@ -1,0 +1,61 @@
+package frc.robot.telemetry;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.lang.reflect.Field;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for the shared voltage drop computation in SystemHealthTelemetry. Uses reflection to
+ * seed the shared battery voltage snapshot, since the real path needs a running RoboRIO and these
+ * tests need to run in plain JUnit.
+ */
+class VoltageDropTest {
+
+  @BeforeEach
+  void resetSharedBatteryVoltage() throws Exception {
+    writeSharedBatteryVoltage(Double.NaN);
+  }
+
+  @Test
+  void healthyDropReadsCorrectly() throws Exception {
+    writeSharedBatteryVoltage(12.0);
+    double drop = SystemHealthTelemetry.computeVoltageDrop(11.5);
+    assertEquals(0.5, drop, 1e-9);
+  }
+
+  @Test
+  void noiseCaseWithBusAboveBatteryClampsToZero() throws Exception {
+    writeSharedBatteryVoltage(11.0);
+    double drop = SystemHealthTelemetry.computeVoltageDrop(11.2);
+    assertEquals(0.0, drop, 0.0);
+  }
+
+  @Test
+  void nanBatterySnapshotReturnsZero() throws Exception {
+    // battery snapshot is NaN (no update cycle has run yet)
+    double drop = SystemHealthTelemetry.computeVoltageDrop(11.5);
+    assertEquals(0.0, drop, 0.0);
+  }
+
+  @Test
+  void nanBusVoltageReturnsZero() throws Exception {
+    writeSharedBatteryVoltage(12.0);
+    double drop = SystemHealthTelemetry.computeVoltageDrop(Double.NaN);
+    assertEquals(0.0, drop, 0.0);
+  }
+
+  @Test
+  void badCrimpCaseReadsHigh() throws Exception {
+    writeSharedBatteryVoltage(12.2);
+    double drop = SystemHealthTelemetry.computeVoltageDrop(10.5);
+    assertEquals(1.7, drop, 1e-9);
+  }
+
+  private static void writeSharedBatteryVoltage(double value) throws Exception {
+    Field field = SystemHealthTelemetry.class.getDeclaredField("sharedBatteryVoltage");
+    field.setAccessible(true);
+    field.setDouble(null, value);
+  }
+}

--- a/src/test/java/frc/robot/util/CoprocessorHealthTest.java
+++ b/src/test/java/frc/robot/util/CoprocessorHealthTest.java
@@ -1,0 +1,149 @@
+package frc.robot.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class CoprocessorHealthTest {
+
+  private double mockTime = 0;
+  private CoprocessorHealth health;
+
+  @BeforeEach
+  void setUp() {
+    mockTime = 0;
+    health = new CoprocessorHealth(() -> mockTime);
+    health.register("back-left", "OrangePi1");
+    health.register("back-right", "OrangePi1");
+  }
+
+  @Test
+  void bothCamerasConnectedReadsAlive() {
+    health.update(Map.of("back-left", true, "back-right", true));
+    assertTrue(health.isGroupAlive("OrangePi1"));
+    assertEquals(0, health.getRebootCount("OrangePi1"));
+  }
+
+  @Test
+  void pairedDropAndRecoveryIncrementsRebootCount() {
+    // Both alive at t=0
+    mockTime = 0;
+    health.update(Map.of("back-left", true, "back-right", true));
+
+    // Both drop at t=10
+    mockTime = 10;
+    health.update(Map.of("back-left", false, "back-right", false));
+    assertFalse(health.isGroupAlive("OrangePi1"));
+    assertEquals(0, health.getRebootCount("OrangePi1"));
+
+    // Both come back at t=30
+    mockTime = 30;
+    health.update(Map.of("back-left", true, "back-right", true));
+
+    // Recovery dwell is 2s. Still pending at t=30.
+    assertEquals(0, health.getRebootCount("OrangePi1"));
+
+    // After 2 seconds of uninterrupted alive, the reboot is counted.
+    mockTime = 32.5;
+    health.update(Map.of("back-left", true, "back-right", true));
+    assertEquals(1, health.getRebootCount("OrangePi1"));
+    assertTrue(health.isGroupAlive("OrangePi1"));
+  }
+
+  @Test
+  void singleCameraDropDoesNotIncrementRebootCount() {
+    // Both alive at t=0
+    mockTime = 0;
+    health.update(Map.of("back-left", true, "back-right", true));
+
+    // Left drops, right stays up (USB cable wiggle, not a Pi reboot)
+    mockTime = 5;
+    Map<String, Boolean> state = new HashMap<>();
+    state.put("back-left", false);
+    state.put("back-right", true);
+    health.update(state);
+    assertTrue(health.isGroupAlive("OrangePi1"));
+
+    // Stays that way for a while
+    mockTime = 20;
+    health.update(state);
+    assertTrue(health.isGroupAlive("OrangePi1"));
+    assertEquals(0, health.getRebootCount("OrangePi1"));
+  }
+
+  @Test
+  void sixRebootsInRowCountsCorrectly() {
+    // Six WPI Day 1 style reboots
+    for (int i = 0; i < 6; i++) {
+      // Alive
+      mockTime = i * 100.0;
+      health.update(Map.of("back-left", true, "back-right", true));
+      mockTime = i * 100.0 + 1;
+      health.update(Map.of("back-left", true, "back-right", true));
+
+      // Paired drop
+      mockTime = i * 100.0 + 50;
+      health.update(Map.of("back-left", false, "back-right", false));
+
+      // Recovery
+      mockTime = i * 100.0 + 70;
+      health.update(Map.of("back-left", true, "back-right", true));
+      // Wait through recovery dwell
+      mockTime = i * 100.0 + 73;
+      health.update(Map.of("back-left", true, "back-right", true));
+    }
+    assertEquals(6, health.getRebootCount("OrangePi1"));
+    assertEquals(6, health.getTotalRebootCount());
+  }
+
+  @Test
+  void anyRebootedRecentlyWindowCheck() {
+    // Simulate one reboot at t=10-13
+    mockTime = 0;
+    health.update(Map.of("back-left", true, "back-right", true));
+    mockTime = 10;
+    health.update(Map.of("back-left", false, "back-right", false));
+    mockTime = 11;
+    health.update(Map.of("back-left", true, "back-right", true));
+    mockTime = 13.5;
+    health.update(Map.of("back-left", true, "back-right", true));
+    assertEquals(1, health.getRebootCount("OrangePi1"));
+
+    // Reboot timestamp was set around t=13.5
+    mockTime = 20;
+    assertTrue(health.anyRebootedRecently(10.0));
+
+    mockTime = 100;
+    assertFalse(health.anyRebootedRecently(10.0));
+    assertTrue(health.anyRebootedRecently(200.0));
+  }
+
+  @Test
+  void unknownGroupReturnsSafeDefaults() {
+    assertFalse(health.isGroupAlive("NonExistentGroup"));
+    assertEquals(0, health.getRebootCount("NonExistentGroup"));
+    assertEquals(0.0, health.getLastRebootTimestamp("NonExistentGroup"), 0.0);
+  }
+
+  @Test
+  void multipleGroupsAreIndependent() {
+    health.register("front-left", "OrangePi2");
+    health.register("front-right", "OrangePi2");
+
+    Map<String, Boolean> state = new HashMap<>();
+    state.put("back-left", true);
+    state.put("back-right", true);
+    state.put("front-left", false);
+    state.put("front-right", false);
+
+    mockTime = 0;
+    health.update(state);
+    assertTrue(health.isGroupAlive("OrangePi1"));
+    assertFalse(health.isGroupAlive("OrangePi2"));
+  }
+}

--- a/src/test/java/frc/robot/util/DeviceFaultDecoderTest.java
+++ b/src/test/java/frc/robot/util/DeviceFaultDecoderTest.java
@@ -1,0 +1,137 @@
+package frc.robot.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import frc.robot.util.DeviceFaultDecoder.DecodedFaults;
+import frc.robot.util.DeviceFaultDecoder.DeviceType;
+import org.junit.jupiter.api.Test;
+
+class DeviceFaultDecoderTest {
+
+  @Test
+  void emptyInputReturnsEmptyRecord() {
+    DecodedFaults result = DeviceFaultDecoder.decodeRevlib(0, 0);
+    assertSame(DeviceFaultDecoder.empty(), result);
+    assertFalse(result.anyActive());
+    assertFalse(result.critical());
+    assertEquals(0, result.activeBitCount());
+    assertEquals("", result.shortSummary());
+  }
+
+  @Test
+  void brownoutWarningBitDecodesToBrownoutAndCritical() {
+    DecodedFaults result = DeviceFaultDecoder.decodeRevlib(0, 0x01);
+    assertTrue(result.brownout());
+    assertTrue(result.critical());
+    assertEquals(1, result.activeBitCount());
+    assertTrue(result.shortSummary().contains("brownout"));
+  }
+
+  @Test
+  void gateDriverFaultBitDecodesToHardwareFaultAndCritical() {
+    DecodedFaults result = DeviceFaultDecoder.decodeRevlib(0x20, 0);
+    assertTrue(result.hardwareFault());
+    assertTrue(result.critical());
+    assertEquals(1, result.activeBitCount());
+    assertTrue(result.shortSummary().contains("gate driver"));
+  }
+
+  @Test
+  void stormOfFaultsDecodesAllExpectedFlags() {
+    // Faults: motorType(0x02) + sensor(0x04) + gateDriver(0x20) + firmware(0x80) = 0xA6
+    // Warnings: brownout(0x01) + overcurrent(0x02) + stall(0x20) + hasReset(0x40) = 0x63
+    int faults = 0xA6;
+    int warnings = 0x63;
+    DecodedFaults result = DeviceFaultDecoder.decodeRevlib(faults, warnings);
+
+    assertTrue(result.motorType());
+    assertTrue(result.sensorFault());
+    assertTrue(result.hardwareFault());
+    assertTrue(result.firmware());
+    assertTrue(result.brownout());
+    assertTrue(result.overcurrent());
+    assertTrue(result.stall());
+    assertTrue(result.hasReset());
+    assertTrue(result.critical());
+    assertEquals(8, result.activeBitCount());
+
+    // "gate driver" should appear early in the summary per ordering contract.
+    String summary = result.shortSummary();
+    int gateIdx = summary.indexOf("gate driver");
+    int stallIdx = summary.indexOf("stall");
+    assertTrue(gateIdx >= 0 && stallIdx >= 0);
+    assertTrue(gateIdx < stallIdx, "gate driver should come before stall in summary");
+  }
+
+  @Test
+  void activeBitCountMatchesPopCount() {
+    // 4 fault bits + 3 warning bits = 7
+    DecodedFaults result = DeviceFaultDecoder.decodeRevlib(0xAA, 0x15);
+    assertEquals(Integer.bitCount(0xAA) + Integer.bitCount(0x15), result.activeBitCount());
+  }
+
+  @Test
+  void summaryIsDeterministic() {
+    DecodedFaults a = DeviceFaultDecoder.decodeRevlib(0x20, 0x02);
+    DecodedFaults b = DeviceFaultDecoder.decodeRevlib(0x20, 0x02);
+    assertEquals(a.shortSummary(), b.shortSummary());
+    assertEquals(a, b);
+  }
+
+  @Test
+  void summaryStaysUnderEightyCharacters() {
+    // Every REVLib bit set.
+    DecodedFaults result = DeviceFaultDecoder.decodeRevlib(0xFF, 0xFF);
+    assertTrue(
+        result.shortSummary().length() <= 80,
+        "summary length " + result.shortSummary().length() + " exceeds 80");
+  }
+
+  @Test
+  void temperatureWarningDoesNotMarkCritical() {
+    // overtemp on its own is a watch condition, not a fix-now condition
+    DecodedFaults result = DeviceFaultDecoder.decodeRevlib(0x10, 0);
+    assertTrue(result.temperature());
+    assertFalse(result.critical());
+  }
+
+  @Test
+  void talonFxHardwareBitDecodesToHardwareFaultAndCritical() {
+    int raw = 1 << 0; // hardware
+    DecodedFaults result = DeviceFaultDecoder.decodeTalonFx(raw);
+    assertTrue(result.hardwareFault());
+    assertTrue(result.critical());
+    assertEquals(1, result.activeBitCount());
+  }
+
+  @Test
+  void talonFxBrownoutAndStatorLimitDecodesCorrectly() {
+    int raw = (1 << 6) | (1 << 20); // bridge brownout + stator limit
+    DecodedFaults result = DeviceFaultDecoder.decodeTalonFx(raw);
+    assertTrue(result.brownout());
+    assertTrue(result.overcurrent());
+    assertTrue(result.critical());
+    assertEquals(2, result.activeBitCount());
+  }
+
+  @Test
+  void dispatcherRoutesToCorrectDecoder() {
+    DecodedFaults sparkResult =
+        DeviceFaultDecoder.decode(DeviceType.SPARK_FLEX, 0x20, 0); // gate driver
+    assertTrue(sparkResult.hardwareFault());
+
+    DecodedFaults talonResult =
+        DeviceFaultDecoder.decode(DeviceType.TALON_FX, 1 << 3, 0); // undervoltage
+    assertTrue(talonResult.underVoltage());
+  }
+
+  @Test
+  void emptyAccessorReturnsNonNullSingleton() {
+    assertNotNull(DeviceFaultDecoder.empty());
+    assertSame(DeviceFaultDecoder.empty(), DeviceFaultDecoder.empty());
+  }
+}


### PR DESCRIPTION

#112 

### What's new

  - util/DeviceFaultDecoder.java: turns raw fault numbers into readable flags like "gate driver, stall."
  - util/CoprocessorHealth.java: groups cameras by Orange Pi so a Pi reboot shows up as one event instead of two random camera flickers
  - dashboards/elastic/electrical.json: electrical team's dashboard
  - dashboards/elastic/pit_check.json: pit TV GO/NO-GO screen
  - Four new test files to cover the above

### What's changed

-   A few subsystems got new accessors for bus voltage and sticky warnings. IntakePivot had current, temperature, and applied output commented out, so I uncommented them.
-   Every motor telemetry class now publishes decoded faults and a voltage drop. VisionTelemetry does the Orange Pi rollup.

### Notes: 
Clean merge into Tuning6. I ran git merge-tree as a dry run and all four overlapping files (Cameras, Indexer, IntakeRoller, FlexActuator) auto-merge with zero conflicts. No hand resolution needed.

 The pit crew needs Callan or Archit to update the PDHChannelMap.LABELS in Constants.java to match the real wiring before the dashboard labels are trustworthy.