### PR TITLE
Rudimentary ball detection in AimAndShoot

### DIFF
--- a/src/main/java/frc/robot/commands/AimAndShootCommand.java
+++ b/src/main/java/frc/robot/commands/AimAndShootCommand.java
@@ -48,6 +48,7 @@ public class AimAndShootCommand extends Command {
   private final HeadingController headingController = new HeadingController();
   private final Timer autoTimer = new Timer();
   private final Timer reverseTimer = new Timer();
+  private final Timer noBallsTimer = new Timer();
 
   // Firing hysteresis state
   private boolean reachedSpeed = false;
@@ -66,6 +67,10 @@ public class AimAndShootCommand extends Command {
   // Tunable thresholds matching SpeedUpThenIndex
   private static final TunableNumber autoTimeoutSec =
       new TunableNumber("AimAndShoot/AutoTimeoutSec", 4.5);
+  private static final TunableNumber noBallsTimeout =
+      new TunableNumber("AimAndShoot/NoBallsTimeout", 1.5);
+  private static final TunableNumber noBallsRPMThreshold =
+      new TunableNumber("AimAndShoot/NoBallsIndexerRPMThreshold", 200);
   private static final TunableNumber underShootPct =
       new TunableNumber("AimAndShoot/UnderShootPct", 0.85);
   private static final TunableNumber underShootDebounceMs =
@@ -117,6 +122,8 @@ public class AimAndShootCommand extends Command {
     if (autoFinish) {
       autoTimer.restart();
     }
+
+    noBallsTimer.restart();
   }
 
   @Override
@@ -227,6 +234,9 @@ public class AimAndShootCommand extends Command {
       rpmRatio = Math.max(feedRatioFloor.get(), rpmRatio);
       indexer.moveToVelocityWithPID(indexer.getTunableTargetSpeed());
       agitator.moveToVelocityWithPID(5990);
+      if (indexer.getVelocityRPM() < indexer.getTargetRPM() - noBallsRPMThreshold.get()) {
+        noBallsTimer.restart();
+      }
     } else {
       indexer.move(0);
       agitator.moveToVelocityWithPID(agitator.getTunableTargetRPM() * 0.1);
@@ -268,6 +278,9 @@ public class AimAndShootCommand extends Command {
   public boolean isFinished() {
     if (autoFinish) {
       return autoTimer.hasElapsed(autoTimeoutSec.get());
+    }
+    if (feeding && noBallsTimer.hasElapsed(noBallsTimeout.get())) {
+      return true;
     }
     return false;
   }

--- a/src/main/java/frc/robot/subsystems/Indexer.java
+++ b/src/main/java/frc/robot/subsystems/Indexer.java
@@ -15,6 +15,8 @@ public class Indexer extends FlexActuator {
   private SparkFlexConfig motorConfig;
   private static Indexer instance;
 
+  private double targetRPM;
+
   // Tunable PID values
   private static final TunableNumber kP = new TunableNumber("Indexer/kP", IndexerConstants.P);
   private static final TunableNumber kI = new TunableNumber("Indexer/kI", IndexerConstants.I);
@@ -102,6 +104,16 @@ public class Indexer extends FlexActuator {
     } catch (Throwable t) {
       // CAN failure degrades jam detection, never kills drive control
     }
+  }
+
+  @Override
+  public void moveToVelocityWithPID(double rpm) {
+    targetRPM = rpm;
+    super.moveToVelocityWithPID(rpm);
+  }
+
+  public double getTargetRPM() {
+    return targetRPM;
   }
 
   public JamProtection getJamProtection() {


### PR DESCRIPTION
Automatically stops the command when indexer has not indexed a ball in 1.5s

At some point could also use this for having two different gains for spinup with no ball and for shooting balls.